### PR TITLE
Fix post processing transcript to auto-append transcript when {transcript} placeholder is missing

### DIFF
--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -158,10 +158,16 @@ export async function postProcessTranscript(transcript: string) {
     return transcript
   }
 
-  const prompt = config.transcriptPostProcessingPrompt.replace(
-    "{transcript}",
-    transcript,
-  )
+  let prompt = config.transcriptPostProcessingPrompt
+
+  // Check if the prompt contains the {transcript} placeholder
+  if (prompt.includes("{transcript}")) {
+    // Replace all occurrences of the placeholder with the actual transcript
+    prompt = prompt.replaceAll("{transcript}", transcript)
+  } else {
+    // If no placeholder is found, append the transcript to the prompt
+    prompt = prompt + "\n\n" + transcript
+  }
 
   const chatProviderId = config.transcriptPostProcessingProviderId
 


### PR DESCRIPTION
## Summary

Fixes issue #91 by modifying the `postProcessTranscript` function to automatically include the transcript content even when users don't include the `{transcript}` placeholder in their prompt.

## Changes Made

- **Smart Placeholder Detection**: Function now checks if the user's prompt contains the `{transcript}` placeholder
- **Conditional Behavior**:
  - If `{transcript}` is present: Replaces all occurrences with the actual transcript content
  - If `{transcript}` is missing: Automatically appends the transcript to the prompt with proper spacing (`\n\n`)
- **Multiple Placeholder Support**: Uses `replaceAll()` to handle cases where users include `{transcript}` multiple times

## Code Changes

**File**: `src/main/llm.ts`
- Modified `postProcessTranscript` function (lines 151-180)
- Added logic to detect `{transcript}` placeholder presence
- Implemented fallback behavior to append transcript when placeholder is missing
- Changed from `replace()` to `replaceAll()` for multiple placeholder support

## Testing

Tested the following scenarios:
- ✅ Prompt with `{transcript}` placeholder
- ✅ Prompt without `{transcript}` placeholder
- ✅ Empty prompt handling
- ✅ Multiple `{transcript}` placeholders

## Impact

This ensures that transcript content is always included in post-processing, improving user experience by making the `{transcript}` placeholder optional while maintaining backward compatibility.

Closes #91

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author