### PR TITLE
fix: Remove thinking blocks from TTS output

### DIFF
--- a/src/main/tts-preprocessing.test.ts
+++ b/src/main/tts-preprocessing.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { preprocessTextForTTS, validateTTSText } from './tts-preprocessing'
+
+describe('TTS Preprocessing - Thinking Blocks', () => {
+  it('should remove simple thinking blocks', () => {
+    const input = 'Here is my answer. <think>This is my reasoning process.</think> The final answer is 42.'
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: true,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    expect(result).not.toContain('<think>')
+    expect(result).not.toContain('</think>')
+    expect(result).not.toContain('This is my reasoning process')
+    expect(result).toContain('Here is my answer')
+    expect(result).toContain('The final answer is 42')
+  })
+
+  it('should remove multiline thinking blocks', () => {
+    const input = `Let me help you with that.
+<think>
+First, I need to analyze the problem.
+Then I'll break it down into steps.
+Finally, I'll provide the solution.
+</think>
+The solution is to use the preprocessTextForTTS function.`
+    
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: true,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    
+    expect(result).not.toContain('<think>')
+    expect(result).not.toContain('</think>')
+    expect(result).not.toContain('analyze the problem')
+    expect(result).toContain('Let me help you with that')
+    expect(result).toContain('The solution is to use the preprocessTextForTTS function')
+  })
+
+  it('should remove multiple thinking blocks', () => {
+    const input = 'First part. <think>Reasoning 1</think> Middle part. <think>Reasoning 2</think> Last part.'
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: true,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    
+    expect(result).not.toContain('Reasoning 1')
+    expect(result).not.toContain('Reasoning 2')
+    expect(result).toContain('First part')
+    expect(result).toContain('Middle part')
+    expect(result).toContain('Last part')
+  })
+
+  it('should handle case-insensitive thinking tags', () => {
+    const input = 'Answer here. <THINK>Reasoning</THINK> More answer. <Think>More reasoning</Think> Final.'
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: true,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    
+    expect(result).not.toContain('Reasoning')
+    expect(result).not.toContain('More reasoning')
+    expect(result).toContain('Answer here')
+    expect(result).toContain('More answer')
+    expect(result).toContain('Final')
+  })
+
+  it('should not remove thinking blocks when option is disabled', () => {
+    const input = 'Text with <think>reasoning</think> included.'
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: false,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    
+    expect(result).toContain('reasoning')
+  })
+
+  it('should handle text without thinking blocks', () => {
+    const input = 'This is just regular text without any thinking blocks.'
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: true,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    
+    expect(result).toContain('This is just regular text without any thinking blocks')
+  })
+
+  it('should remove thinking blocks with default options', () => {
+    const input = 'Answer. <think>Internal reasoning.</think> Final answer.'
+    const result = preprocessTextForTTS(input)
+    
+    expect(result).not.toContain('Internal reasoning')
+    expect(result).toContain('Answer')
+    expect(result).toContain('Final answer')
+  })
+
+  it('should handle nested or malformed tags gracefully', () => {
+    const input = 'Text <think>reasoning <think>nested</think> more</think> end.'
+    const result = preprocessTextForTTS(input, { 
+      removeThinkingBlocks: true,
+      removeCodeBlocks: false,
+      removeUrls: false,
+      convertMarkdown: false,
+      removeSymbols: false,
+      convertNumbers: false
+    })
+    
+    // The regex should remove the first <think>...</think> pair it finds
+    expect(result).not.toContain('reasoning')
+  })
+})
+
+describe('TTS Preprocessing - Integration', () => {
+  it('should remove thinking blocks before other processing', () => {
+    const input = 'Here is **bold text**. <think>This has `code` inside.</think> Final answer with https://example.com link.'
+    const result = preprocessTextForTTS(input)
+    
+    // Thinking block should be removed
+    expect(result).not.toContain('This has')
+    expect(result).not.toContain('code')
+    
+    // Other processing should still work
+    expect(result).toContain('bold text')
+    expect(result).not.toContain('**')
+    expect(result).not.toContain('https://')
+  })
+})
+

