### PR TITLE
fix: remove unsupported minimum/maximum from verifier JSON schema

### DIFF
--- a/src/main/llm-fetch.ts
+++ b/src/main/llm-fetch.ts
@@ -60,6 +60,8 @@ const toolCallResponseSchema: OpenAI.ResponseFormatJSONSchema["json_schema"] = {
 }
 
 // JSON schema for completion verification
+// Note: 'minimum' and 'maximum' are NOT supported by OpenAI's strict structured outputs.
+// The constraint is documented in the description field instead.
 const verificationResponseSchema: OpenAI.ResponseFormatJSONSchema["json_schema"] = {
   name: "CompletionVerification",
   description: "Strict verifier to determine if the user's request has been fully satisfied.",
@@ -67,7 +69,7 @@ const verificationResponseSchema: OpenAI.ResponseFormatJSONSchema["json_schema"]
     type: "object",
     properties: {
       isComplete: { type: "boolean", description: "True only if the user's original request has been fully satisfied." },
-      confidence: { type: "number", minimum: 0, maximum: 1, description: "Confidence in the judgment (0-1)." },
+      confidence: { type: "number", description: "Confidence in the judgment, must be between 0 and 1 inclusive." },
       missingItems: { type: "array", items: { type: "string" }, description: "List of missing steps, outputs, or requirements, if any." },
       reason: { type: "string", description: "Brief explanation of the judgment." }
     },


### PR DESCRIPTION
## Problem

The verifier was not working properly because the `verificationResponseSchema` used `minimum` and `maximum` JSON Schema keywords that are **not supported by OpenAI's strict structured outputs**.

When OpenAI's API encounters these unsupported keywords with `strict: true`, it returns a schema validation error, causing the verifier to fail and return `isComplete: false` with "Verification failed" as the reason.

## Root Cause

The `confidence` field in the verifier schema was defined as:
```javascript
confidence: { type: "number", minimum: 0, maximum: 1, description: "..." }
```

OpenAI's structured outputs with `strict: true` do not support the following JSON Schema keywords:
- `minimum` / `maximum`
- `minItems` / `maxItems`
- `minLength` / `maxLength`
- `pattern`
- And several others

See: https://community.openai.com/t/new-function-calling-with-strict-has-a-problem-with-minimum-integer-type/903258

## Solution

- Removed the unsupported `minimum` and `maximum` keywords from the `confidence` field
- Added the constraint information to the `description` field instead (as recommended by OpenAI staff)
- Added a comment explaining this limitation for future maintainers

## Changes

**Before:**
```javascript
confidence: { type: "number", minimum: 0, maximum: 1, description: "Confidence in the judgment (0-1)." }
```

**After:**
```javascript
confidence: { type: "number", description: "Confidence in the judgment, must be between 0 and 1 inclusive." }
```

## Testing

- ✅ TypeScript compilation passes
- ✅ All 24 tests pass

## Impact

The verifier should now work correctly with OpenAI's structured outputs, allowing proper completion verification in agent mode.

Fixes #344

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author