### PR TITLE
Enhance restart UI after permissions are granted

### DIFF
--- a/src/renderer/src/components/setup.tsx
+++ b/src/renderer/src/components/setup.tsx
@@ -10,6 +10,11 @@ export function Setup() {
     queryFn: () => tipcClient.isAccessibilityGranted(),
   })
 
+  // Check if all required permissions are granted
+  const microphoneGranted = microphoneStatusQuery.data === "granted"
+  const accessibilityGranted = isAccessibilityGrantedQuery.data
+  const allPermissionsGranted = microphoneGranted && (process.env.IS_MAC ? accessibilityGranted : true)
+
   return (
     <div className="app-drag-region flex h-dvh items-center justify-center p-10">
       <div className="-mt-20">
@@ -52,16 +57,29 @@ export function Setup() {
           </div>
         </div>
 
+        {/* Show restart instructions when permissions are granted */}
+        {allPermissionsGranted && (
+          <div className="mt-6 rounded-lg border border-green-200 bg-green-50 p-4 text-center dark:border-green-800 dark:bg-green-950">
+            <div className="flex items-center justify-center gap-2 text-green-700 dark:text-green-300">
+              <span className="i-mingcute-check-circle-fill text-lg"></span>
+              <span className="font-semibold">All permissions granted!</span>
+            </div>
+            <p className="mt-2 text-sm text-green-600 dark:text-green-400">
+              Please restart the app to complete the setup and start using {process.env.PRODUCT_NAME}.
+            </p>
+          </div>
+        )}
+
         <div className="mt-10 flex items-center justify-center">
           <Button
-            variant="outline"
-            className="gap-2"
+            variant={allPermissionsGranted ? "default" : "outline"}
+            className={`gap-2 ${allPermissionsGranted ? "animate-pulse bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800" : ""}`}
             onClick={() => {
               tipcClient.restartApp()
             }}
           >
             <span className="i-mingcute-refresh-2-line"></span>
-            <span>Restart App</span>
+            <span>{allPermissionsGranted ? "Restart App Now" : "Restart App"}</span>
           </Button>
         </div>
       </div>

--- a/src/renderer/src/pages/setup.tsx
+++ b/src/renderer/src/pages/setup.tsx
@@ -10,6 +10,11 @@ export function Component() {
     queryFn: () => tipcClient.isAccessibilityGranted(),
   })
 
+  // Check if all required permissions are granted
+  const microphoneGranted = microphoneStatusQuery.data === "granted"
+  const accessibilityGranted = isAccessibilityGrantedQuery.data
+  const allPermissionsGranted = microphoneGranted && (process.env.IS_MAC ? accessibilityGranted : true)
+
   return (
     <div className="app-drag-region flex h-dvh items-center justify-center p-10">
       <div className="-mt-20">
@@ -52,16 +57,29 @@ export function Component() {
           </div>
         </div>
 
+        {/* Show restart instructions when permissions are granted */}
+        {allPermissionsGranted && (
+          <div className="mt-6 rounded-lg border border-green-200 bg-green-50 p-4 text-center dark:border-green-800 dark:bg-green-950">
+            <div className="flex items-center justify-center gap-2 text-green-700 dark:text-green-300">
+              <span className="i-mingcute-check-circle-fill text-lg"></span>
+              <span className="font-semibold">All permissions granted!</span>
+            </div>
+            <p className="mt-2 text-sm text-green-600 dark:text-green-400">
+              Please restart the app to complete the setup and start using {process.env.PRODUCT_NAME}.
+            </p>
+          </div>
+        )}
+
         <div className="mt-10 flex items-center justify-center">
           <Button
-            variant="outline"
-            className="gap-2"
+            variant={allPermissionsGranted ? "default" : "outline"}
+            className={`gap-2 ${allPermissionsGranted ? "animate-pulse bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800" : ""}`}
             onClick={() => {
               tipcClient.restartApp()
             }}
           >
             <span className="i-mingcute-refresh-2-line"></span>
-            <span>Restart App</span>
+            <span>{allPermissionsGranted ? "Restart App Now" : "Restart App"}</span>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

This PR makes it much more obvious that the app needs to be restarted after permissions have been successfully granted.

## Changes

### Visual Enhancements
- **Green notification banner**: Added a prominent green notification that appears when all permissions are granted
- **Enhanced restart button**: Changes from outline to primary variant with green styling and pulse animation when permissions are ready
- **Updated button text**: Changes from "Restart App" to "Restart App Now" when permissions are granted
- **Helper text**: Added clear instructions explaining that restart is needed to complete setup

### Technical Details
- Added logic to detect when all required permissions are granted
- Conditional styling and messaging based on permission status
- Applied changes to both `setup.tsx` component and page for consistency
- Maintains existing functionality while improving UX

## User Experience

Before: Users had to figure out that they needed to restart after granting permissions
After: Clear visual indicators and instructions guide users to restart the app

## Testing

- [ ] Test on macOS with accessibility permissions
- [ ] Test on Windows/Linux (microphone only)
- [ ] Verify button styling and animations work correctly
- [ ] Confirm restart functionality works as expected

Fixes the issue where users weren't sure when or why they needed to restart the app after granting permissions.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author