### PR TITLE
Fix waveform positioning to span full width while staying centered

### DIFF
--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -945,7 +945,7 @@ Always use actual resource IDs from the conversation history or create new ones 
               const summary = `Found ${parsed.length} items. First few:\n${JSON.stringify(parsed.slice(0, 3), null, 2)}${parsed.length > 3 ? `\n... and ${parsed.length - 3} more items` : ''}`
               return {
                 ...result,
-                content: [{ type: 'text', text: summary }]
+                content: [{ type: 'text' as const, text: summary }]
               }
             } else if (typeof parsed === 'object') {
               // For objects, show structure with truncated values
@@ -953,7 +953,7 @@ Always use actual resource IDs from the conversation history or create new ones 
               const summary = `Object with ${Object.keys(parsed).length} properties:\n${keys.map(key => `${key}: ${JSON.stringify(parsed[key]).substring(0, 100)}...`).join('\n')}${Object.keys(parsed).length > 10 ? `\n... and ${Object.keys(parsed).length - 10} more properties` : ''}`
               return {
                 ...result,
-                content: [{ type: 'text', text: summary }]
+                content: [{ type: 'text' as const, text: summary }]
               }
             }
           } catch (e) {
@@ -966,7 +966,7 @@ Always use actual resource IDs from the conversation history or create new ones 
           const truncated = content.substring(0, 2000) + '\n... [truncated for brevity]'
           return {
             ...result,
-            content: [{ type: 'text', text: truncated }]
+            content: [{ type: 'text' as const, text: truncated }]
           }
         }
       }

--- a/src/renderer/src/pages/panel.tsx
+++ b/src/renderer/src/pages/panel.tsx
@@ -496,34 +496,34 @@ export function Component() {
                 />
               )}
 
-              {/* Waveform visualization - right-aligned, dimmed when agent progress is showing */}
+              {/* Waveform visualization - full width with centered content, dimmed when agent progress is showing */}
               <div
                 className={cn(
-                  "absolute right-0 flex h-6 items-center gap-0.5 transition-opacity duration-300",
+                  "absolute inset-x-0 flex h-6 items-center justify-center transition-opacity duration-300 px-4",
                   agentProgress && !mcpTranscribeMutation.isPending
                     ? "opacity-30"
                     : "opacity-100",
                 )}
-                dir="rtl"
               >
-                {visualizerData
-                  .slice()
-                  .reverse()
-                  .map((rms, index) => {
-                    return (
-                      <div
-                        key={index}
-                        className={cn(
-                          "h-full w-0.5 shrink-0 rounded-lg",
-                          "bg-red-500 dark:bg-white",
-                          rms === -1000 && "bg-neutral-400 dark:bg-neutral-500",
-                        )}
-                        style={{
-                          height: `${Math.min(100, Math.max(16, rms * 100))}%`,
-                        }}
-                      />
-                    )
-                  })}
+                <div className="flex h-6 items-center gap-0.5">
+                  {visualizerData
+                    .slice()
+                    .map((rms, index) => {
+                      return (
+                        <div
+                          key={index}
+                          className={cn(
+                            "h-full w-0.5 shrink-0 rounded-lg",
+                            "bg-red-500 dark:bg-white",
+                            rms === -1000 && "bg-neutral-400 dark:bg-neutral-500",
+                          )}
+                          style={{
+                            height: `${Math.min(100, Math.max(16, rms * 100))}%`,
+                          }}
+                        />
+                      )
+                    })}
+                </div>
               </div>
             </div>
           </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -211,6 +211,7 @@ export type Config = {
 
   // Text-to-Speech Configuration
   ttsEnabled?: boolean
+  ttsAutoPlay?: boolean
   ttsProviderId?: TTS_PROVIDER_ID
 
   // OpenAI TTS Configuration


### PR DESCRIPTION
## Problem
The voice input waveform was only showing on the right side of the panel when the panel width increased past a certain size. This made the waveform visualization inconsistent and hard to see in wider panels.

## Solution
This PR fixes the waveform positioning by:

- **Full-width container**: Changed from `absolute right-0` to `absolute inset-x-0` to span the entire panel width
- **Centered content**: Added `justify-center` to center the waveform visualization within the full-width container
- **Proper height**: Added explicit `h-6` to the inner container so waveform bars render correctly with `h-full`
- **Better spacing**: Added `px-4` padding for breathing room from panel edges
- **Simplified data flow**: Removed RTL direction and data reversal since we're now centering the content

## Result
The waveform visualization now:
- ✅ Appears centered regardless of panel width
- ✅ Spans the full available width when needed
- ✅ Maintains consistent positioning across different panel sizes
- ✅ Shows audio visualization in correct chronological order

## Additional Changes
- Fixed TypeScript build errors by adding missing `ttsAutoPlay` property to Config type
- Fixed MCPToolResult type issues in llm.ts by using proper literal types

## Testing
- [x] Development server runs without errors
- [x] Waveform renders correctly in centered position
- [x] Panel resizing works as expected
- [x] No TypeScript compilation errors

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author