### PR TITLE
Fix: Register speakmcp:// protocol for Windows NSIS installer

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -5,6 +5,10 @@ module.exports = {
   appId: "app.speakmcp",
   productName: "SpeakMCP",
   icon: "build/icon.png",
+  protocols: {
+    name: "SpeakMCP Protocol",
+    schemes: ["speakmcp"],
+  },
   directories: {
     buildResources: "build",
   },


### PR DESCRIPTION
## Description

This PR fixes the OAuth functionality that was broken in build 0.2.2 by properly registering the `speakmcp://` custom URL protocol scheme for Windows NSIS installers.

## Problem

The OAuth flow in production builds was failing because the custom URL protocol (`speakmcp://oauth/callback`) was not being registered during installation on Windows. While the protocol was configured for macOS in the `CFBundleURLTypes`, it was missing from the Windows installer configuration.

## Solution

Added the `protocols` configuration to `electron-builder.config.cjs` at the top level, which ensures that:
- The `speakmcp://` protocol is registered during NSIS installation on Windows
- OAuth callbacks can be properly handled via deep links in production builds
- The protocol registration works consistently across all platforms (Windows, macOS, Linux)

## Changes

- Added `protocols` configuration to `electron-builder.config.cjs`:
  ```javascript
  protocols: {
    name: "SpeakMCP Protocol",
    schemes: ["speakmcp"],
  },
  ```

## Testing

This fix requires testing with a production build:
1. Build the Windows installer with the updated configuration
2. Install the application
3. Verify that the `speakmcp://` protocol is registered in Windows
4. Test OAuth flow with an MCP server that requires OAuth authentication
5. Confirm that the OAuth callback is properly handled

## Related Issues

Fixes #215

## Additional Context

The OAuth implementation uses different callback mechanisms for development and production:
- **Development**: `http://localhost:3000/callback` (HTTP server)
- **Production**: `speakmcp://oauth/callback` (Deep link)

This fix ensures the production deep link mechanism works correctly on Windows by registering the protocol during installation.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author