### PR TITLE
Emergency Stop: Stop Everything (Abort LLM, Stop MCP Servers, Kill Processes) + Cleaner Implementation

### DIFF
--- a/src/main/emergency-stop.ts
+++ b/src/main/emergency-stop.ts
@@ -1,0 +1,44 @@
+import { agentProcessManager, llmRequestAbortManager, state } from "./state"
+import { mcpService } from "./mcp-service"
+
+/**
+ * Centralized emergency stop: abort LLM requests, stop MCP servers,
+ * kill tracked child processes, and reset agent state.
+ * Returns before/after counts for logging.
+ */
+export async function emergencyStopAll(): Promise<{ before: number; after: number }> {
+  // Signal all consumers to stop ASAP
+  state.shouldStopAgent = true
+
+  // Abort any in-flight LLM HTTP requests
+  try {
+    llmRequestAbortManager.abortAll()
+  } catch {
+    // ignore
+  }
+
+  // Stop all MCP server processes (stdio/ws/http transports)
+  try {
+    mcpService.emergencyStopAllProcesses()
+  } catch {
+    // ignore
+  }
+
+  const before = agentProcessManager.getActiveProcessCount()
+
+  // Kill all tracked child processes immediately
+  try {
+    agentProcessManager.emergencyStop()
+  } catch {
+    // ignore
+  }
+
+  const after = agentProcessManager.getActiveProcessCount()
+
+  // Reset core agent state flags (keep shouldStopAgent=true for agent loop visibility)
+  state.isAgentModeActive = false
+  state.agentIterationCount = 0
+
+  return { before, after }
+}
+

--- a/src/main/state.ts
+++ b/src/main/state.ts
@@ -11,6 +11,8 @@ export const state = {
   agentProcesses: new Set<ChildProcess>(),
   shouldStopAgent: false,
   agentIterationCount: 0,
+  // Track in-flight LLM abort controllers
+  llmAbortControllers: new Set<AbortController>(),
 }
 
 // Process management for agent mode
@@ -82,5 +84,25 @@ export const agentProcessManager = {
   // Get count of active processes
   getActiveProcessCount(): number {
     return state.agentProcesses.size
+  },
+}
+
+// Abort management for LLM HTTP requests
+export const llmRequestAbortManager = {
+  register(controller: AbortController) {
+    state.llmAbortControllers.add(controller)
+  },
+  unregister(controller: AbortController) {
+    state.llmAbortControllers.delete(controller)
+  },
+  abortAll() {
+    for (const controller of state.llmAbortControllers) {
+      try {
+        controller.abort()
+      } catch (_e) {
+        // ignore
+      }
+    }
+    state.llmAbortControllers.clear()
   },
 }

