### PR TITLE
feat: Improve tool calling UX with hotkeys and better preview

### DIFF
--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -615,17 +615,25 @@ const ToolApprovalBubble: React.FC<{
       // Don't handle if already responding or if user is typing in an input
       if (isResponding) return
       const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+      // Ignore when focus is on interactive elements to preserve standard keyboard navigation
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'BUTTON' ||
+        target.tagName === 'A' ||
+        target.isContentEditable
+      ) {
         return
       }
 
+      // Use e.code for more consistent Space detection across browsers/platforms
       // Space to approve (without modifiers)
-      if (e.key === ' ' && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      if (e.code === 'Space' && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
         e.preventDefault()
         onApprove()
       }
       // Shift+Space to deny
-      else if (e.key === ' ' && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      else if (e.code === 'Space' && e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
         e.preventDefault()
         onDeny()
       }


### PR DESCRIPTION
## Summary

This PR improves the tool calling UX by adding keyboard shortcuts and better parameter previews in collapsed views, addressing issue #336.

## Changes

### 1. Hotkey Support for Tool Calls
- **Space** to approve a pending tool call
- **Escape** to deny a pending tool call
- Keyboard handlers are only active when a tool approval is pending
- Prevents conflicts with input fields (won't trigger when typing in text areas)

### 2. Better Preview in Collapsed View
- Tool execution bubbles now show key parameters in collapsed state
- Format: `key1: value1, key2: value2 (+N more)` for quick scanning
- Long values are truncated with ellipsis
- Arrays show item count, objects show `{...}`

### 3. Tool Approval UI Enhancements
- Arguments preview shown directly in the approval bubble (before needing to expand)
- Hotkey hints displayed on the Approve/Deny buttons:
  - Approve button shows `[Space]` badge
  - Deny button shows `[Esc]` badge

## Benefits
- Faster tool call review and approval workflow
- Better visibility into what tools are doing without expanding
- More keyboard-friendly interaction
- Reduced cognitive load when managing multiple tool calls

## Technical Details

### Helper function for argument preview
```typescript
const formatArgumentsPreview = (args: any): string => {
  // Takes first 3 key parameters
  // Truncates long strings to 30 chars
  // Shows array lengths and object indicators
}
```

### Keyboard event handling
The `ToolApprovalBubble` component now includes a `useEffect` hook that:
- Listens for `keydown` events on the document
- Ignores events when `isResponding` is true
- Ignores events from input/textarea elements
- Maps Space → approve, Escape → deny

## Testing

- ✅ TypeScript compilation passes
- ✅ Electron-vite build succeeds
- ⚠️ Unit tests couldn't run due to Node.js v25.2.1 compatibility issue with vitest (pre-existing issue)

## Screenshots

The changes are visible in the agent progress panel when a tool approval is pending.

Fixes #336

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author