### PR TITLE
Fix #283: Hide button doesn't work on tool execution expanded view

### DIFF
--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -357,6 +357,22 @@ const ToolExecutionBubble: React.FC<{
     onToggleExpand()
   }
 
+  // Handle hide/show buttons with event propagation stopped
+  const handleToggleInputs = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setShowInputs((v) => !v)
+  }
+
+  const handleToggleOutputs = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setShowOutputs((v) => !v)
+  }
+
+  const handleCopy = (e: React.MouseEvent, text: string) => {
+    e.stopPropagation()
+    copy(text)
+  }
+
 
   return (
     <div
@@ -403,10 +419,10 @@ const ToolExecutionBubble: React.FC<{
             <div className="flex items-center justify-between">
               <div className="text-[11px] font-semibold opacity-80">Call Parameters</div>
               <div className="flex items-center gap-1">
-                <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => setShowInputs((v) => !v)}>
+                <Button size="sm" variant="ghost" className="h-6 px-2" onClick={handleToggleInputs}>
                   {showInputs ? "Hide" : "Show"}
                 </Button>
-                <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => copy(JSON.stringify(execution.calls, null, 2))}>
+                <Button size="sm" variant="ghost" className="h-6 px-2" onClick={(e) => handleCopy(e, JSON.stringify(execution.calls, null, 2))}>
                   Copy
                 </Button>
               </div>
@@ -435,10 +451,10 @@ const ToolExecutionBubble: React.FC<{
               <div className="text-[11px] font-semibold opacity-80">Response</div>
               {!isPending && (
                 <div className="flex items-center gap-1">
-                  <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => setShowOutputs((v) => !v)}>
+                  <Button size="sm" variant="ghost" className="h-6 px-2" onClick={handleToggleOutputs}>
                     {showOutputs ? "Hide" : "Show"}
                   </Button>
-                  <Button size="sm" variant="ghost" className="h-6 px-2" onClick={() => copy(JSON.stringify(execution.results, null, 2))}>
+                  <Button size="sm" variant="ghost" className="h-6 px-2" onClick={(e) => handleCopy(e, JSON.stringify(execution.results, null, 2))}>
                     Copy
                   </Button>
                 </div>


### PR DESCRIPTION
## Summary

Fixes #283 - The hide button in the tool execution expanded view was not functioning properly.

## Problem

When clicking the "Hide" or "Show" buttons in the expanded tool execution view (for Call Parameters or Response sections), the click event was bubbling up to the parent div, which has an `onClick` handler to toggle the entire tool execution expansion. This caused the tool execution to collapse/expand instead of just hiding/showing the specific section.

## Root Cause

The buttons were using inline arrow functions without stopping event propagation:
```tsx
<Button onClick={() => setShowInputs((v) => !v)}>
  {showInputs ? "Hide" : "Show"}
</Button>
```

The parent div has a click handler:
```tsx
<div onClick={handleToggleExpand}>
  {/* buttons are inside here */}
</div>
```

Without `e.stopPropagation()`, the button clicks bubble up to the parent div.

## Solution

Added dedicated event handlers that stop propagation:

```tsx
const handleToggleInputs = (e: React.MouseEvent) => {
  e.stopPropagation()
  setShowInputs((v) => !v)
}

const handleToggleOutputs = (e: React.MouseEvent) => {
  e.stopPropagation()
  setShowOutputs((v) => !v)
}

const handleCopy = (e: React.MouseEvent, text: string) => {
  e.stopPropagation()
  copy(text)
}
```

Updated all buttons to use these handlers:
- Hide/Show button for Call Parameters
- Hide/Show button for Response
- Copy buttons (for consistency)

## Changes

- Modified `src/renderer/src/components/agent-progress.tsx`
  - Added `handleToggleInputs`, `handleToggleOutputs`, and `handleCopy` event handlers
  - Updated button onClick handlers to use the new functions
  - All handlers call `e.stopPropagation()` to prevent event bubbling

## Testing

- ✅ TypeScript compilation passes
- ✅ All tests pass (24/24)
- ✅ Build completes successfully
- ✅ No new diagnostics or errors

## Impact

- **Fixes the bug**: Hide/Show buttons now work correctly
- **No breaking changes**: Existing functionality preserved
- **Improved UX**: Users can now properly hide/show tool execution details
- **Consistent behavior**: Copy buttons also stop propagation for consistency

## Before

Clicking "Hide" would collapse the entire tool execution instead of hiding the section.

## After

Clicking "Hide" properly hides just the Call Parameters or Response section while keeping the tool execution expanded.

Fixes #283

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author