--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -19,7 +19,6 @@ interface AgentProgressProps {
 
 // Enhanced conversation message component
 
-
 // Compact message component for space efficiency
 const CompactMessage: React.FC<{
   message: {
@@ -173,7 +172,7 @@ const CompactMessage: React.FC<{
                           <div className="mb-1 text-xs font-medium opacity-70">
                             Parameters:
                           </div>
-                          <pre className="rounded bg-muted/50 p-2 overflow-x-auto text-xs whitespace-pre-wrap">
+                          <pre className="rounded bg-muted/50 p-2 overflow-auto text-xs whitespace-pre-wrap max-h-80 scrollbar-thin">
                             {JSON.stringify(toolCall.arguments, null, 2)}
                           </pre>
                         </div>
@@ -209,7 +208,7 @@ const CompactMessage: React.FC<{
                           <div className="text-xs font-medium opacity-70 mb-1">
                             Content:
                           </div>
-                          <pre className="rounded bg-muted/30 p-2 overflow-x-auto text-xs whitespace-pre-wrap break-all">
+                          <pre className="rounded bg-muted/30 p-2 overflow-auto text-xs whitespace-pre-wrap break-all max-h-80 scrollbar-thin">
                             {result.content || "No content returned"}
                           </pre>
                         </div>
@@ -219,7 +218,7 @@ const CompactMessage: React.FC<{
                             <div className="text-xs font-medium text-destructive mb-1">
                               Error Details:
                             </div>
-                            <pre className="rounded bg-destructive/10 p-2 overflow-x-auto text-xs whitespace-pre-wrap break-all">
+                            <pre className="rounded bg-destructive/10 p-2 overflow-auto text-xs whitespace-pre-wrap break-all max-h-60 scrollbar-thin">
                               {result.error}
                             </pre>
                           </div>

--- a/src/renderer/src/components/conversation-display.tsx
+++ b/src/renderer/src/components/conversation-display.tsx
@@ -323,7 +323,7 @@ function ConversationMessageItem({
                     <div className="mb-1 text-xs font-medium text-muted-foreground">
                       Parameters:
                     </div>
-                    <pre className="modern-panel rounded bg-muted/50 p-2 overflow-x-auto text-xs">
+                    <pre className="modern-panel rounded bg-muted/50 p-2 overflow-auto text-xs max-h-80 scrollbar-thin">
                       {JSON.stringify(toolCall.arguments, null, 2)}
                     </pre>
                   </div>
@@ -368,7 +368,7 @@ function ConversationMessageItem({
                     <div className="text-xs font-medium text-muted-foreground mb-1">
                       Content:
                     </div>
-                    <pre className="modern-panel rounded bg-muted/30 p-2 overflow-x-auto text-xs whitespace-pre-wrap break-all">
+                    <pre className="modern-panel rounded bg-muted/30 p-2 overflow-auto text-xs whitespace-pre-wrap break-all max-h-80 scrollbar-thin">
                       {result.content || "No content returned"}
                     </pre>
                   </div>
@@ -378,7 +378,7 @@ function ConversationMessageItem({
                       <div className="text-xs font-medium text-destructive mb-1">
                         Error Details:
                       </div>
-                      <pre className="modern-panel rounded bg-destructive/10 p-2 overflow-x-auto text-xs whitespace-pre-wrap break-all">
+                      <pre className="modern-panel rounded bg-destructive/10 p-2 overflow-auto text-xs whitespace-pre-wrap break-all max-h-60 scrollbar-thin">
                         {result.error}
                       </pre>
                     </div>


### PR DESCRIPTION
This PR improves the emergency stop behavior and simplifies the implementation:

Key changes
- Centralized emergency stop helper (src/main/emergency-stop.ts) that:
  - Sets shouldStopAgent immediately
  - Aborts all in-flight LLM HTTP requests
  - Stops all MCP servers (stdio/ws/http transports)
  - Kills tracked child processes
  - Resets agent state; returns counts for logging
- window.emergencyStopAgentMode now delegates to the helper and only handles renderer UI signals (clear and hide panel), reducing duplication
- LLM fetch is now abortable with AbortController; retry logic no longer retries aborted requests and respects shouldStopAgent
- Agent loop catches AbortError and emits a clean final “Agent stopped” progress state

Why
- Previously, the kill switch didn’t cancel in-flight HTTP calls and sometimes the agent continued after emergency stop
- This PR ensures the keyboard kill switch stops everything immediately and cleanly

Files touched
- src/main/emergency-stop.ts (new)
- src/main/window.ts (use centralized helper)
- src/main/state.ts (LLM abort manager + minimal state addition)
- src/main/llm-fetch.ts (abortable fetch + stop-aware retry)
- src/main/llm.ts (handle AbortError cleanly in agent loop)

Notes
- No test files in repo; ran test script, none found
- UI and behavior verified via logs: AbortError on stop, final progress rendered, and panel hides promptly

Let me know if you want the tipc emergencyStopAgent route switched to call the centralized helper directly for full deduplication (currently remains functionally correct).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author