### PR TITLE
Remove 'done', 'esc', and 'details' buttons from agent progress interface

### DIFF
--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react"
 import { cn } from "@renderer/lib/utils"
 import { AgentProgressUpdate } from "../../../shared/types"
-import { ChevronDown, ChevronUp, ChevronRight, ExternalLink } from "lucide-react"
+import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react"
 import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
@@ -503,27 +503,8 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         </div>
         <div className="flex items-center gap-3">
           <span className="text-xs text-muted-foreground">
-            {isComplete ? "Done" : `${currentIteration}/${maxIterations}`}
+            {isComplete ? "" : `${currentIteration}/${maxIterations}`}
           </span>
-          {isComplete && finalContent && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                const url = currentConversationId
-                  ? `/conversations/${currentConversationId}`
-                  : "/conversations"
-                tipcClient.showMainWindow({ url })
-              }}
-              className="h-6 px-2 text-xs"
-            >
-              <ExternalLink className="h-3 w-3" />
-              Details
-            </Button>
-          )}
-          {isComplete && (
-            <span className="text-xs text-muted-foreground">ESC</span>
-          )}
         </div>
       </div>
 

--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -503,7 +503,11 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         </div>
         <div className="flex items-center gap-3">
           <span className="text-xs text-muted-foreground">
-            {isComplete ? "" : `${currentIteration}/${maxIterations}`}
+{!isComplete && (
+  <span className="text-xs text-muted-foreground">
+    {`${currentIteration}/${maxIterations}`}
+  </span>
+)}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Removes the 'done', 'esc', and 'details' buttons from the agent progress interface as requested in issue #145 to simplify the UI.

## Changes Made

- **Removed Details button**: Eliminated the button with ExternalLink icon that appeared when agent completed with final content
- **Removed ESC text indicator**: Removed the 'ESC' text that showed when agent was complete
- **Removed 'Done' text**: Removed the 'Done' text from the status area when agent completed
- **Cleaned up imports**: Removed unused ExternalLink import from lucide-react

## Technical Details

The changes were made in `src/renderer/src/components/agent-progress.tsx`:
- Lines 508-523: Removed the Details button component entirely
- Lines 524-526: Removed the ESC text indicator
- Line 506: Changed 'Done' text to empty string when agent is complete
- Line 4: Removed ExternalLink from lucide-react imports

## Impact

- ✅ **Simplified UI**: Agent progress interface is now cleaner without unnecessary buttons
- ✅ **Maintains functionality**: Core agent progress display and iteration tracking remain intact
- ✅ **No breaking changes**: Existing agent workflow continues to work as expected
- ✅ **Clean code**: Removed unused imports and simplified component structure

## Testing

- ✅ Code compiles successfully (pre-existing TypeScript errors in codebase are unrelated)
- ✅ Component structure remains valid
- ✅ No syntax errors introduced

Fixes #145

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author