### PR TITLE
feat: add welcome/tutorial screen as first tab after install

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -68,6 +68,9 @@ const getConfig = () => {
     // Theme preference defaults
     themePreference: "system",
 
+    // Welcome screen defaults
+    showWelcomeTab: true,
+
 	    // App behavior
 	    launchAtLogin: false,
 

--- a/src/renderer/src/components/app-layout.tsx
+++ b/src/renderer/src/components/app-layout.tsx
@@ -1,10 +1,11 @@
 import { rendererHandlers } from "@renderer/lib/tipc-client"
 import { cn } from "@renderer/lib/utils"
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { NavLink, Outlet, useNavigate, useLocation } from "react-router-dom"
 import { LoadingSpinner } from "@renderer/components/ui/loading-spinner"
 import { SettingsDragBar } from "@renderer/components/settings-drag-bar"
 import { ActiveAgentsSidebar } from "@renderer/components/active-agents-sidebar"
+import { useConfigQuery } from "@renderer/lib/query-client"
 
 type NavLink = {
   text: string
@@ -15,41 +16,55 @@ type NavLink = {
 export const Component = () => {
   const navigate = useNavigate()
   const location = useLocation()
+  const configQuery = useConfigQuery()
 
-  const navLinks: NavLink[] = [
-    {
-      text: "General",
-      href: "/settings",
-      icon: "i-mingcute-settings-3-line",
-    },
-    {
-      text: "History",
-      href: "/history",
-      icon: "i-mingcute-message-3-line",
-    },
-    {
-      text: "Models",
-      href: "/settings/models",
-      icon: "i-mingcute-brain-line",
-    },
+  const navLinks: NavLink[] = useMemo(() => {
+    const links: NavLink[] = []
 
-    {
-      text: "Agents",
-      href: "/settings/tools",
-      icon: "i-mingcute-android-2-line",
-    },
-    {
-      text: "MCP Tools",
-      href: "/settings/mcp-tools",
-      icon: "i-mingcute-tool-line",
-    },
-    {
-      text: "Remote Server",
-      href: "/settings/remote-server",
-      icon: "i-mingcute-server-line",
-    },
+    // Add Welcome tab first if enabled (defaults to true)
+    if (configQuery.data?.showWelcomeTab !== false) {
+      links.push({
+        text: "Welcome",
+        href: "/welcome",
+        icon: "i-mingcute-home-4-line",
+      })
+    }
 
-  ]
+    links.push(
+      {
+        text: "General",
+        href: "/settings",
+        icon: "i-mingcute-settings-3-line",
+      },
+      {
+        text: "History",
+        href: "/history",
+        icon: "i-mingcute-message-3-line",
+      },
+      {
+        text: "Models",
+        href: "/settings/models",
+        icon: "i-mingcute-brain-line",
+      },
+      {
+        text: "Agents",
+        href: "/settings/tools",
+        icon: "i-mingcute-android-2-line",
+      },
+      {
+        text: "MCP Tools",
+        href: "/settings/mcp-tools",
+        icon: "i-mingcute-tool-line",
+      },
+      {
+        text: "Remote Server",
+        href: "/settings/remote-server",
+        icon: "i-mingcute-server-line",
+      },
+    )
+
+    return links
+  }, [configQuery.data?.showWelcomeTab])
 
   useEffect(() => {
     return rendererHandlers.navigate.listen((url) => {

--- a/src/renderer/src/pages/settings-general.tsx
+++ b/src/renderer/src/pages/settings-general.tsx
@@ -134,6 +134,16 @@ export function Component() {
               }}
             />
           </Control>
+          <Control label="Show Welcome Tab" className="px-3">
+            <Switch
+              defaultChecked={configQuery.data.showWelcomeTab ?? true}
+              onCheckedChange={(value) => {
+                saveConfig({
+                  showWelcomeTab: value,
+                })
+              }}
+            />
+          </Control>
         </ControlGroup>
 
         <ControlGroup title="Appearance">

--- a/src/renderer/src/pages/settings-welcome.tsx
+++ b/src/renderer/src/pages/settings-welcome.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@renderer/components/ui/button"
+import {
+  useConfigQuery,
+  useSaveConfigMutation,
+} from "@renderer/lib/query-client"
+import { useCallback } from "react"
+import { Config } from "@shared/types"
+import { useNavigate } from "react-router-dom"
+
+export function Component() {
+  const configQuery = useConfigQuery()
+  const saveConfigMutation = useSaveConfigMutation()
+  const navigate = useNavigate()
+
+  const saveConfig = useCallback(
+    (config: Partial<Config>) => {
+      saveConfigMutation.mutate({
+        config: {
+          ...(configQuery.data as any),
+          ...config,
+        },
+      })
+    },
+    [saveConfigMutation, configQuery.data],
+  )
+
+  const handleGetStarted = () => {
+    navigate("/settings")
+  }
+
+  const handleHideWelcome = () => {
+    saveConfig({ showWelcomeTab: false })
+    navigate("/settings")
+  }
+
+  if (!configQuery.data) return null
+
+  return (
+    <div className="modern-panel h-full overflow-auto px-6 py-6">
+      <div className="max-w-2xl mx-auto space-y-8">
+        {/* Header */}
+        <div className="text-center space-y-3">
+          <div className="text-5xl mb-4">🎙️</div>
+          <h1 className="text-3xl font-bold">Welcome to SpeakMCP</h1>
+          <p className="text-muted-foreground text-lg">
+            Your AI-powered voice assistant with MCP tool integration
+          </p>
+        </div>
+
+        {/* Features Overview */}
+        <div className="grid gap-4">
+          <FeatureCard
+            icon="🗣️"
+            title="Voice Input"
+            description="Hold a hotkey to speak. Your voice is transcribed and sent to your AI model."
+          />
+          <FeatureCard
+            icon="🤖"
+            title="Agent Mode"
+            description="Let AI agents execute multi-step tasks using MCP tools like file operations, web browsing, and more."
+          />
+          <FeatureCard
+            icon="🔧"
+            title="MCP Tools"
+            description="Connect powerful tools via the Model Context Protocol. Browse files, control your desktop, and integrate with services."
+          />
+          <FeatureCard
+            icon="⌨️"
+            title="Text Input"
+            description="Prefer typing? Use the text input panel for quick interactions with your AI."
+          />
+        </div>
+
+        {/* Getting Started */}
+        <div className="rounded-lg border bg-card p-6 space-y-4">
+          <h2 className="text-xl font-semibold">Getting Started</h2>
+          <ol className="space-y-3 text-sm text-muted-foreground">
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-medium">1</span>
+              <span><strong className="text-foreground">Configure your API key</strong> — Go to Models to set up your OpenAI, Groq, or Gemini credentials.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-medium">2</span>
+              <span><strong className="text-foreground">Set up MCP tools</strong> — Visit MCP Tools to enable and configure available tools.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-medium">3</span>
+              <span><strong className="text-foreground">Try the hotkeys</strong> — Hold <kbd className="px-1.5 py-0.5 rounded bg-muted font-mono text-xs">Ctrl</kbd> to record voice, or <kbd className="px-1.5 py-0.5 rounded bg-muted font-mono text-xs">Ctrl+Alt</kbd> for agent mode.</span>
+            </li>
+          </ol>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Button size="lg" onClick={handleGetStarted}>
+            Get Started
+          </Button>
+          <Button size="lg" variant="outline" onClick={handleHideWelcome}>
+            Don't Show Again
+          </Button>
+        </div>
+
+        {/* Footer Note */}
+        <p className="text-center text-xs text-muted-foreground">
+          You can always access this page again from General Settings.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function FeatureCard({ icon, title, description }: { icon: string; title: string; description: string }) {
+  return (
+    <div className="rounded-lg border bg-card p-4 flex gap-4 items-start">
+      <span className="text-2xl">{icon}</span>
+      <div>
+        <h3 className="font-semibold">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  )
+}
+

--- a/src/renderer/src/router.tsx
+++ b/src/renderer/src/router.tsx
@@ -11,6 +11,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
           lazy: () => import("./pages/settings-general"),
         },
         {
+          path: "welcome",
+          lazy: () => import("./pages/settings-welcome"),
+        },
+        {
           path: "history",
           lazy: () => import("./pages/history"),
         },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -421,4 +421,7 @@ export type Config = {
   streamStatusWatcherEnabled?: boolean
   streamStatusFilePath?: string
 
+  // Welcome Screen Configuration
+  showWelcomeTab?: boolean
+
 }


### PR DESCRIPTION
## Summary

Adds a Welcome/Tutorial screen as the first tab in settings when users first install SpeakMCP.

## Features

- **Welcome Screen** with:
  - App introduction and emoji branding
  - Feature overview cards (Voice Input, Agent Mode, MCP Tools, Text Input)
  - Getting Started guide with numbered steps
  - "Get Started" and "Don't Show Again" buttons

- **Configuration Options**:
  - `showWelcomeTab` config option (defaults to `true`)
  - Toggle in General Settings to show/hide the welcome tab
  - Users can re-enable the welcome tab at any time

## Screenshots

The welcome screen displays:
- 🎙️ App logo/emoji
- Feature cards with icons
- Step-by-step getting started instructions
- Action buttons for navigation

## Changes

- `src/renderer/src/pages/settings-welcome.tsx` - New welcome page component
- `src/renderer/src/router.tsx` - Added `/welcome` route
- `src/renderer/src/components/app-layout.tsx` - Conditionally show Welcome tab first
- `src/renderer/src/pages/settings-general.tsx` - Added "Show Welcome Tab" toggle
- `src/main/config.ts` - Added `showWelcomeTab` default value
- `src/shared/types.ts` - Added `showWelcomeTab` to Config type

## Testing

- [x] TypeScript compilation passes
- [x] CDP debugging verified Welcome tab appears in navigation
- [x] Verified toggle appears in General Settings

Closes #343

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author