### PR TITLE
fix: Expand final output summary in agent progress by default

### DIFF
--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -1261,7 +1261,12 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                   ? `approval-${(item.data as any).approvalId}`
                   : `exec-${(item as any).data?.id || (item as any).data?.timestamp}`)
 
-                const isExpanded = !!expandedItems[itemKey]
+                // Final assistant message should be expanded by default when agent is complete
+                // unless user has explicitly toggled it (itemKey exists in expandedItems)
+                const isFinalAssistantMessage = item.kind === "message" && index === lastAssistantDisplayIndex && isComplete
+                const isExpanded = itemKey in expandedItems
+                  ? expandedItems[itemKey]
+                  : isFinalAssistantMessage
 
                 if (item.kind === "message") {
                   return (


### PR DESCRIPTION
## Summary

This PR fixes issue #339 by expanding the final output summary in agent progress/completion by default to improve user experience and visibility of results.

## Changes

- Modified the expansion logic in `agent-progress.tsx` to automatically expand the final assistant message when the agent completes
- The change only affects the final output summary display state
- Users can still manually toggle the expansion state if they prefer it collapsed

## Technical Details

The fix identifies the final assistant message (at `lastAssistantDisplayIndex`) and sets it to expanded by default when `isComplete` is true. The expansion state is tracked in `expandedItems`, and if the user has explicitly toggled an item, that preference is preserved.

```typescript
// Final assistant message should be expanded by default when agent is complete
// unless user has explicitly toggled it (itemKey exists in expandedItems)
const isFinalAssistantMessage = item.kind === "message" && index === lastAssistantDisplayIndex && isComplete
const isExpanded = itemKey in expandedItems
  ? expandedItems[itemKey]
  : isFinalAssistantMessage
```

## Testing

- ✅ TypeScript compilation passes
- ✅ All 24 existing tests pass

Fixes #339

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author