### PR TITLE
Fix: Show voice input waveform when agent is running

### DIFF
--- a/src/renderer/src/pages/panel.tsx
+++ b/src/renderer/src/pages/panel.tsx
@@ -537,10 +537,10 @@ export function Component() {
             }
             agentProgress={agentProgress}
           />
-        ) : transcribeMutation.isPending ||
+        ) : (transcribeMutation.isPending ||
           mcpTranscribeMutation.isPending ||
           textInputMutation.isPending ||
-          mcpTextInputMutation.isPending ? (
+          mcpTextInputMutation.isPending) && !recording ? (
           <AgentProcessingView
             agentProgress={agentProgress}
             isProcessing={true}
@@ -595,7 +595,7 @@ export function Component() {
               {/* Waveform visualization - full width with centered content, dimmed when agent progress is showing */}
               <div
                 className={cn(
-                  "absolute inset-x-0 flex h-6 items-center justify-center transition-opacity duration-300 px-4",
+                  "absolute inset-x-0 flex h-6 items-center justify-center transition-opacity duration-300 px-4 z-30 pointer-events-none",
                   agentProgress && !mcpTranscribeMutation.isPending
                     ? "opacity-30"
                     : "opacity-100",


### PR DESCRIPTION
This fixes #240.

Changes:
- Prioritize recording state so the voice input panel (and waveform) renders even when mutations are pending from an active agent
- Ensure the waveform is visible by layering it above the agent progress overlay (`z-30`) and making it non-interactive

Verification:
- Type checks pass (`npm run typecheck`)
- Unit tests pass (`npm run test:run`)

Behavior:
- When an agent is running and the user starts voice input, the mic waveform is now visible during recording.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author