### PR TITLE
fix: Add --yes flag to example MCP servers with npx to prevent timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ pnpm test         # Run test suite
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["@modelcontextprotocol/server-filesystem", "/path"]
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
     },
     "web-search": {
       "command": "npx",
-      "args": ["@modelcontextprotocol/server-web-search"],
+      "args": ["-y", "@modelcontextprotocol/server-web-search"],
       "env": {"BRAVE_API_KEY": "your-key"}
     }
   }

--- a/src/renderer/src/components/mcp-config-manager.tsx
+++ b/src/renderer/src/components/mcp-config-manager.tsx
@@ -682,7 +682,7 @@ const MCP_EXAMPLES = {
     config: {
       transport: "stdio" as MCPTransportType,
       command: "npx",
-      args: ["@wonderwhy-er/desktop-commander@latest"],
+      args: ["-y", "@wonderwhy-er/desktop-commander@latest"],
       env: {},
     },
   },


### PR DESCRIPTION
## 🎯 Addresses Issue #144

This PR adds the `--yes` flag to example MCP servers that use npx commands to prevent timeout issues during installation/execution.

## ✨ Changes Made

### 🔧 Fixed Missing --yes Flag
- **desktop-commander server**: Added `-y` flag to prevent npx timeout
- **README.md examples**: Updated documentation examples to include `-y` flag
- **UI placeholders**: Verified all placeholder examples already include `-y` flag

### 📋 Files Modified
- `src/renderer/src/components/mcp-config-manager.tsx` - Added `-y` flag to desktop-commander server
- `README.md` - Updated MCP server configuration examples

## 🎯 Problem Solved

Without the `--yes` flag, npx commands can timeout waiting for user input during package installation. The `-y` flag automatically answers "yes" to any prompts, allowing npx commands to run non-interactively.

## ✅ Before/After

**Before:**
```json
"args": ["@wonderwhy-er/desktop-commander@latest"]
```

**After:**
```json
"args": ["-y", "@wonderwhy-er/desktop-commander@latest"]
```

## 🧪 Testing

- ✅ Verified syntax correctness of all changes
- ✅ Confirmed all other MCP examples already have `-y` flag
- ✅ Updated documentation examples for consistency
- ✅ No breaking changes introduced

## 🎉 Impact

- **Eliminates timeout issues** for desktop-commander MCP server
- **Improves user experience** with reliable server initialization
- **Maintains consistency** across all npx-based MCP server examples
- **Better documentation** with correct examples

Fixes #144

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author