### PR TITLE
fix: remove hallucinated focus management commands

### DIFF
--- a/src/main/keyboard.ts
+++ b/src/main/keyboard.ts
@@ -75,99 +75,9 @@ export const writeText = (text: string) => {
   })
 }
 
-export const getFocusedAppInfo = () => {
-  return new Promise<string>((resolve, reject) => {
-    const child: ChildProcess = spawn(rdevPath, ["get-focus"])
 
-    // Register process if agent mode is active
-    if (state.isAgentModeActive) {
-      agentProcessManager.registerProcess(child)
-    }
 
-    let stdout = ""
-    let stderr = ""
 
-    child.stdout?.on("data", (data) => {
-      stdout += data.toString()
-    })
-
-    child.stderr?.on("data", (data) => {
-      stderr += data.toString()
-    })
-
-    child.on("error", (error) => {
-      reject(new Error(`Failed to spawn process: ${error.message}`))
-    })
-
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve(stdout.trim())
-      } else {
-        const errorMessage = `get-focus command failed with code ${code}${stderr.trim() ? `. stderr: ${stderr.trim()}` : ""}`
-        reject(new Error(errorMessage))
-      }
-    })
-  })
-}
-
-export const restoreFocusToApp = (appInfo: string) => {
-  return new Promise<void>((resolve, reject) => {
-    const child: ChildProcess = spawn(rdevPath, ["restore-focus", appInfo])
-
-    // Register process if agent mode is active
-    if (state.isAgentModeActive) {
-      agentProcessManager.registerProcess(child)
-    }
-
-    let stderr = ""
-
-    child.stderr?.on("data", (data) => {
-      stderr += data.toString()
-    })
-
-    child.on("error", (error) => {
-      reject(new Error(`Failed to spawn process: ${error.message}`))
-    })
-
-    child.on("close", (code) => {
-      if (code === 0) {
-        resolve()
-      } else {
-        const errorMessage = `restore-focus command failed with code ${code}${stderr.trim() ? `. stderr: ${stderr.trim()}` : ""}`
-        reject(new Error(errorMessage))
-      }
-    })
-  })
-}
-
-const captureFocusBeforeRecording = async () => {
-  try {
-    const focusedApp = await getFocusedAppInfo()
-    state.focusedAppBeforeRecording = focusedApp
-  } catch (error) {
-    state.focusedAppBeforeRecording = null
-  }
-}
-
-export const writeTextWithFocusRestore = async (text: string) => {
-  const focusedApp = state.focusedAppBeforeRecording
-
-  if (focusedApp) {
-    try {
-      await restoreFocusToApp(focusedApp)
-
-      // Small delay to ensure focus is restored before pasting
-      await new Promise((resolve) => setTimeout(resolve, 100))
-
-      await writeText(text)
-    } catch (error) {
-      // Fallback to regular paste without focus restoration
-      await writeText(text)
-    }
-  } else {
-    await writeText(text)
-  }
-}
 
 const parseEvents = (data: any): RdevEvent[] => {
   try {

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -3,7 +3,6 @@ import { ChildProcess } from "child_process"
 export const state = {
   isRecording: false,
   isTextInputActive: false,
-  focusedAppBeforeRecording: null as string | null,
   // Agent mode state
   isAgentModeActive: false,
   agentProcesses: new Set<ChildProcess>(),

--- a/src/main/tipc.ts
+++ b/src/main/tipc.ts
@@ -157,7 +157,7 @@ async function processWithAgentMode(
 import { diagnosticsService } from "./diagnostics"
 import { updateTrayIcon } from "./tray"
 import { isAccessibilityGranted } from "./utils"
-import { writeText, writeTextWithFocusRestore } from "./keyboard"
+import { writeText } from "./keyboard"
 
 const t = tipc.create()
 
@@ -501,7 +501,7 @@ export const router = {
         const pasteDelay = 500 // 0.5 second delay for regular transcripts
         setTimeout(async () => {
           try {
-            await writeTextWithFocusRestore(transcript)
+            await writeText(transcript)
           } catch (error) {
             // Don't throw here, just log the error so the recording still gets saved
           }
@@ -550,7 +550,7 @@ export const router = {
       }
 
       // Auto-paste if enabled
-      if (config.mcpAutoPasteEnabled && state.focusedAppBeforeRecording) {
+      if (config.mcpAutoPasteEnabled) {
         setTimeout(async () => {
           try {
             await writeText(processedText)
@@ -599,7 +599,7 @@ export const router = {
       }
 
       // Auto-paste if enabled
-      if (config.mcpAutoPasteEnabled && state.focusedAppBeforeRecording) {
+      if (config.mcpAutoPasteEnabled) {
         setTimeout(async () => {
           try {
             await writeText(finalResponse)

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -14,7 +14,6 @@ import {
 } from "@egoist/electron-panel-window"
 import { RendererHandlers } from "./renderer-handlers"
 import { configStore } from "./config"
-import { getFocusedAppInfo } from "./keyboard"
 import { state, agentProcessManager } from "./state"
 import { calculatePanelPosition } from "./panel-position"
 
@@ -215,40 +214,16 @@ export function showPanelWindow() {
 }
 
 export async function showPanelWindowAndStartRecording() {
-  // Capture focus before showing panel
-  try {
-    const focusedApp = await getFocusedAppInfo()
-    state.focusedAppBeforeRecording = focusedApp
-  } catch (error) {
-    state.focusedAppBeforeRecording = null
-  }
-
   showPanelWindow()
   getWindowRendererHandlers("panel")?.startRecording.send()
 }
 
 export async function showPanelWindowAndStartMcpRecording() {
-  // Capture focus before showing panel
-  try {
-    const focusedApp = await getFocusedAppInfo()
-    state.focusedAppBeforeRecording = focusedApp
-  } catch (error) {
-    state.focusedAppBeforeRecording = null
-  }
-
   showPanelWindow()
   getWindowRendererHandlers("panel")?.startMcpRecording.send()
 }
 
 export async function showPanelWindowAndShowTextInput() {
-  // Capture focus before showing panel
-  try {
-    const focusedApp = await getFocusedAppInfo()
-    state.focusedAppBeforeRecording = focusedApp
-  } catch (error) {
-    state.focusedAppBeforeRecording = null
-  }
-
   // Set text input state first, then show panel (which will use correct positioning)
   state.isTextInputActive = true
   resizePanelForTextInput()


### PR DESCRIPTION
## Summary
Removes hallucinated focus management system that was calling non-existent Rust binary commands, fixing critical architecture violations.

## Changes Made
- **Removed hallucinated functions:**
  - `getFocusedAppInfo()` - called non-existent `get-focus` command
  - `restoreFocusToApp()` - called non-existent `restore-focus` command  
  - `writeTextWithFocusRestore()` - wrapper using above functions
  - `captureFocusBeforeRecording()` - helper function

- **Updated references:**
  - Replace `writeTextWithFocusRestore()` with `writeText()` in tipc.ts
  - Remove focus capture from window show functions
  - Remove `focusedAppBeforeRecording` from state
  - Simplify auto-paste logic

## Architecture Fix
The focus management system was attempting to call `get-focus` and `restore-focus` commands that were never implemented in the Rust binary (`speakmcp-rs`). The actual Rust binary only supports:

✅ `listen` - keyboard event monitoring  
✅ `write <text>` - text injection

❌ `get-focus` - never existed  
❌ `restore-focus` - never existed

## Impact
- **Fixes runtime failures** - eliminates calls to non-existent commands
- **Preserves functionality** - text injection still works via reliable `write <text>` command
- **Simplifies codebase** - removes 120+ lines of broken code
- **Cross-platform compatibility** - relies only on implemented Rust commands

## Test plan
- [x] Verified no remaining references to hallucinated commands
- [x] Confirmed only valid Rust commands (`listen`, `write`) are used
- [x] Auto-paste functionality preserved with simplified logic

🤖 Generated with [Claude Code](https://claude.ai/code)