### PR TITLE
fix: JSON schema compatibility with Cerebras API and retry progress updates

### DIFF
--- a/src/main/llm-fetch.ts
+++ b/src/main/llm-fetch.ts
@@ -38,6 +38,7 @@ const toolCallResponseSchema: OpenAI.ResponseFormatJSONSchema["json_schema"] = {
             arguments: {
               type: "object",
               description: "Arguments to pass to the tool",
+              properties: {},
               additionalProperties: true,
             },
           },
@@ -686,7 +687,9 @@ async function makeAPICallAttempt(
                                       // Novita and other providers may return generic "model inference" errors
                                       // when they don't support structured output features
                                       (errorTextLower.includes("model inference") && errorTextLower.includes("error")) ||
-                                      errorTextLower.includes("unknown error in the model"))
+                                      errorTextLower.includes("unknown error in the model") ||
+                                      // Cerebras API returns this error when JSON schema format is incompatible
+                                      (errorTextLower.includes("object fields require") && errorTextLower.includes("properties")))
       if (isStructuredOutputError) {
         if (isDebugLLM()) {
           logLLM("🔴 Detected as structured output error")

--- a/src/main/llm.ts
+++ b/src/main/llm.ts
@@ -579,6 +579,8 @@ export async function processTranscriptWithAgentMode(
 
   // Create retry progress callback that emits updates to the UI
   // This callback is passed to makeLLMCall to show retry status
+  // Note: This callback captures conversationHistory and formatConversationForProgress by reference,
+  // so it will have access to them when called (they are defined later in this function)
   const onRetryProgress: RetryProgressCallback = (retryInfo) => {
     emit({
       currentIteration: currentIterationRef,
@@ -586,6 +588,10 @@ export async function processTranscriptWithAgentMode(
       steps: [], // Empty - retry info is separate from steps
       isComplete: false,
       retryInfo: retryInfo.isRetrying ? retryInfo : undefined,
+      // Include conversationHistory to avoid "length: 0" logs in emitAgentProgress
+      conversationHistory: typeof formatConversationForProgress === 'function' && conversationHistory
+        ? formatConversationForProgress(conversationHistory)
+        : [],
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes two bugs identified from analyzing debug logs:

### Bug 1: JSON Schema mode fails with Cerebras API

**Issue**: The Cerebras API returned a 422 error:
```
"Object fields require at least one of: 'properties' or 'anyOf' with a list of possible properties."
```

**Root cause**: The `arguments` object in `toolCallResponseSchema` had `type: "object"` with only `additionalProperties: true` but no `properties` field.

**Fix**: Added `properties: {}` to the `arguments` object definition and added detection for this specific Cerebras error message in the structured output error detection logic.

### Bug 2: onRetryProgress callback missing conversationHistory

**Issue**: The `onRetryProgress` callback emitted progress updates without `conversationHistory`, causing `conversationHistory length: 0` logs to appear repeatedly in the debug output.

**Fix**: Added `conversationHistory: formatConversationForProgress(conversationHistory)` to the emit call in the `onRetryProgress` callback.

## Testing

- ✅ All 32 tests pass
- ✅ Type checking passes

## Files Changed

- `src/main/llm-fetch.ts` - Added empty properties object to arguments schema, added Cerebras error detection
- `src/main/llm.ts` - Added conversationHistory to onRetryProgress callback

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author