### PR TITLE
Fix hanging 'signing in...' state when user closes browser

### DIFF
--- a/src/main/tipc.ts
+++ b/src/main/tipc.ts
@@ -289,9 +289,9 @@ export const router = {
         setTimeout(() => {
           if (server.listening) {
             server.close()
-            reject(new Error('Authentication timeout - no response received'))
+            reject(new Error('Authentication timeout - no response received within 2 minutes'))
           }
-        }, 300000) // 5 minutes timeout
+        }, 120000) // 2 minutes timeout
       }
 
       // Start server on a fixed port for OAuth callback

--- a/src/renderer/src/components/auth-status.tsx
+++ b/src/renderer/src/components/auth-status.tsx
@@ -11,10 +11,19 @@ export function AuthStatus() {
 
   const handleLogin = async () => {
     try {
+      // Reset any previous error state
+      initiateLoginMutation.reset()
       await initiateLoginMutation.mutateAsync()
       toast.success("Successfully signed in!")
     } catch (error) {
-      toast.error("Failed to sign in: " + (error as Error).message)
+      const errorMessage = (error as Error).message
+      if (errorMessage.includes('timeout')) {
+        toast.error("Sign in timed out. Please try again.")
+      } else if (errorMessage.includes('Authentication failed')) {
+        toast.error("Authentication was cancelled or failed. Please try again.")
+      } else {
+        toast.error("Failed to sign in: " + errorMessage)
+      }
     }
   }
 
@@ -69,7 +78,9 @@ export function AuthStatus() {
 
   return (
     <div className="space-y-2">
-      <div className="text-xs text-muted-foreground">Not signed in</div>
+      <div className="text-xs text-muted-foreground">
+        {initiateLoginMutation.isError ? "Sign in failed" : "Not signed in"}
+      </div>
       <Button
         variant="default"
         size="sm"
@@ -77,8 +88,18 @@ export function AuthStatus() {
         disabled={initiateLoginMutation.isPending}
         className="w-full h-6 text-xs"
       >
-        {initiateLoginMutation.isPending ? "Signing in..." : "Sign in"}
+        {initiateLoginMutation.isPending
+          ? "Signing in..."
+          : initiateLoginMutation.isError
+            ? "Try again"
+            : "Sign in"
+        }
       </Button>
+      {initiateLoginMutation.isError && (
+        <div className="text-xs text-muted-foreground text-center">
+          Close the browser? Click "Try again" to retry.
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/lib/query-client.ts
+++ b/src/renderer/src/lib/query-client.ts
@@ -60,6 +60,11 @@ export const useInitiateLoginMutation = () => useMutation({
       queryKey: ["config"],
     })
   },
+  onError(error) {
+    console.error('Login mutation failed:', error)
+    // The mutation state will automatically reset to not pending
+    // This ensures the UI can show the retry button
+  },
 })
 
 export const useLogoutMutation = () => useMutation({


### PR DESCRIPTION
## Problem
When users skip signing in by closing the OAuth browser window, the UI gets stuck showing "Signing in..." indefinitely. The authentication timeout was set to 5 minutes, which is too long, and the UI didn't properly handle the error state.

## Solution
- **Improved error handling**: Added specific error messages for timeout and cancellation scenarios
- **Try again button**: When authentication fails, the button changes to "Try again" with a helpful message
- **Shorter timeout**: Reduced from 5 minutes to 2 minutes for better user experience
- **Proper state reset**: Added mutation reset when retrying authentication
- **Better UX feedback**: Clear indication when sign-in fails with guidance on next steps

## Changes
- `src/renderer/src/components/auth-status.tsx`: Enhanced UI to show error states and retry option
- `src/renderer/src/lib/query-client.ts`: Added error handling to login mutation
- `src/main/tipc.ts`: Reduced timeout from 5 to 2 minutes

## Testing
The fix ensures that:
1. When a user closes the browser during OAuth, the UI will show an error state after 2 minutes
2. The "Try again" button appears with helpful messaging
3. Users can retry authentication without restarting the app
4. The pending state properly resets on both success and failure

Fixes the hanging authentication state issue reported by users.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author