### PR TITLE
chore: tests and coverage improvements (shared, renderer lib, panel-position)

### DIFF
--- a/src/main/panel-position.test.ts
+++ b/src/main/panel-position.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock electron and config before importing module under test
+vi.mock('electron', () => ({
+  screen: {
+    getDisplayNearestPoint: vi.fn(),
+    getCursorScreenPoint: vi.fn(),
+  },
+}))
+vi.mock('./config', () => ({
+  configStore: {
+    get: () => ({}),
+    save: vi.fn(),
+  },
+}))
+
+describe('panel-position', async () => {
+  const mod = await import('./panel-position')
+  const { calculatePositionForPreset, constrainPositionToScreen } = mod
+
+  const screenSize = { x: 0, y: 0, width: 1920, height: 1080 }
+  const size = { width: 300, height: 200 }
+
+  describe('calculatePositionForPreset', () => {
+    it('computes each preset correctly', () => {
+      expect(calculatePositionForPreset('top-left', screenSize, size)).toEqual({ x: 10, y: 10 })
+      expect(calculatePositionForPreset('top-center', screenSize, size)).toEqual({ x: 810, y: 10 })
+      expect(calculatePositionForPreset('top-right', screenSize, size)).toEqual({ x: 1610, y: 10 })
+
+      expect(calculatePositionForPreset('bottom-left', screenSize, size)).toEqual({ x: 10, y: 870 })
+      expect(calculatePositionForPreset('bottom-center', screenSize, size)).toEqual({ x: 810, y: 870 })
+      expect(calculatePositionForPreset('bottom-right', screenSize, size)).toEqual({ x: 1610, y: 870 })
+
+      // default/custom falls back to top-right
+      expect(calculatePositionForPreset('custom', screenSize, size)).toEqual({ x: 1610, y: 10 })
+    })
+  })
+
+  describe('constrainPositionToScreen', () => {
+    it('clamps position within screen bounds', () => {
+      // off left/top
+      expect(constrainPositionToScreen({ x: -100, y: -50 }, size, screenSize)).toEqual({ x: 0, y: 0 })
+      // off right/bottom
+      expect(constrainPositionToScreen({ x: 5000, y: 5000 }, size, screenSize)).toEqual({ x: 1620, y: 880 })
+      // inside unchanged
+      expect(constrainPositionToScreen({ x: 200, y: 300 }, size, screenSize)).toEqual({ x: 200, y: 300 })
+    })
+  })
+})
+

--- a/src/renderer/src/lib/final-fixes.test.ts
+++ b/src/renderer/src/lib/final-fixes.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { safe } from './final-fixes'
+
+describe('renderer lib: final-fixes', () => {
+  it('primitive guards', () => {
+    expect(safe.string('x')).toBe('x')
+    expect(safe.string(1 as any, 'f')).toBe('f')
+
+    expect(safe.number(2)).toBe(2)
+    expect(safe.number('n' as any, 7)).toBe(7)
+
+    expect(safe.boolean(true)).toBe(true)
+    expect(safe.boolean('t' as any, false)).toBe(false)
+  })
+
+  it('array/object/get helpers', () => {
+    expect(safe.array<number>([1,2,3])).toEqual([1,2,3])
+    expect(safe.array<number>(null as any, [9])).toEqual([9])
+
+    const def = { a: 1 }
+    expect(safe.object<typeof def>({ a: 2 }, def)).toEqual({ a: 2 })
+    expect(safe.object<typeof def>(null as any, def)).toEqual(def)
+
+    expect(safe.get<number>({ a: 1 }, 'a', 0)).toBe(1)
+    expect(safe.get<number>({}, 'a', 0)).toBe(0)
+  })
+
+  it('length/filter/map helpers', () => {
+    expect(safe.length([1,2,3])).toBe(3)
+    expect(safe.length(null as any)).toBe(0)
+
+    expect(safe.filter<number>([1,2,3,4], (n) => n % 2 === 0)).toEqual([2,4])
+    expect(safe.filter<number>(null as any, (n) => n > 0)).toEqual([])
+
+    expect(safe.map<number, number>([1,2,3], (n) => n * 2)).toEqual([2,4,6])
+    expect(safe.map<number, number>(null as any, (n) => n * 2)).toEqual([])
+  })
+})
+

