### PR TITLE
chore: remove unused executedToolsThisIteration variable

### DIFF
--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -776,8 +776,6 @@ Return ONLY JSON per schema.`,
   let finalContent = ""
   let noOpCount = 0 // Track iterations without meaningful progress
 
-  let executedToolsThisIteration = false // Whether any tools were executed in the current iteration
-
   let verificationFailCount = 0 // Count consecutive verification failures to avoid loops
 
   while (iteration < maxIterations) {
@@ -1091,8 +1089,6 @@ Always use actual resource IDs from the conversation history or create new ones 
       }
       logTools("Planned tool calls from LLM", toolCallsArray)
     }
-    // Track whether tools are planned this iteration
-    executedToolsThisIteration = toolCallsArray.length > 0
     const hasToolCalls = toolCallsArray.length > 0
     const explicitlyComplete = llmResponse.needsMoreWork === false
 


### PR DESCRIPTION
## Summary

Removes the unused `executedToolsThisIteration` variable from `src/main/llm.ts`.

## Background

This was discovered during a deep inspection of PR #313, which fixed a structural issue where this variable's assignment was incorrectly placed inside an `if (isDebugTools())` block. While the fix was valid, the variable itself was **never read anywhere** in the codebase - it was dead code.

## Changes

- Removed variable declaration at line 779
- Removed assignment at line 1095
- Net: **4 lines deleted**

## Before
```typescript
let executedToolsThisIteration = false // declared but never read
...
executedToolsThisIteration = toolCallsArray.length > 0 // assigned but never read
const hasToolCalls = toolCallsArray.length > 0 // this is what's actually used
```

## After
```typescript
const hasToolCalls = toolCallsArray.length > 0 // just use this directly
```

## Testing

- ✅ TypeScript typecheck passes
- ✅ All 24 tests pass
- ✅ No references to the variable remain in codebase

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author