### PR TITLE
fix: Wire up delete all button in history settings to confirmation dialog

### DIFF
--- a/src/renderer/src/pages/history.tsx
+++ b/src/renderer/src/pages/history.tsx
@@ -14,9 +14,9 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@renderer/components/ui/dialog"
 import {
   MessageCircle,
@@ -148,19 +148,12 @@ export function Component() {
   }
 
   const handleDeleteAllHistory = async () => {
-    if (
-      !window.confirm(
-        "Are you sure you want to delete all history? This action cannot be undone.",
-      )
-    ) {
-      return
-    }
-
     try {
       await deleteAllHistoryMutation.mutateAsync()
       toast.success("All history deleted")
       setSelectedHistoryItem(null)
       setViewMode("list")
+      setShowDeleteAllDialog(false)
     } catch (error) {
       toast.error("Failed to delete history")
     }
@@ -396,6 +389,33 @@ export function Component() {
           </div>
         </>
       )}
+
+      {/* Delete All Confirmation Dialog */}
+      <Dialog open={showDeleteAllDialog} onOpenChange={setShowDeleteAllDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete All History</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete all history? This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteAllDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteAllHistory}
+              disabled={deleteAllHistoryMutation.isPending}
+            >
+              {deleteAllHistoryMutation.isPending ? "Deleting..." : "Delete All"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #295 - The "Delete All" button in history settings was not working because clicking it set a state variable but there was no Dialog component that used this state to show a confirmation and trigger the deletion.

## Problem

The Delete All button in the history settings page was:
1. Setting `showDeleteAllDialog` state to `true` on click
2. But there was no `<Dialog>` component that used this state
3. The `handleDeleteAllHistory` function was defined but never called

## Solution

- Added a `Dialog` component with `open={showDeleteAllDialog}` and `onOpenChange={setShowDeleteAllDialog}` to properly show the confirmation dialog
- Updated `handleDeleteAllHistory` to:
  - Remove the redundant `window.confirm` call (since the Dialog now handles confirmation)
  - Close the dialog after successful deletion with `setShowDeleteAllDialog(false)`
- Added `DialogFooter` import for proper dialog button layout
- Dialog shows "Cancel" and "Delete All" buttons with proper styling and loading state

## Testing

- ✅ TypeScript compilation passes (`npm run typecheck`)
- ✅ All 24 tests pass (`npm run test:run`)

## Changes

- Modified `src/renderer/src/pages/history.tsx`
  - Updated imports to include `DialogFooter`
  - Simplified `handleDeleteAllHistory` by removing `window.confirm` and adding dialog close
  - Added `Dialog` component with confirmation UI

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author