### PR TITLE
fix: remove unused optimisticSnoozeState in active-agents-sidebar

### DIFF
--- a/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/src/renderer/src/components/active-agents-sidebar.tsx
@@ -38,9 +38,6 @@ export function ActiveAgentsSidebar() {
 
   const { focusedSessionId, setFocusedSessionId } = useConversation()
 
-  // Track optimistic snooze state updates (sessionId -> isSnoozed)
-  const [optimisticSnoozeState, setOptimisticSnoozeState] = useState<Map<string, boolean>>(new Map())
-
   const { data } = useQuery<AgentSessionsResponse>({
     queryKey: ["agentSessions"],
     queryFn: async () => {


### PR DESCRIPTION
## Summary

Removes the unused `optimisticSnoozeState` state variable from the `ActiveAgentsSidebar` component.

## Problem

The `optimisticSnoozeState` state was declared but never used anywhere in the component, causing:
- Potential linter warnings
- Code confusion for developers
- Unnecessary state management overhead

## Solution

Removed the unused state declaration:
```typescript
const [optimisticSnoozeState, setOptimisticSnoozeState] = useState<Map<string, boolean>>(new Map())
```

## Changes

- **Modified `src/renderer/src/components/active-agents-sidebar.tsx`**:
  - Removed unused `optimisticSnoozeState` state declaration
  - Removed associated comment

## Testing

- ✅ All tests pass (15/15)
- ✅ TypeScript compilation successful
- ✅ No breaking changes
- ✅ Component functionality unchanged

## Impact

- Cleaner code with no unused variables
- Eliminates potential linter warnings
- Reduces confusion for future developers
- No functional changes to the component

Fixes #268

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author