--- a/src/main/tts-preprocessing.ts
+++ b/src/main/tts-preprocessing.ts
@@ -10,6 +10,7 @@ export interface TTSPreprocessingOptions {
   removeSymbols?: boolean
   convertNumbers?: boolean
   maxLength?: number
+  removeThinkingBlocks?: boolean
 }
 
 const DEFAULT_OPTIONS: TTSPreprocessingOptions = {
@@ -19,6 +20,7 @@ const DEFAULT_OPTIONS: TTSPreprocessingOptions = {
   removeSymbols: true,
   convertNumbers: true,
   maxLength: 4000, // Reasonable limit for TTS
+  removeThinkingBlocks: true,
 }
 
 /**
@@ -30,6 +32,12 @@ export function preprocessTextForTTS(
 ): string {
   const opts = { ...DEFAULT_OPTIONS, ...options }
   let processedText = text
+
+  // Remove thinking blocks first (before other processing)
+  // This ensures <think>...</think> content is not read aloud
+  if (opts.removeThinkingBlocks) {
+    processedText = removeThinkingBlocks(processedText)
+  }
 
   // Remove or replace code blocks
   if (opts.removeCodeBlocks) {
@@ -65,6 +73,18 @@ export function preprocessTextForTTS(
   }
 
   return processedText
+}
+
+/**
+ * Removes thinking blocks (<think>...</think>) from text
+ * These blocks contain the AI's reasoning process and should not be read aloud
+ */
+function removeThinkingBlocks(text: string): string {
+  // Remove <think>...</think> blocks (including multiline)
+  // This regex matches the opening tag, any content (including newlines), and the closing tag
+  text = text.replace(/<think>[\s\S]*?<\/think>/gi, "")
+
+  return text
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #246 - TTS now skips thinking blocks and only reads final answers.

## Problem

Previously, when TTS was enabled, it would read both the AI's thinking process (contained in `<think>...</think>` tags) and the final answer. This made the audio output verbose and confusing, as users would hear the internal reasoning process that was meant to be hidden.

## Solution

Added a `removeThinkingBlocks` function to the TTS preprocessing pipeline that:
- Removes all `<think>...</think>` tags and their content before other text processing
- Works with single-line and multiline thinking blocks
- Handles case-insensitive tags (`<think>`, `<THINK>`, `<Think>`)
- Supports multiple thinking blocks in the same text

## Changes Made

### `src/main/tts-preprocessing.ts`

1. **Added `removeThinkingBlocks` option** to `TTSPreprocessingOptions` interface
2. **Added `removeThinkingBlocks: true`** to default options
3. **Created `removeThinkingBlocks()` function** that uses regex to remove `<think>...</think>` blocks
4. **Updated `preprocessTextForTTS()`** to call `removeThinkingBlocks()` first, before other preprocessing

### `src/main/tts-preprocessing.test.ts` (New File)

- Comprehensive test suite with 9 test cases covering:
  - Simple thinking block removal
  - Multiline thinking blocks
  - Multiple thinking blocks
  - Case-insensitive tags
  - Option toggling
  - Text without thinking blocks
  - Default options behavior
  - Nested/malformed tags
  - Integration with other preprocessing

## Testing

- ✅ All 24 tests pass (9 new tests + 15 existing)
- ✅ TypeScript compilation passes with no errors
- ✅ Thinking blocks are properly removed from TTS text
- ✅ Other preprocessing features continue to work correctly

## Benefits

- **Better UX**: Users only hear the final answer, not the reasoning process
- **Cleaner audio**: TTS output is more concise and focused
- **Configurable**: Can be disabled if needed via `removeThinkingBlocks: false`
- **Well-tested**: Comprehensive test coverage ensures reliability
- **Backward compatible**: Enabled by default but can be toggled

## Example

**Before:**
```
Input: "Here's the answer. <think>Let me analyze this step by step...</think> The result is 42."
TTS reads: "Here's the answer. Let me analyze this step by step... The result is 42."
```

**After:**
```
Input: "Here's the answer. <think>Let me analyze this step by step...</think> The result is 42."
TTS reads: "Here's the answer. The result is 42."
```

---

Closes #246

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author