### PR TITLE
fix: exclude test files from TypeScript compilation in tsconfig

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   "include": ["electron.vite.config.*", "src/main/**/*", "src/shared/**/*","src/preload/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"],

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -8,6 +8,7 @@
     "src/renderer/src/**/*.tsx",
     "src/preload/*.d.ts"
   ],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
   "compilerOptions": {
     "composite": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

This PR fixes TypeScript compilation errors by excluding test files from the tsconfig configurations.

## Problem

Test files (.test.ts, .test.tsx, .spec.ts, .spec.tsx) were being included in TypeScript compilation, causing errors for test-specific globals like describe, it, and expect that are only available at runtime through vitest.

## Solution

Added exclude patterns to both tsconfig.node.json and tsconfig.web.json to exclude test files from TypeScript compilation.

## Changes

- tsconfig.node.json: Added exclude patterns
- tsconfig.web.json: Added exclude patterns

## Testing

✅ npm run typecheck now passes without errors
✅ npm run dev works correctly

## Impact

This is a minimal, non-breaking change that only affects TypeScript compilation configuration. It allows developers to run npm run dev and npm run typecheck without encountering test-related TypeScript errors.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author