### PR TITLE
fix: accept LLM responses with toolCalls but empty content

### DIFF
--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -1054,7 +1054,11 @@ Always use actual resource IDs from the conversation history or create new ones 
     }
 
     // Validate response is not null/empty
-    if (!llmResponse || !llmResponse.content) {
+    // A response is valid if it has either content OR toolCalls (tool-only responses have empty content)
+    const hasValidContent = llmResponse?.content && llmResponse.content.trim().length > 0
+    const hasValidToolCalls = llmResponse?.toolCalls && Array.isArray(llmResponse.toolCalls) && llmResponse.toolCalls.length > 0
+
+    if (!llmResponse || (!hasValidContent && !hasValidToolCalls)) {
       logLLM(`❌ LLM null/empty response on iteration ${iteration}`)
       logLLM("Response details:", {
         hasResponse: !!llmResponse,
@@ -1070,7 +1074,7 @@ Always use actual resource IDs from the conversation history or create new ones 
       diagnosticsService.logError("llm", "Null/empty LLM response in agent mode", {
         iteration,
         response: llmResponse,
-        message: "LLM response is null or has no content"
+        message: "LLM response has neither content nor toolCalls"
       })
       thinkingStep.status = "error"
       thinkingStep.description = "Invalid response. Retrying..."


### PR DESCRIPTION
## Problem

The LLM response validation in `src/main/llm.ts` was incorrectly treating responses with `toolCalls` but empty `content` as invalid. This caused an infinite retry loop when the LLM returned tool-only responses.

### Observed Behavior

From the debug logs, when the LLM returned a valid tool-calling response:

```json
{
  "toolCalls": [{"name": "github:list_issues", "arguments": {...}}],
  "content": "",
  "needsMoreWork": true
}
```

The system logged:
```
[DEBUG][LLM] ❌ LLM null/empty response on iteration 1
[DEBUG][LLM] ❌ LLM null/empty response on iteration 2
[DEBUG][LLM] ❌ LLM null/empty response on iteration 3
...
```

And kept retrying indefinitely without ever executing the requested tool.

## Root Cause

The validation condition was:
```typescript
if (!llmResponse || !llmResponse.content) {
```

This treats `content: ""` (empty string) as falsy and rejects the response, even though having `toolCalls` is a perfectly valid response format for tool-only operations.

## Solution

Changed the validation to accept responses that have **either** content **or** toolCalls:

```typescript
const hasValidContent = llmResponse?.content && llmResponse.content.trim().length > 0
const hasValidToolCalls = llmResponse?.toolCalls && Array.isArray(llmResponse.toolCalls) && llmResponse.toolCalls.length > 0

if (!llmResponse || (!hasValidContent && !hasValidToolCalls)) {
```

## Testing

- [x] TypeScript compilation passes
- [ ] Manual testing with tool-calling requests

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author