### PR TITLE
Remove resume scroll button in agent progress (fix #152)

### DIFF
--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -550,12 +550,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           )}
         </div>
 
-        {/* Auto-scroll indicator */}
-        {isUserScrolling && !isComplete && (
-          <div className="absolute bottom-2 right-2 animate-pulse rounded-full bg-primary/80 px-2 py-1 text-xs text-primary-foreground shadow-lg">
-            Resume auto-scroll
-          </div>
-        )}
       </div>
 
       {/* Slim Progress Bar */}


### PR DESCRIPTION
This PR removes the now-unnecessary "Resume auto-scroll" indicator from the AgentProgress UI.

- Removes the floating "Resume auto-scroll" pill shown when the user scrolls
- Retains auto-scroll behavior without showing the confusing indicator

Closes #152.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author