### PR TITLE
Add toggle voice dictation feature with Fn key support

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -29,11 +29,15 @@ const getConfig = () => {
     // Agent kill switch defaults
     agentKillSwitchEnabled: true,
     agentKillSwitchHotkey: "ctrl-shift-escape",
+    // Toggle voice dictation defaults
+    toggleVoiceDictationEnabled: false,
+    toggleVoiceDictationHotkey: "fn",
     // Custom shortcut defaults
     customShortcut: "",
     customTextInputShortcut: "",
     customAgentKillSwitchHotkey: "",
     customMcpToolsShortcut: "",
+    customToggleVoiceDictationHotkey: "",
     // Persisted MCP runtime state
     mcpRuntimeDisabledServers: [],
     // Panel position defaults

--- a/src/main/keyboard.ts
+++ b/src/main/keyboard.ts
@@ -574,6 +574,85 @@ export function listenToKeyboardEvents() {
         }
       }
 
+      // Handle toggle voice dictation shortcuts
+      if (config.toggleVoiceDictationEnabled) {
+        const effectiveToggleShortcut = getEffectiveShortcut(
+          config.toggleVoiceDictationHotkey,
+          config.customToggleVoiceDictationHotkey,
+        )
+
+        const toggleHotkey = config.toggleVoiceDictationHotkey
+
+        if (toggleHotkey === "fn") {
+          if (e.data.key === "Function" || e.data.key === "Fn") {
+            if (isDebugKeybinds()) {
+              logKeybinds("Toggle voice dictation triggered: Fn")
+            }
+            if (state.isToggleRecordingActive) {
+              // Stop toggle recording
+              state.isToggleRecordingActive = false
+              getWindowRendererHandlers("panel")?.finishRecording.send()
+            } else {
+              // Start toggle recording
+              state.isToggleRecordingActive = true
+              showPanelWindowAndStartRecording()
+            }
+            return
+          }
+        } else if (toggleHotkey && toggleHotkey !== "custom" && toggleHotkey.startsWith("f")) {
+          // Handle F1-F12 keys
+          const fKeyMap: Record<string, string> = {
+            f1: "F1", f2: "F2", f3: "F3", f4: "F4", f5: "F5", f6: "F6",
+            f7: "F7", f8: "F8", f9: "F9", f10: "F10", f11: "F11", f12: "F12"
+          }
+          const expectedKey = fKeyMap[toggleHotkey]
+          if (e.data.key === expectedKey) {
+            if (isDebugKeybinds()) {
+              logKeybinds(`Toggle voice dictation triggered: ${expectedKey}`)
+            }
+            if (state.isToggleRecordingActive) {
+              // Stop toggle recording
+              state.isToggleRecordingActive = false
+              getWindowRendererHandlers("panel")?.finishRecording.send()
+            } else {
+              // Start toggle recording
+              state.isToggleRecordingActive = true
+              showPanelWindowAndStartRecording()
+            }
+            return
+          }
+        } else if (toggleHotkey === "custom" && effectiveToggleShortcut) {
+          // Handle custom toggle shortcut
+          const matches = matchesKeyCombo(
+            e.data,
+            {
+              ctrl: isPressedCtrlKey,
+              shift: isPressedShiftKey,
+              alt: isPressedAltKey,
+            },
+            effectiveToggleShortcut,
+          )
+          if (isDebugKeybinds() && matches) {
+            logKeybinds(
+              "Toggle voice dictation triggered: Custom hotkey",
+              effectiveToggleShortcut,
+            )
+          }
+          if (matches) {
+            if (state.isToggleRecordingActive) {
+              // Stop toggle recording
+              state.isToggleRecordingActive = false
+              getWindowRendererHandlers("panel")?.finishRecording.send()
+            } else {
+              // Start toggle recording
+              state.isToggleRecordingActive = true
+              showPanelWindowAndStartRecording()
+            }
+            return
+          }
+        }
+      }
+
       // Handle recording shortcuts
       const effectiveRecordingShortcut = getEffectiveShortcut(
         config.shortcut,

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -4,6 +4,8 @@ export const state = {
   isRecording: false,
   isTextInputActive: false,
   focusedAppBeforeRecording: null as string | null,
+  // Toggle voice dictation state
+  isToggleRecordingActive: false,
   // Agent mode state
   isAgentModeActive: false,
   agentProcesses: new Set<ChildProcess>(),

--- a/src/renderer/src/pages/settings-general.tsx
+++ b/src/renderer/src/pages/settings-general.tsx
@@ -204,6 +204,69 @@ export function Component() {
             </div>
           </Control>
 
+          <Control label="Toggle Voice Dictation" className="px-3">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={configQuery.data?.toggleVoiceDictationEnabled || false}
+                  onCheckedChange={(checked) => {
+                    saveConfig({
+                      toggleVoiceDictationEnabled: checked,
+                    })
+                  }}
+                />
+                <span className="text-sm text-muted-foreground">
+                  Enable toggle mode (press once to start, press again to stop)
+                </span>
+              </div>
+
+              {configQuery.data?.toggleVoiceDictationEnabled && (
+                <>
+                  <Select
+                    defaultValue={configQuery.data?.toggleVoiceDictationHotkey || "fn"}
+                    onValueChange={(value) => {
+                      saveConfig({
+                        toggleVoiceDictationHotkey: value as typeof configQuery.data.toggleVoiceDictationHotkey,
+                      })
+                    }}
+                  >
+                    <SelectTrigger className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="fn">Fn</SelectItem>
+                      <SelectItem value="f1">F1</SelectItem>
+                      <SelectItem value="f2">F2</SelectItem>
+                      <SelectItem value="f3">F3</SelectItem>
+                      <SelectItem value="f4">F4</SelectItem>
+                      <SelectItem value="f5">F5</SelectItem>
+                      <SelectItem value="f6">F6</SelectItem>
+                      <SelectItem value="f7">F7</SelectItem>
+                      <SelectItem value="f8">F8</SelectItem>
+                      <SelectItem value="f9">F9</SelectItem>
+                      <SelectItem value="f10">F10</SelectItem>
+                      <SelectItem value="f11">F11</SelectItem>
+                      <SelectItem value="f12">F12</SelectItem>
+                      <SelectItem value="custom">Custom</SelectItem>
+                    </SelectContent>
+                  </Select>
+
+                  {configQuery.data?.toggleVoiceDictationHotkey === "custom" && (
+                    <KeyRecorder
+                      value={configQuery.data?.customToggleVoiceDictationHotkey || ""}
+                      onChange={(keyCombo) => {
+                        saveConfig({
+                          customToggleVoiceDictationHotkey: keyCombo,
+                        })
+                      }}
+                      placeholder="Click to record custom toggle shortcut"
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          </Control>
+
           <Control label="Text Input" className="px-3">
             <div className="space-y-2">
               <div className="flex items-center gap-2">

--- a/src/shared/key-utils.ts
+++ b/src/shared/key-utils.ts
@@ -114,6 +114,8 @@ export function matchesKeyCombo(
     f10: "f10",
     f11: "f11",
     f12: "f12",
+    fn: "fn",
+    function: "fn",
   }
 
   // Apply key mappings
@@ -160,6 +162,19 @@ export function formatKeyComboForDisplay(combo: string): string {
       pageup: "Page Up",
       pagedown: "Page Down",
       insert: "Insert",
+      fn: "Fn",
+      f1: "F1",
+      f2: "F2",
+      f3: "F3",
+      f4: "F4",
+      f5: "F5",
+      f6: "F6",
+      f7: "F7",
+      f8: "F8",
+      f9: "F9",
+      f10: "F10",
+      f11: "F11",
+      f12: "F12",
     }
 
     displayKey = displayMappings[parsed.key] || parsed.key.toUpperCase()
@@ -183,9 +198,9 @@ export function validateKeyCombo(combo: string): {
 
   const parsed = parseKeyCombo(combo)
 
-  // Must have at least one modifier or be a function key
+  // Must have at least one modifier or be a function key (including Fn)
   const hasModifier = parsed.ctrl || parsed.shift || parsed.alt || parsed.meta
-  const isFunctionKey = parsed.key && parsed.key.match(/^f\d+$/)
+  const isFunctionKey = parsed.key && (parsed.key.match(/^f\d+$/) || parsed.key === "fn")
 
   if (!hasModifier && !isFunctionKey) {
     return {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -184,6 +184,11 @@ export type Config = {
   customShortcut?: string
   hideDockIcon?: boolean
 
+  // Toggle Voice Dictation Configuration
+  toggleVoiceDictationEnabled?: boolean
+  toggleVoiceDictationHotkey?: "fn" | "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12" | "custom"
+  customToggleVoiceDictationHotkey?: string
+
   // Theme Configuration
   themePreference?: "system" | "light" | "dark"
 


### PR DESCRIPTION
## Summary

Adds a toggle voice dictation feature that allows users to press a hotkey once to start recording and press it again to stop recording, instead of having to hold down a key.

## Features

- **Toggle Mode**: Press once to start recording, press again to stop
- **Fn Key Default**: Uses the Fn key as the default toggle hotkey
- **Multiple Options**: Supports Fn, F1-F12, and custom hotkey combinations
- **Optional Feature**: Disabled by default to maintain existing behavior
- **Settings UI**: Easy to enable/disable and configure in settings

## Changes Made

### Configuration
- Added `toggleVoiceDictationEnabled` flag (default: false)
- Added `toggleVoiceDictationHotkey` with options: fn, f1-f12, custom
- Added `customToggleVoiceDictationHotkey` for custom combinations

### State Management
- Added `isToggleRecordingActive` to track toggle recording state

### Keyboard Handling
- Implemented toggle logic in keyboard event handler
- Added support for Fn key detection
- Added F1-F12 key handling
- Added custom hotkey support for toggle mode

### UI
- Added toggle voice dictation section in General Settings
- Switch to enable/disable the feature
- Dropdown to select hotkey (Fn, F1-F12, Custom)
- Custom hotkey recorder when "Custom" is selected

### Key Utilities
- Added Fn key mapping and display formatting
- Updated validation to allow Fn key without modifiers
- Added F1-F12 display formatting

## Usage

1. Go to Settings → General
2. Enable "Toggle Voice Dictation"
3. Select desired hotkey (default: Fn)
4. Press the configured key once to start recording
5. Press the same key again to stop recording

## Testing

- TypeScript compilation passes for all new code
- No breaking changes to existing functionality
- Feature is disabled by default, so existing users are unaffected

Closes the request for toggle voice dictation functionality.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author