### PR TITLE
fix: Set window icon for Windows taskbar display

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -103,6 +103,10 @@ function createBaseWindow({
     height: 670,
     show: false,
     autoHideMenuBar: true,
+    // Set window icon for Windows to ensure proper taskbar display
+    ...(process.platform === "win32" && {
+      icon: path.join(__dirname, "../../build/icon.ico"),
+    }),
     ...windowOptions,
     webPreferences: {
       preload: path.join(__dirname, "../preload/index.mjs"),


### PR DESCRIPTION
## Summary

This PR fixes issue #106 where the Windows taskbar was showing the Electron default icon instead of the custom SpeakMCP icon.

## Problem

While the electron-builder configuration correctly specified the application icon (`build/icon.ico` for Windows), individual BrowserWindow instances were not explicitly setting their icon property. This caused Windows to display the default Electron icon in the taskbar instead of the custom SpeakMCP icon.

## Solution

Added explicit `icon` property to the BrowserWindow constructor options in the `createBaseWindow` function, specifically for Windows platform:

```typescript
// Set window icon for Windows to ensure proper taskbar display
...(process.platform === "win32" && {
  icon: path.join(__dirname, "../../build/icon.ico"),
}),
```

## Changes Made

- **Modified `src/main/window.ts`**: Added Windows-specific icon configuration to BrowserWindow constructor
- **Platform-specific**: Only applies to Windows (`process.platform === "win32"`) to avoid affecting other platforms
- **Correct path**: Uses the same icon file specified in electron-builder config (`build/icon.ico`)

## Benefits

- ✅ **Proper branding**: Windows taskbar now shows the SpeakMCP icon instead of generic Electron icon
- ✅ **Platform-specific**: Only affects Windows, maintaining existing behavior on macOS and Linux
- ✅ **Consistent with build config**: Uses the same icon file as electron-builder configuration
- ✅ **No breaking changes**: Existing functionality remains unchanged

## Testing

- ✅ Development server builds and runs successfully
- ✅ No TypeScript compilation errors
- ✅ Changes are platform-specific and don't affect other operating systems
- ✅ Icon path correctly references the existing `build/icon.ico` file

## Technical Details

The fix works by:
1. Detecting Windows platform using `process.platform === "win32"`
2. Adding the `icon` property to BrowserWindow options only on Windows
3. Using the correct path to the icon file that already exists in the build directory
4. Applying this to all windows created through the `createBaseWindow` function

## Impact

This change only affects Windows users and ensures that:
- Main application window shows correct icon in taskbar
- Setup window shows correct icon in taskbar
- Panel window (if it appears in taskbar) shows correct icon

Fixes #106

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author