### PR TITLE
fix(agent): auto-continue conversation when pressing hotkey; avoid duplicate assistant insertion; remove 'Resume auto-scroll' pill

### DIFF
--- a/src/main/tipc.ts
+++ b/src/main/tipc.ts
@@ -747,14 +747,6 @@ export const router = {
         conversationId,
       )
 
-      // Add assistant response to conversation
-      if (conversationId) {
-        await conversationService.addMessageToConversation(
-          conversationId,
-          finalResponse,
-          "assistant",
-        )
-      }
 
       // Save to history
       const history = getRecordingHistory()

--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -550,12 +550,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           )}
         </div>
 
-        {/* Auto-scroll indicator */}
-        {isUserScrolling && !isComplete && (
-          <div className="absolute bottom-2 right-2 animate-pulse rounded-full bg-primary/80 px-2 py-1 text-xs text-primary-foreground shadow-lg">
-            Resume auto-scroll
-          </div>
-        )}
       </div>
 
       {/* Slim Progress Bar */}

--- a/src/renderer/src/pages/panel.tsx
+++ b/src/renderer/src/pages/panel.tsx
@@ -269,17 +269,26 @@ export function Component() {
         isConfirmedRef.current = true
         recorderRef.current?.stopRecording()
       } else {
-        // Force normal dictation mode when using the normal hotkey
-        setMcpMode(false)
-        mcpModeRef.current = false
+        // If there's an active conversation, automatically continue in MCP mode
+        const continueConv = showContinueButton && !mcpMode
         setAgentProgress(null)
-        tipcClient.showPanelWindow({})
+        if (continueConv) {
+          setMcpMode(true)
+          mcpModeRef.current = true
+          tipcClient.resizePanelToNormal({})
+          tipcClient.showPanelWindow({})
+        } else {
+          // Force normal dictation mode when not continuing a conversation
+          setMcpMode(false)
+          mcpModeRef.current = false
+          tipcClient.showPanelWindow({})
+        }
         recorderRef.current?.startRecording()
       }
     })
 
     return unlisten
-  }, [recording])
+  }, [recording, showContinueButton, mcpMode])
 
   // Text input handlers
   useEffect(() => {


### PR DESCRIPTION
This PR addresses the "Continue conversation flow is broken" issue and cleans up Agent Progress UI.

Changes
- Auto-continue: When the user presses the normal dictation hotkey and a conversation continuation is available, the panel automatically enters MCP mode and records, so the next utterance continues the active conversation instead of starting a fresh one
- Remove duplicate assistant insertion: Avoid double-inserting the final assistant message by removing server-side insertion from createMcpRecording; renderer ConversationProvider already appends final content upon agent completion
- UI cleanup: Remove the confusing floating "Resume auto-scroll" pill from AgentProgress; auto-scroll behavior remains intact

Files touched
- src/renderer/src/pages/panel.tsx: detect showContinueButton in startOrFinishRecording handler to auto-continue in MCP mode
- src/main/tipc.ts: remove redundant assistant message insertion in createMcpRecording
- src/renderer/src/components/agent-progress.tsx: remove auto-scroll indicator pill

Notes
- Typecheck has known pre-existing errors elsewhere in the repo; these changes are isolated and UI/flow verified by inspection

Closes #150
Related: #152

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author