--- a/src/renderer/src/lib/fixes.test.ts
+++ b/src/renderer/src/lib/fixes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import * as mod from './fixes'
+
+describe('renderer lib: fixes', () => {
+  it('safeQueryResult returns object or empty object cast', () => {
+    expect(mod.safeQueryResult<{ x: number }>({ x: 1 })).toEqual({ x: 1 })
+    expect(mod.safeQueryResult<{ x: number }>(null as any)).toEqual({})
+  })
+
+  it('safeArray returns array or []', () => {
+    expect(mod.safeArray<number>([1,2,3])).toEqual([1,2,3])
+    expect(mod.safeArray<number>(null as any)).toEqual([])
+  })
+
+  it('safeObject returns object or default', () => {
+    const def = { a: 1 }
+    expect(mod.safeObject<typeof def>({ a: 2 }, def)).toEqual({ a: 2 })
+    expect(mod.safeObject<typeof def>(null as any, def)).toEqual(def)
+  })
+
+  it('safeGet returns property or default', () => {
+    expect(mod.safeGet<number>({ a: 1 }, 'a', 0)).toBe(1)
+    expect(mod.safeGet<number>({}, 'a', 0)).toBe(0)
+  })
+
+  it('safeSpread merges source onto target when source is object', () => {
+    expect(mod.safeSpread({ b: 2 }, { a: 1 } as { a: number; b?: number })).toEqual({ a: 1, b: 2 })
+    expect(mod.safeSpread(null as any, { a: 1 })).toEqual({ a: 1 })
+  })
+})
+

--- a/src/renderer/src/lib/type-guards.test.ts
+++ b/src/renderer/src/lib/type-guards.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+
+import * as mod from './type-guards'
+
+describe('renderer lib: type-guards', () => {
+  it('isValidQueryResult detects minimal shape', () => {
+    expect(mod.isValidQueryResult({ data: 1, isLoading: false, isError: false })).toBe(true)
+    expect(mod.isValidQueryResult({})).toBe(false)
+    expect(mod.isValidQueryResult(null)).toBe(false)
+  })
+
+  it('safeGet traverses by path with fallback', () => {
+    const obj = { a: { b: { c: 42 } } }
+    expect(mod.safeGet<number>(obj, 'a.b.c', 0)).toBe(42)
+    expect(mod.safeGet<string>(obj, 'a.b.x', 'nope')).toBe('nope')
+    expect(mod.safeGet<string>(null as any, 'a', 'nope')).toBe('nope')
+  })
+
+  it('assertType returns the value unchanged', () => {
+    const v = { x: 1 }
+    expect(mod.assertType<typeof v>(v)).toBe(v)
+  })
+
+  it('safeSpread merges when source is object, else returns default', () => {
+    const def = { a: 1, b: 2 }
+    expect(mod.safeSpread({ b: 3, c: 4 }, def)).toEqual({ a: 1, b: 3, c: 4 })
+    expect(mod.safeSpread(null as any, def)).toEqual(def)
+  })
+})
+

--- a/src/renderer/src/lib/utils.test.ts
+++ b/src/renderer/src/lib/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('renderer lib: utils.cn', () => {
+  it('joins class names', () => {
+    expect(cn('foo', 'bar', 'baz')).toBe('foo bar baz')
+  })
+
+  it('merges conflicting tailwind classes preferring later', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+    expect(cn('text-red-500', 'text-red-600')).toBe('text-red-600')
+  })
+})
+

