### PR TITLE
fix: Reintroduce Settings option in tray menu without global keybind

### DIFF
--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -43,6 +43,15 @@ const buildMenu = (tray: Tray) =>
       type: "separator",
     },
     {
+      label: "Settings",
+      click() {
+        showMainWindow("/settings")
+      },
+    },
+    {
+      type: "separator",
+    },
+    {
       role: "quit",
     },
   ])


### PR DESCRIPTION
## Summary

This PR fixes issue #197 by reintroducing the Settings option in the tray icon menu without displaying the global keybind.

## Problem

The Settings option was completely removed from the tray menu in commit 7231e81 when fixing issue #194. However, the intention was only to remove the non-functional global keybind display, not the entire Settings menu item.

## Solution

- Reintroduced the Settings menu item in the tray menu
- Removed the `accelerator` property (CmdOrCtrl+,) to avoid showing the non-functional keybind
- Settings option now appears between "View History" and "Quit"
- Clicking Settings opens the main window to the /settings route

## Changes Made

- **Modified `src/main/tray.ts`**: Added Settings menu item back without the accelerator property

## Testing

- ✅ TypeScript compilation successful (pre-existing errors unrelated to this change)
- ✅ Settings menu item properly positioned in tray menu
- ✅ No global keybind displayed
- ✅ Clicking Settings opens the settings page

## Impact

- ✅ Users can now access Settings from the tray menu
- ✅ No confusing non-functional keybind is displayed
- ✅ Maintains existing functionality for other menu items

Fixes #197

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Settings option to the tray menu, providing quick access to application configuration options from the system tray.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->