### PR TITLE
feat: MCP improvements from October 22

### DIFF
--- a/src/main/tipc.ts
+++ b/src/main/tipc.ts
@@ -1164,6 +1164,19 @@ export const router = {
       return mcpService.stopServer(input.serverName)
     }),
 
+  getMcpServerLogs: t.procedure
+    .input<{ serverName: string }>()
+    .action(async ({ input }) => {
+      return mcpService.getServerLogs(input.serverName)
+    }),
+
+  clearMcpServerLogs: t.procedure
+    .input<{ serverName: string }>()
+    .action(async ({ input }) => {
+      mcpService.clearServerLogs(input.serverName)
+      return { success: true }
+    }),
+
   // Text-to-Speech
   generateSpeech: t.procedure
     .input<{

--- a/src/renderer/src/components/text-input-panel.tsx
+++ b/src/renderer/src/components/text-input-panel.tsx
@@ -54,6 +54,7 @@ export const TextInputPanel = forwardRef<TextInputPanelRef, TextInputPanelProps>
         clearTimeout(timer2)
       }
     }
+    return undefined
   }, [isProcessing])
 
   const handleSubmit = () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -93,6 +93,12 @@ export interface MCPConfig {
   mcpServers: Record<string, MCPServerConfig>
 }
 
+// Server log entry interface
+export interface ServerLogEntry {
+  timestamp: number
+  message: string
+}
+
 // Agent Mode Progress Tracking Types
 export interface AgentProgressStep {
   id: string


### PR DESCRIPTION
This PR contains the MCP-related improvements from October 22, 2025:

## Changes

1. **Improve MCP server configuration UX** (f0c8ac0)
   - Enhanced user experience for MCP server configuration

2. **MCP logs: capture and display server output in UI** (68f49ff)
   - Capture diagnostic logs from stdio servers via StdioClientTransport.stderr (stderr: 'pipe')
   - Remove manual child_process spawn; rely on SDK transport to manage process
   - Add minimal in-memory circular log buffer per server and IPC endpoints (get/clear)
   - UI: collapsible terminal-style log viewer on MCP config card (polling, clear)
   - Simplify ServerLogEntry (timestamp + message); no stream-type label in UI
   - Centralize cleanup: close transports in cleanupServer/terminateAll; simplify stopServer
   - Fix TS: ensure useEffect returns a cleanup value in text-input-panel

## Branch Details
- Base: `9b7c554d12f4a9bb5108e45a134b7d02fa4a3021`
- Commits cherry-picked from October 22, 2025

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author