--- a/src/shared/key-utils.test.ts
+++ b/src/shared/key-utils.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  parseKeyCombo,
+  matchesKeyCombo,
+  formatKeyComboForDisplay,
+  validateKeyCombo,
+  getEffectiveShortcut,
+} from './key-utils'
+
+describe('key-utils', () => {
+  describe('parseKeyCombo', () => {
+    it('parses modifiers and key', () => {
+      expect(parseKeyCombo('ctrl-shift-t')).toEqual({
+        ctrl: true,
+        shift: true,
+        alt: false,
+        meta: false,
+        key: 't',
+      })
+
+      expect(parseKeyCombo('Cmd-Alt-space')).toEqual({
+        ctrl: false,
+        shift: false,
+        alt: true,
+        meta: true,
+        key: 'space',
+      })
+    })
+
+    it('handles empty input', () => {
+      expect(parseKeyCombo('')).toEqual({ ctrl: false, shift: false, alt: false, meta: false, key: '' })
+    })
+  })
+
+  describe('matchesKeyCombo', () => {
+    it('matches letter keys with KeyX normalization', () => {
+      const event = { key: 'KeyT' }
+      const modifiers = { ctrl: true, shift: true, alt: false, meta: false }
+      expect(matchesKeyCombo(event, modifiers, 'ctrl-shift-t')).toBe(true)
+    })
+
+    it('matches special keys with mappings', () => {
+      const event = { key: 'slash' }
+      const modifiers = { ctrl: false, shift: false, alt: false, meta: false }
+      expect(matchesKeyCombo(event, modifiers, 'slash')).toBe(true)
+      expect(matchesKeyCombo({ key: 'space' }, modifiers, 'space')).toBe(true)
+    })
+
+    it('respects modifier mismatches', () => {
+      const event = { key: 'KeyT' }
+      const modifiers = { ctrl: true, shift: false, alt: false, meta: false }
+      expect(matchesKeyCombo(event, modifiers, 'ctrl-shift-t')).toBe(false)
+    })
+  })
+
+  describe('formatKeyComboForDisplay', () => {
+    const originalPlatform = process.platform
+
+    it('formats with Cmd on darwin', () => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin' as any)
+      expect(formatKeyComboForDisplay('meta-space')).toBe('Cmd + SPACE')
+    })
+
+    it('formats with Meta on non-darwin', () => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('win32' as any)
+      expect(formatKeyComboForDisplay('meta-slash')).toBe('Meta + SLASH')
+      // restore
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(originalPlatform as any)
+    })
+
+    it('returns empty string for empty combo', () => {
+      expect(formatKeyComboForDisplay('')).toBe('')
+    })
+  })
+
+  describe('validateKeyCombo', () => {
+    it('validates basic combos and rejects invalid/dangerous ones', () => {
+      expect(validateKeyCombo('ctrl-t')).toEqual({ valid: true })
+      expect(validateKeyCombo('f10')).toEqual({ valid: true })
+
+      expect(validateKeyCombo('')).toEqual({ valid: false, error: 'Key combination cannot be empty' })
+      expect(validateKeyCombo('t')).toEqual({
+        valid: false,
+        error: 'Key combination must include at least one modifier key (Ctrl, Shift, Alt, Meta) or be a function key',
+      })
+      expect(validateKeyCombo('ctrl-alt-delete')).toEqual({
+        valid: false,
+        error: 'This key combination is reserved by the system',
+      })
+      expect(validateKeyCombo('ctrl-shift-escape')).toEqual({
+        valid: false,
+        error: 'This key combination is reserved by the system',
+      })
+    })
+  })
+
+  describe('getEffectiveShortcut', () => {
+    it('returns custom when type is custom, otherwise returns type', () => {
+      expect(getEffectiveShortcut('custom', 'ctrl-k')).toBe('ctrl-k')
+      expect(getEffectiveShortcut('ctrl-t', 'ctrl-k')).toBe('ctrl-t')
+      expect(getEffectiveShortcut(undefined, undefined)).toBeUndefined()
+    })
+  })
+})
+

