### PR TITLE
fix: resolve ambiguous -da debug flag

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -14,11 +14,13 @@ pnpm dev d
 **Individual debug modes:**
 ```bash
 pnpm dev debug-llm    # Enable LLM debug
-pnpm dev debug-tools  # Enable tools debug  
+pnpm dev debug-tools  # Enable tools debug
+pnpm dev debug-app    # Enable app debug
 pnpm dev debug-all    # Enable all debug modes
 pnpm dev dl           # Enable LLM debug (short)
 pnpm dev dt           # Enable tools debug (short)
 pnpm dev dk           # Enable keybinds debug (short)
+pnpm dev dapp         # Enable app debug (short)
 ```
 
 ### Traditional Formats
@@ -26,9 +28,12 @@ pnpm dev dk           # Enable keybinds debug (short)
 **With dashes:**
 ```bash
 pnpm dev -- -d              # Debug all (short)
+pnpm dev -- -da             # Debug all (short)
 pnpm dev -- --debug-llm     # LLM debug (long)
 pnpm dev -- --debug-tools   # Tools debug (long)
+pnpm dev -- --debug-app     # App debug (long)
 pnpm dev -- --debug-all     # All debug modes (long)
+pnpm dev -- -dapp           # App debug (short)
 ```
 
 **Environment variables:**
@@ -36,7 +41,9 @@ pnpm dev -- --debug-all     # All debug modes (long)
 DEBUG=* pnpm dev             # Enable all debug modes
 DEBUG_LLM=true pnpm dev      # LLM debug only
 DEBUG_TOOLS=true pnpm dev    # Tools debug only
+DEBUG_APP=true pnpm dev      # App debug only
 DEBUG=llm,tools pnpm dev     # Multiple specific modes
+DEBUG=llm,tools,app pnpm dev # Multiple specific modes including app
 ```
 
 ## 🔍 Debug Output Details
@@ -116,6 +123,25 @@ When keybinds debug is enabled, you'll see:
 - Recording state changes
 - Text insertion and focus management
 
+### App Debug (`debug-app` or `dapp`)
+
+When app debug is enabled, you'll see:
+
+```
+[DEBUG][APP] Application startup sequence initiated
+[DEBUG][APP] Window creation: main window
+[DEBUG][APP] Configuration loaded: { theme: "dark", shortcuts: {...} }
+[DEBUG][APP] Panel window state change: visible -> hidden
+[DEBUG][APP] Menu action triggered: show_settings
+```
+
+**What it shows:**
+- Application lifecycle events
+- Window management operations
+- Configuration changes and loading
+- UI state transitions
+- Menu and user interaction events
+
 ## 🛠️ Advanced Debugging
 
 ### Custom Debug Combinations
@@ -126,8 +152,11 @@ You can combine multiple debug modes:
 # LLM + Tools (most common combination)
 pnpm dev dl dt
 
+# LLM + App debugging
+pnpm dev dl dapp
+
 # All modes explicitly
-pnpm dev debug-llm debug-tools debug-keybinds
+pnpm dev debug-llm debug-tools debug-keybinds debug-app
 ```
 
 ### Environment Variable Debugging
@@ -138,6 +167,7 @@ For persistent debugging across sessions:
 # Add to your shell profile (.bashrc, .zshrc, etc.)
 export DEBUG_LLM=true
 export DEBUG_TOOLS=true
+export DEBUG_APP=true
 
 # Then just run
 pnpm dev

--- a/src/main/debug.ts
+++ b/src/main/debug.ts
@@ -65,7 +65,7 @@ export function initDebugFlags(argv: string[] = process.argv): DebugFlags {
   flags.tools = all || hasAny("--debug-tools", "-dt", "debug-tools", "dt") || envTools
   flags.keybinds = all || hasAny("--debug-keybinds", "-dk", "debug-keybinds", "dk") || envKeybinds
   flags.tts = all || hasAny("--debug-tts", "-dts", "debug-tts", "dts") || envTTS
-  flags.app = all || hasAny("--debug-app", "-da", "debug-app", "da") || envApp
+  flags.app = all || hasAny("--debug-app", "-dapp", "debug-app", "dapp") || envApp
   flags.all = all
 
 
@@ -80,7 +80,7 @@ export function initDebugFlags(argv: string[] = process.argv): DebugFlags {
     if (flags.app) enabled.push("APP")
     // eslint-disable-next-line no-console
     console.log(
-      `[DEBUG] Enabled: ${enabled.join(", ")} (argv: ${argv.filter((a) => a.startsWith("--debug") || a.startsWith("-d") || a.startsWith("debug") || ["d", "dt", "dl", "dk", "dts", "da"].includes(a)).join(" ") || "none"})`,
+      `[DEBUG] Enabled: ${enabled.join(", ")} (argv: ${argv.filter((a) => a.startsWith("--debug") || a.startsWith("-d") || a.startsWith("debug") || ["d", "dt", "dl", "dk", "dts", "da", "dapp"].includes(a)).join(" ") || "none"})`,
     )
   }
 


### PR DESCRIPTION
## 🐛 Issue

Fixes #125 - The `-da` flag was ambiguously used for both `--debug-all` and `--debug-app`, causing unexpected behavior based on evaluation order.

## 🔧 Solution

### Changes Made

**Debug Flag Parsing** (`src/main/debug.ts`):
- Changed `--debug-app` short flag from `-da` to `-dapp`
- Kept `-da` for `--debug-all` (more commonly used)
- Updated debug banner to include new `-dapp` flag

**Documentation Updates** (`DEBUGGING.md`):
- Added comprehensive examples for all debug modes
- Updated command reference with new `-dapp` flag
- Added App Debug section with examples
- Updated environment variable examples
- Enhanced custom debug combinations

### Flag Assignments (After Fix)

- `--debug-all` / `-da` - Enable all debug modes
- `--debug-app` / `-dapp` - Enable app debug only
- `--debug-llm` / `-dl` - Enable LLM debug only
- `--debug-tools` / `-dt` - Enable tools debug only
- `--debug-keybinds` / `-dk` - Enable keybinds debug only
- `--debug-tts` / `-dts` - Enable TTS debug only

## 🧪 Testing

✅ **Verified flag disambiguation**:
- `-da` now only enables debug-all
- `-dapp` now only enables debug-app
- No ambiguity between flags
- All existing functionality preserved

✅ **Documentation updated**:
- All examples reflect new flag assignments
- Comprehensive usage guide included
- Environment variable examples updated

## 🎯 Impact

- ✅ **Eliminates ambiguity**: Users get predictable behavior from debug flags
- ✅ **Maintains compatibility**: Existing `-da` usage still works for debug-all
- ✅ **Clear documentation**: Updated examples prevent confusion
- ✅ **No breaking changes**: All existing debug functionality preserved

## 📋 Usage Examples

```bash
# Debug all modes
pnpm dev -da
pnpm dev --debug-all

# Debug app only
pnpm dev -dapp
pnpm dev --debug-app

# Multiple specific modes
pnpm dev -dl -dt -dapp  # LLM + Tools + App
```

This fix ensures that debug flags have distinct, unambiguous meanings and provides users with clear, predictable behavior when debugging SpeakMCP.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author