### PR TITLE
feat: combine speech-to-text and transcript post-processing into single section

### DIFF
--- a/src/renderer/src/pages/settings-general.tsx
+++ b/src/renderer/src/pages/settings-general.tsx
@@ -405,7 +405,7 @@ export function Component() {
           </Control>
         </ControlGroup>
 
-        <ControlGroup title="Speech to Text">
+        <ControlGroup title="Speech-to-Text">
           <Control label={<ControlLabel label="Language" tooltip="Select the language for speech transcription. 'Auto-detect' lets the model determine the language automatically based on your speech." />} className="px-3">
             <Select
               value={configQuery.data.sttLanguage || "auto"}
@@ -490,6 +490,63 @@ export function Component() {
               />
             </Control>
           )}
+
+          <Control label={<ControlLabel label="Post-Processing" tooltip="Enable AI-powered post-processing to clean up and improve transcripts" />} className="px-3">
+            <Switch
+              defaultChecked={configQuery.data.transcriptPostProcessingEnabled}
+              onCheckedChange={(value) => {
+                saveConfig({
+                  transcriptPostProcessingEnabled: value,
+                })
+              }}
+            />
+          </Control>
+
+          {configQuery.data.transcriptPostProcessingEnabled && (
+            <Control label={<ControlLabel label="Post-Processing Prompt" tooltip="Custom prompt for transcript post-processing. Use {transcript} placeholder to insert the original transcript." />} className="px-3">
+              <div className="flex flex-col items-end gap-1 text-right">
+                {configQuery.data.transcriptPostProcessingPrompt && (
+                  <div className="line-clamp-3 text-sm text-neutral-500 dark:text-neutral-400">
+                    {configQuery.data.transcriptPostProcessingPrompt}
+                  </div>
+                )}
+                <Dialog>
+                  <DialogTrigger className="" asChild>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-6 gap-1 px-2"
+                    >
+                      <span className="i-mingcute-edit-2-line"></span>
+                      Edit
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Edit Post-Processing Prompt</DialogTitle>
+                    </DialogHeader>
+                    <Textarea
+                      rows={10}
+                      defaultValue={
+                        configQuery.data.transcriptPostProcessingPrompt
+                      }
+                      onChange={(e) => {
+                        saveConfig({
+                          transcriptPostProcessingPrompt:
+                            e.currentTarget.value,
+                        })
+                      }}
+                    ></Textarea>
+                    <div className="text-sm text-muted-foreground">
+                      Use{" "}
+                      <span className="select-text">{"{transcript}"}</span>{" "}
+                      placeholder to insert the original transcript
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              </div>
+            </Control>
+          )}
         </ControlGroup>
 
         <ControlGroup title="Text to Speech">
@@ -568,65 +625,6 @@ export function Component() {
               )}
             </>
           )}
-        </ControlGroup>
-
-        <ControlGroup title="Transcript Post-Processing">
-          <Control label="Enabled" className="px-3">
-            <Switch
-              defaultChecked={configQuery.data.transcriptPostProcessingEnabled}
-              onCheckedChange={(value) => {
-                saveConfig({
-                  transcriptPostProcessingEnabled: value,
-                })
-              }}
-            />
-          </Control>
-
-          {configQuery.data.transcriptPostProcessingEnabled && (
-              <Control label="Prompt" className="px-3">
-                <div className="flex flex-col items-end gap-1 text-right">
-                  {configQuery.data.transcriptPostProcessingPrompt && (
-                    <div className="line-clamp-3 text-sm text-neutral-500 dark:text-neutral-400">
-                      {configQuery.data.transcriptPostProcessingPrompt}
-                    </div>
-                  )}
-                  <Dialog>
-                    <DialogTrigger className="" asChild>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="h-6 gap-1 px-2"
-                      >
-                        <span className="i-mingcute-edit-2-line"></span>
-                        Edit
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>Edit Prompt</DialogTitle>
-                      </DialogHeader>
-                      <Textarea
-                        rows={10}
-                        defaultValue={
-                          configQuery.data.transcriptPostProcessingPrompt
-                        }
-                        onChange={(e) => {
-                          saveConfig({
-                            transcriptPostProcessingPrompt:
-                              e.currentTarget.value,
-                          })
-                        }}
-                      ></Textarea>
-                      <div className="text-sm text-muted-foreground">
-                        Use{" "}
-                        <span className="select-text">{"{transcript}"}</span>{" "}
-                        placeholder to insert the original transcript
-                      </div>
-                    </DialogContent>
-                  </Dialog>
-                </div>
-              </Control>
-            )}
         </ControlGroup>
 
         {/* Panel Position Settings */}


### PR DESCRIPTION
## Summary

Combines the speech-to-text and transcript post-processing features together under a single "Speech-to-Text" section in the UI, as described in issue #361.

## Changes

- Renamed 'Speech to Text' section to 'Speech-to-Text' (with hyphen for consistency)
- Moved transcript post-processing toggle into the Speech-to-Text section
- Updated Post-Processing label to use consistent `ControlLabel` pattern with tooltip
- Updated dialog title from 'Edit Prompt' to 'Edit Post-Processing Prompt' for clarity
- Removed the duplicate 'Transcript Post-Processing' ControlGroup

## UI Pattern

The Post-Processing toggle now follows the same pattern as other settings:
- Label on the left with tooltip ("Post-Processing")
- Enabled/Disabled toggle on the right
- When enabled, shows the prompt editor option below

## Before

- "Speech to Text" section (Language, Language Override, Prompt)
- "Transcript Post-Processing" section (Enabled, Prompt)

## After

- "Speech-to-Text" section (Language, Language Override, Prompt, Post-Processing, Post-Processing Prompt)

## Testing

- ✅ TypeScript compilation passes
- ✅ All 32 tests pass
- ✅ App runs successfully with UI debug mode

Closes #361

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author