--- a/src/shared/languages.test.ts
+++ b/src/shared/languages.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  SUPPORTED_LANGUAGES,
+  OPENAI_WHISPER_SUPPORTED_LANGUAGES,
+  GROQ_WHISPER_SUPPORTED_LANGUAGES,
+  getLanguageName,
+  getLanguageNativeName,
+  isValidLanguageCode,
+  isValidLanguageForProvider,
+  getApiLanguageCode,
+  getSupportedLanguagesForProvider,
+} from './languages'
+
+describe('languages', () => {
+  it('gets language names and native names', () => {
+    expect(getLanguageName('en')).toBe('English')
+    expect(getLanguageNativeName('es')).toBe('Español')
+    expect(getLanguageName('xx')).toBe('xx')
+  })
+
+  it('validates ISO codes', () => {
+    expect(isValidLanguageCode('auto')).toBe(true)
+    expect(isValidLanguageCode('en')).toBe(true)
+    expect(isValidLanguageCode('xx')).toBe(false)
+  })
+
+  it('validates language per provider', () => {
+    expect(isValidLanguageForProvider('en', 'openai')).toBe(true)
+    expect(isValidLanguageForProvider('en', 'groq')).toBe(true)
+    expect(isValidLanguageForProvider('xx', 'openai')).toBe(false)
+    expect(isValidLanguageForProvider('xx', 'unknown')).toBe(false)
+  })
+
+  it('returns API language code or undefined and warns when unsupported by provider', () => {
+    expect(getApiLanguageCode('auto')).toBeUndefined()
+    expect(getApiLanguageCode('en')).toBe('en')
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(getApiLanguageCode('xx', 'openai')).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('lists supported languages for provider including auto', () => {
+    const openaiLangs = getSupportedLanguagesForProvider('openai')
+    const groqLangs = getSupportedLanguagesForProvider('groq')
+
+    // Must include auto
+    expect(openaiLangs.find(l => l.code === 'auto')).toBeTruthy()
+    expect(groqLangs.find(l => l.code === 'auto')).toBeTruthy()
+
+    // Should include each provider's supported codes
+    for (const code of OPENAI_WHISPER_SUPPORTED_LANGUAGES) {
+      expect(openaiLangs.find(l => l.code === code)).toBeTruthy()
+    }
+    for (const code of GROQ_WHISPER_SUPPORTED_LANGUAGES) {
+      expect(groqLangs.find(l => l.code === code)).toBeTruthy()
+    }
+
+    // Unknown provider falls back to full list
+    const unknown = getSupportedLanguagesForProvider('unknown')
+    expect(unknown.length).toBe(SUPPORTED_LANGUAGES.length)
+  })
+})
+

--- a/src/shared/oauth-examples.test.ts
+++ b/src/shared/oauth-examples.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { getOAuthExample, getOAuthExampleKeys, OAUTH_MCP_EXAMPLES } from './oauth-examples'
+
+describe('oauth-examples', () => {
+  it('returns known example by key', () => {
+    const ex = getOAuthExample('notion')
+    expect(ex).toBeTruthy()
+    expect(ex?.name).toBe('Notion')
+    expect(ex?.config.transport).toBe('streamableHttp')
+    expect(ex?.config.oauth?.useDiscovery).toBe(true)
+    expect(Array.isArray(ex?.setupInstructions)).toBe(true)
+    expect(ex?.setupInstructions.length).toBeGreaterThan(0)
+  })
+
+  it('returns undefined for unknown key', () => {
+    expect(getOAuthExample('missing')).toBeUndefined()
+  })
+
+  it('lists all example keys and includes notion', () => {
+    const keys = getOAuthExampleKeys()
+    expect(keys).toContain('notion')
+    // sanity: keys should match object keys
+    expect(keys.sort()).toEqual(Object.keys(OAUTH_MCP_EXAMPLES).sort())
+  })
+})
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,20 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text'],
+      include: [
+        'src/shared/**/*.ts',
+        'src/shared/**/*.tsx',
+        'src/main/panel-position.ts',
+        'src/renderer/src/lib/type-guards.ts',
+        'src/renderer/src/lib/fixes.ts',
+        'src/renderer/src/lib/final-fixes.ts',
+        'src/renderer/src/lib/utils.ts',
+      ],
+      exclude: ['**/*.d.ts', 'out/**', 'build/**', 'scripts/**'],
+    },
   },
 })
 


### PR DESCRIPTION
Summary
- Add unit tests for shared: key-utils, languages, oauth-examples
- Add unit tests for main: panel-position (with electron/config mocks)
- Add unit tests for renderer lib: utils, type-guards, fixes, final-fixes
- Vitest coverage: focus include on source we test; exclude build outputs; reporter set to text-only (no HTML)

Why
- Provide fast and meaningful test + coverage signal without noise from build artifacts/out
- Establish a testing foundation across shared, main (Electron-safe logic), and renderer helpers

Local results
- Tests: 9 files, 44 tests passed (0 failed)
- Coverage (focused set):
  - main/panel-position.ts ~78% lines; ~91% branches
  - renderer/src/lib/* 100% across functions
  - shared: shell-parse ~97.6%, key-utils ~99.2%, languages 100%, oauth-examples 100%

Notes
- shared/index.ts is a constants file and remains untested; can be excluded or lightly tested if desirable
- HTML coverage report is disabled per request; text-only output retained

Next
- Optionally expand coverage in src/main and selected src/renderer modules
- Optionally adjust key display mapping to show “Space” and “/” instead of “SPACE” and “SLASH” and update tests accordingly


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author