### PR TITLE
Linux: disable hardware acceleration by default (opt-in via SPEAKMCP_ENABLE_GPU=1)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,23 @@ import { initializeDeepLinkHandling } from "./oauth-deeplink-handler"
 import { configStore } from "./config"
 import { startRemoteServer } from "./remote-server"
 
+
+// On Linux, disable hardware acceleration by default to avoid VA-API driver issues
+// Users can override by setting SPEAKMCP_ENABLE_GPU=1
+const enableGpu = process.env.SPEAKMCP_ENABLE_GPU === "1"
+if (process.platform === "linux" && !enableGpu) {
+  try {
+    app.disableHardwareAcceleration()
+    app.commandLine.appendSwitch("disable-gpu")
+    app.commandLine.appendSwitch(
+      "disable-features",
+      "VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoDecode,AcceleratedVideoEncoder,CanvasOopRasterization",
+    )
+  } catch (_) {
+    // best-effort only
+  }
+}
+
 registerServeSchema()
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
This PR addresses Linux startup failures reported in #168 due to VA-API initialization issues on some systems (e.g., WSLg/Wayland/VMs or mismatched libva/mesa drivers).

What changed
- On Linux, disable hardware acceleration early during app startup and explicitly disable VA-API video paths to avoid fatal initialization issues.
- Users with a healthy VA-API setup can opt back in by setting `SPEAKMCP_ENABLE_GPU=1`.

Code excerpt (src/main/index.ts):

```ts
// On Linux, disable hardware acceleration by default to avoid VA-API driver issues
// Users can override by setting SPEAKMCP_ENABLE_GPU=1
const enableGpu = process.env.SPEAKMCP_ENABLE_GPU === "1"
if (process.platform === "linux" && !enableGpu) {
  app.disableHardwareAcceleration()
  app.commandLine.appendSwitch("disable-gpu")
  app.commandLine.appendSwitch(
    "disable-features",
    "VaapiVideoDecoder,VaapiVideoEncoder,AcceleratedVideoDecode,AcceleratedVideoEncoder,CanvasOopRasterization",
  )
}
```

Rationale
- The user attempted flags like `--disable-gpu` and `--disable-features=VaapiVideoDecodeLinuxGL`, but VA-API probing can still occur or flags may not pass through in dev mode. Applying this at startup is more robust.

Scope
- Only `src/main/index.ts` is changed in this PR.

Closes #168.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author