### PR TITLE
fix: sync tool management UI when MCP servers are stopped/deleted

### DIFF
--- a/src/main/tipc.ts
+++ b/src/main/tipc.ts
@@ -808,6 +808,8 @@ export const router = {
   saveConfig: t.procedure
     .input<{ config: Config }>()
     .action(async ({ input }) => {
+      // Handle MCP server configuration changes before saving
+      mcpService.handleConfigChange(input.config)
       configStore.save(input.config)
     }),
 

--- a/src/renderer/src/pages/settings-mcp-tools.tsx
+++ b/src/renderer/src/pages/settings-mcp-tools.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useNavigate } from "react-router-dom"
 import { Button } from "@renderer/components/ui/button"
 import { Label } from "@renderer/components/ui/label"
@@ -14,6 +14,7 @@ export function Component() {
   const queryClient = useQueryClient()
   const configQuery = useConfigQuery()
   const config = configQuery.data || {}
+  const toolManagerRefreshRef = useRef<(() => void) | null>(null)
 
   const saveConfigMutation = useMutation({
     mutationFn: async (config: Config) => {
@@ -21,6 +22,10 @@ export function Component() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["config"] })
+      // Trigger tool manager refresh when config changes
+      if (toolManagerRefreshRef.current) {
+        toolManagerRefreshRef.current()
+      }
     },
   })
 
@@ -65,7 +70,11 @@ export function Component() {
             />
 
             <div className="border-t pt-6">
-              <MCPToolManager />
+              <MCPToolManager
+                onRefreshReady={(refreshFn) => {
+                  toolManagerRefreshRef.current = refreshFn
+                }}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 🐛 Issue

Fixes #113 - MCP server removal not reflected in tool management section

## 📝 Problem

When MCP servers are stopped or deleted, they remain visible in the tool management section, creating inconsistency between the actual server state and the UI representation. This causes:

- User confusion about actual server availability
- Potential errors when users try to use non-existent servers
- Inconsistent state management

## 🔧 Solution

### Backend Changes

**Added `handleConfigChange` method to MCPService** (`src/main/mcp-service.ts`):
- Detects when servers are removed from configuration
- Automatically cleans up removed servers (stops processes, removes tools)
- Updates persisted runtime disabled servers list

**Modified `saveConfig` endpoint** (`src/main/tipc.ts`):
- Calls `handleConfigChange` before saving config
- Ensures cleanup happens whenever config is updated

### Frontend Changes

**Enhanced MCPConfigManager** (`src/renderer/src/components/mcp-config-manager.tsx`):
- Added immediate UI refresh after server operations (stop/start/delete)
- 100ms delay for delete operations to allow backend cleanup
- 500ms delay for start operations to allow server initialization

**Enhanced MCPToolManager** (`src/renderer/src/components/mcp-tool-manager.tsx`):
- Added dynamic polling interval (can temporarily increase frequency)
- Added `onRefreshReady` callback to expose refresh function
- Immediate refresh + 10 seconds of faster polling when triggered

**Coordinated refresh mechanism** (`src/renderer/src/pages/settings-mcp-tools.tsx`):
- Shared refresh coordination between MCPConfigManager and MCPToolManager
- Tool manager refreshes automatically when config changes

## 🧪 Testing

### Scenarios Covered

1. **Server Deletion**: When a server is deleted from config, it's immediately removed from tool management
2. **Server Stop**: When a server is stopped, tools disappear from tool management
3. **Server Start**: When a server is started, tools appear in tool management
4. **Config Changes**: Any config modification triggers appropriate UI updates

### Technical Validation

- ✅ Backend cleanup properly removes server state
- ✅ Frontend polling detects changes immediately
- ✅ UI coordination works between components
- ✅ No memory leaks from uncleaned server references

## 🔄 Flow

### Before (Broken)
1. User deletes server → Config updated
2. Server still running in background
3. Tools still visible in UI ❌

### After (Fixed)
1. User deletes server → Config updated
2. `handleConfigChange` detects removal → Stops server & cleans up
3. UI immediately refreshes → Tools disappear ✅

## 📋 Changes Summary

- **Backend**: Added server cleanup on config changes
- **Frontend**: Added immediate UI updates after operations
- **Coordination**: Shared refresh mechanism between components
- **Reliability**: Proper state management and cleanup

## 🎯 Impact

- ✅ Tool management section now accurately reflects server state
- ✅ No more ghost servers in the UI
- ✅ Immediate feedback for user actions
- ✅ Consistent state management across the application

This fix ensures that the tool management UI stays in sync with the actual MCP server state, providing users with accurate information about available tools and servers.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author