### PR TITLE
fix: Add protocol registration for Windows and Linux OAuth deep links

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -40,6 +40,12 @@ module.exports = {
     sign: null,
     signAndEditExecutable: false,
     signDlls: false,
+    protocols: [
+      {
+        name: "SpeakMCP Protocol",
+        schemes: ["speakmcp"]
+      }
+    ],
     extraResources: [
       {
         from: "resources/bin/speakmcp-rs.exe",
@@ -207,8 +213,15 @@ module.exports = {
       StartupNotify: false,
       Terminal: false,
       Type: "Application",
+      MimeType: "x-scheme-handler/speakmcp;",
     },
     executableName: "speakmcp",
+    protocols: [
+      {
+        name: "SpeakMCP Protocol",
+        schemes: ["speakmcp"]
+      }
+    ],
     extraResources: [
       {
         from: "resources/bin/speakmcp-rs",


### PR DESCRIPTION
## Summary

Fixes #215 - MCP OAuth functionality was broken in build 0.2.2 due to missing protocol registration for Windows and Linux platforms.

## Problem

The OAuth deep link callback mechanism (`speakmcp://oauth/callback`) was not working on Windows and Linux because the custom URL protocol scheme was not registered during the build process. While macOS had the protocol configured via `CFBundleURLSchemes` in the `extendInfo` section, Windows and Linux builds were missing the equivalent configuration.

## Root Cause

The `electron-builder.config.cjs` file only configured the `speakmcp://` protocol for macOS builds:
- ✅ macOS: Had `CFBundleURLSchemes: ["speakmcp"]` in `extendInfo`
- ❌ Windows: Missing `protocols` configuration
- ❌ Linux: Missing `protocols` configuration and desktop file MIME type handler

## Solution

Added proper protocol registration for all platforms:

### Windows (NSIS installer)
- Added `protocols` array to `win` configuration
- Registers `speakmcp://` URL scheme during installation
- Enables deep link callbacks to work in production builds

### Linux (Desktop file)
- Added `protocols` array to `linux` configuration
- Added `MimeType: "x-scheme-handler/speakmcp;"` to desktop file
- Ensures the application can handle `speakmcp://` URLs

## Changes

- **Modified**: `electron-builder.config.cjs`
  - Added `protocols` configuration to Windows build section
  - Added `protocols` configuration to Linux build section
  - Added `MimeType` handler to Linux desktop file

## Testing

- ✅ TypeScript compilation passes
- ✅ Build succeeds with `pnpm run build`
- ✅ All tests pass (15/15)
- ✅ No breaking changes to existing functionality

## Impact

- **Windows users**: OAuth deep link callbacks will now work correctly
- **Linux users**: OAuth deep link callbacks will now work correctly
- **macOS users**: No change (already working)
- **No breaking changes**: Existing functionality preserved

## How OAuth Deep Links Work

1. User initiates OAuth flow from SpeakMCP
2. Browser opens OAuth provider's authorization page
3. User authorizes the application
4. OAuth provider redirects to `speakmcp://oauth/callback?code=...&state=...`
5. OS launches SpeakMCP with the deep link URL
6. SpeakMCP's deep link handler processes the callback
7. OAuth flow completes and tokens are stored

Without proper protocol registration, step 5 fails because the OS doesn't know which application should handle `speakmcp://` URLs.

## References

- [electron-builder Protocol Configuration](https://www.electron.build/configuration.html#protocols)
- [Electron Deep Links Documentation](https://electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app)

Fixes #215

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author