### PR TITLE
feat(mac): native Liquid Glass for main and panel windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@egoist/electron-panel-window": "^8.0.3",
     "@modelcontextprotocol/sdk": "^1.13.3",
     "@radix-ui/react-scroll-area": "^1.2.9",
+    "electron-liquid-glass": "^1.0.1",
     "highlight.js": "^11.11.1",
     "openai": "^5.10.2",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.9
         version: 1.2.9(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      electron-liquid-glass:
+        specifier: ^1.0.1
+        version: 1.0.1
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -1863,6 +1866,11 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  electron-liquid-glass@1.0.1:
+    resolution: {integrity: sha512-XznNF0uDOmwvIQFGfgZM6PiQbrpXJiG4GYN6VnLzUrZwcOsQUGy51cJ5mPZCfwH+ST/ahorhLzwFEr+hsKRHXw==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   electron-publish@24.13.1:
     resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
 
@@ -2803,8 +2811,16 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@8.5.0:
+    resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
@@ -5651,6 +5667,13 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
+  electron-liquid-glass@1.0.1:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 8.5.0
+    optionalDependencies:
+      node-gyp-build: 4.8.4
+
   electron-publish@24.13.1:
     dependencies:
       '@types/fs-extra': 9.0.13
@@ -6882,7 +6905,12 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@8.5.0: {}
+
   node-fetch-native@1.6.4: {}
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-releases@2.0.18: {}
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -12,11 +12,15 @@ import {
   makePanel,
   makeWindow,
 } from "@egoist/electron-panel-window"
+import liquidGlass from "electron-liquid-glass"
 import { RendererHandlers } from "./renderer-handlers"
 import { configStore } from "./config"
 import { getFocusedAppInfo } from "./keyboard"
 import { state, agentProcessManager } from "./state"
 import { calculatePanelPosition } from "./panel-position"
+
+
+const isMac = process.platform === "darwin"
 
 type WINDOW_ID = "main" | "panel" | "setup"
 
@@ -80,8 +84,29 @@ export function createMainWindow({ url }: { url?: string } = {}) {
     url,
     windowOptions: {
       titleBarStyle: "hiddenInset",
+      ...(isMac ? { transparent: true } : {}),
     },
   })
+
+  if (isMac) {
+    // Required for traffic light buttons when using transparent windows
+    try {
+      win.setWindowButtonVisibility(true)
+    } catch (err) {
+      // noop on non-mac or older electron
+    }
+
+    // Apply native Liquid Glass effect after the content loads
+    win.webContents.once("did-finish-load", () => {
+      try {
+        liquidGlass.addView(win.getNativeWindowHandle(), {
+          cornerRadius: 12,
+        })
+      } catch (e) {
+        console.warn("Failed to apply liquid glass to main window:", e)
+      }
+    })
+  }
 
   if (process.env.IS_MAC) {
     win.on("close", () => {
@@ -170,7 +195,7 @@ export function createPanelWindow() {
       closable: false,
       maximizable: false,
       frame: false,
-      // transparent: true,
+      ...(isMac ? { transparent: true as const } : {}),
       paintWhenInitiallyHidden: true,
       // hasShadow: false,
       width: panelWindowSize.width,
@@ -180,12 +205,26 @@ export function createPanelWindow() {
       minWidth: panelWindowSize.width,
       minHeight: panelWindowSize.height,
       visualEffectState: "active",
-      vibrancy: "under-window",
+      ...(isMac ? {} : { vibrancy: "under-window" as const }),
       alwaysOnTop: true,
       x: position.x,
       y: position.y,
     },
   })
+
+  if (isMac) {
+    // Use native glass on macOS for the panel window
+    win.webContents.once("did-finish-load", () => {
+      try {
+        liquidGlass.addView(win.getNativeWindowHandle(), {
+          cornerRadius: 12,
+          opaque: false,
+        })
+      } catch (e) {
+        console.warn("Failed to apply liquid glass to panel window:", e)
+      }
+    })
+  }
 
   win.on("hide", () => {
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()


### PR DESCRIPTION
This PR integrates electron-liquid-glass to enable native macOS Liquid Glass effects on Electron windows.

Changes
- Add dependency: electron-liquid-glass
- src/main/window.ts
  - Import and conditionally enable on macOS
  - Main window: make transparent on macOS, ensure traffic lights visible, apply glass after did-finish-load
  - Panel window: remove vibrancy on macOS, use transparent window, apply glass effect after did-finish-load with corner radius, keep original behavior on other platforms
- Renderer CSS already uses transparent html/body; no changes needed.

Notes
- Only affects macOS (no-ops elsewhere). Falls back gracefully on non-mac platforms.
- Maintains existing behavior on Windows/Linux; vibrancy kept for panel window there.

Validation
- Built successfully with electron-vite build.
- Typecheck shows unrelated existing repo errors in tests/renderer; main process compiles fine. No changes to tests included.

Follow-ups (optional)
- Tweak GlassOptions (corner radius, tint) based on design preference.
- Consider applying to setup window if desired.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author