### PR TITLE
feat: Add headless-terminal as MCP server example

### DIFF
--- a/src/renderer/src/components/mcp-config-manager.tsx
+++ b/src/renderer/src/components/mcp-config-manager.tsx
@@ -658,6 +658,15 @@ const MCP_EXAMPLES: Record<string, { name: string; config: MCPServerConfig }> = 
       env: {},
     },
   },
+  "headless-terminal": {
+    name: "headless-terminal",
+    config: {
+      transport: "stdio" as MCPTransportType,
+      command: "ht-mcp",
+      args: [],
+      env: {},
+    },
+  },
 }
 
 export function MCPConfigManager({


### PR DESCRIPTION
## Summary

Adds `ht-mcp` (headless terminal) to the list of standard MCP server examples in the MCP configuration UI.

## Problem

Users wanted an example for the headless terminal MCP server to help them understand how to configure it.

## Solution

Added `headless-terminal` as a new entry in the `MCP_EXAMPLES` constant in `mcp-config-manager.tsx`. This example configures:
- **Name**: `headless-terminal`
- **Transport**: `stdio`
- **Command**: `ht-mcp`
- **Args**: `[]` (empty, as ht-mcp doesn't require arguments)

## About ht-mcp

[ht-mcp](https://github.com/memextech/ht-mcp) is a high-performance Rust implementation of an MCP server for headless terminal. It allows agentic coding tools to interact with terminal applications designed for human interaction (like vim, emacs, interactive CLI tools).

### Installation Options

Users can install ht-mcp via:
- **Homebrew**: `brew tap memextech/tap && brew install ht-mcp`
- **Cargo**: `cargo install ht-mcp`
- **Pre-built binaries**: Download from [releases](https://github.com/memextech/ht-mcp/releases)

## Testing

- ✅ TypeScript compilation passes (`npm run typecheck`)
- ✅ All 24 tests pass (`npm run test:run`)

## Changes

- Modified `src/renderer/src/components/mcp-config-manager.tsx`
  - Added `headless-terminal` to `MCP_EXAMPLES`

Fixes #296

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author