### PR TITLE
feat: Set default filesystem MCP path to root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pnpm test:tts     # Test TTS functionality
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["@modelcontextprotocol/server-filesystem", "/path"]
+      "args": ["@modelcontextprotocol/server-filesystem", "/"]
     },
     "web-search": {
       "command": "npx",

--- a/src/renderer/src/components/mcp-config-manager.tsx
+++ b/src/renderer/src/components/mcp-config-manager.tsx
@@ -572,7 +572,7 @@ function ServerDialog({ server, onSave, onCancel }: ServerDialogProps) {
                 placeholder={`{
   "transport": "stdio",
   "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/directory"],
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/"],
   "env": {
     "API_KEY": "your-key-here"
   }
@@ -690,7 +690,7 @@ const MCP_EXAMPLES = {
       args: [
         "-y",
         "@modelcontextprotocol/server-filesystem",
-        "/path/to/allowed/directory",
+        "/",
       ],
       env: {},
     },


### PR DESCRIPTION
## Summary

This PR implements the feature requested in issue #112 to set the default allowed directories path for the filesystem MCP server to forward slash (`/`) for broader access.

## Changes Made

- **Updated MCP_EXAMPLES configuration**: Changed filesystem server path from `/path/to/allowed/directory` to `/`
- **Updated JSON placeholder text**: Changed example path from `/path/to/directory` to `/`
- **Updated README.md documentation**: Changed example configuration to show `/` as the default path

## Files Modified

- `src/renderer/src/components/mcp-config-manager.tsx`: Updated both the MCP_EXAMPLES object and JSON input placeholder
- `README.md`: Updated the filesystem MCP server configuration example

## Benefits

- **Broader access by default**: Users get full filesystem access without needing to manually configure paths
- **Better user experience**: More flexible and user-friendly default configuration
- **Consistency**: All filesystem MCP examples now use the same default path

## Testing

- ✅ Development server builds and runs successfully
- ✅ No new TypeScript compilation errors introduced
- ✅ Changes are syntactically correct and maintain existing functionality

## Impact

This change only affects the default examples and placeholder text shown to users when configuring filesystem MCP servers. Existing configurations are not modified.

Fixes #112

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author