### PR TITLE
fix: Maximize button for scrollable tiles creates blank floating panel

### DIFF
--- a/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/src/renderer/src/components/active-agents-sidebar.tsx
@@ -39,6 +39,7 @@ export function ActiveAgentsSidebar() {
 
   const focusedSessionId = useAgentStore((s) => s.focusedSessionId)
   const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
+  const setSessionSnoozed = useAgentStore((s) => s.setSessionSnoozed)
   const agentProgressById = useAgentStore((s) => s.agentProgressById)
   const navigate = useNavigate()
 
@@ -126,8 +127,10 @@ export function ActiveAgentsSidebar() {
         // Unsnoozing: restore the session to foreground
         logUI('[ActiveAgentsSidebar] Unsnoozing session')
 
-        // IMPORTANT: Focus the session FIRST before showing panel
-        // This ensures agentProgress is computed before the panel renders
+        // Update local store first so panel shows content immediately
+        setSessionSnoozed(sessionId, false)
+
+        // Focus the session
         setFocusedSessionId(sessionId)
 
         // Unsnooze the session in backend
@@ -146,6 +149,8 @@ export function ActiveAgentsSidebar() {
       } else {
         // Snoozing: move session to background
         logUI('[ActiveAgentsSidebar] Snoozing session')
+        // Update local store first
+        setSessionSnoozed(sessionId, true)
         await tipcClient.snoozeAgentSession({ sessionId })
         // Unfocus if this was the focused session
         if (focusedSessionId === sessionId) {

--- a/src/renderer/src/components/agent-progress.tsx
+++ b/src/renderer/src/components/agent-progress.tsx
@@ -871,6 +871,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   // Get current conversation ID for deep-linking and session focus control
   const currentConversationId = useConversationStore((s) => s.currentConversationId)
   const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
+  const setSessionSnoozed = useAgentStore((s) => s.setSessionSnoozed)
   const agentProgressById = useAgentStore((s) => s.agentProgressById)
 
   // Helper to toggle expansion state for a specific item
@@ -1404,7 +1405,9 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               <Button variant="ghost" size="icon" className="h-6 w-6" onClick={async (e) => {
                 e.stopPropagation()
                 if (!progress?.sessionId) return
-                // Focus this session in state first
+                // Update local store first so panel shows content immediately
+                setSessionSnoozed(progress.sessionId, false)
+                // Focus this session in state
                 setFocusedSessionId(progress.sessionId)
                 // Unsnooze the session in backend
                 await tipcClient.unsnoozeAgentSession({ sessionId: progress.sessionId })

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -22,6 +22,7 @@ interface AgentState {
   clearAllProgress: () => void
   clearSessionProgress: (sessionId: string) => void
   setFocusedSessionId: (sessionId: string | null) => void
+  setSessionSnoozed: (sessionId: string, isSnoozed: boolean) => void
   getAgentProgress: () => AgentProgressUpdate | null
 
   // View settings actions
@@ -125,6 +126,17 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   setFocusedSessionId: (sessionId: string | null) => {
     set({ focusedSessionId: sessionId })
+  },
+
+  setSessionSnoozed: (sessionId: string, isSnoozed: boolean) => {
+    set((state) => {
+      const existingProgress = state.agentProgressById.get(sessionId)
+      if (!existingProgress) return state
+
+      const newMap = new Map(state.agentProgressById)
+      newMap.set(sessionId, { ...existingProgress, isSnoozed })
+      return { agentProgressById: newMap }
+    })
   },
 
   getAgentProgress: () => {


### PR DESCRIPTION
## Summary

Fixes #367 - The maximize button for scrollable tiles was creating a blank floating panel.

## Problem

When clicking the maximize button on a snoozed session tile, the floating panel would appear blank. This happened because:

1. The maximize button called `unsnoozeAgentSession` to update the backend
2. The backend updated `isSnoozed = false` in the session tracker
3. But the panel's `agentProgressById` store still had the old progress with `isSnoozed: true`
4. The panel checks `!progress.isSnoozed` to determine visibility, so it showed blank

## Solution

Added a `setSessionSnoozed` method to the agent store that updates the `isSnoozed` flag for a specific session. This is called **before** showing the panel when unsnoozing, ensuring the panel's visibility check passes immediately.

## Changes

- **`src/renderer/src/stores/agent-store.ts`**: Added `setSessionSnoozed(sessionId, isSnoozed)` method
- **`src/renderer/src/components/agent-progress.tsx`**: Call `setSessionSnoozed(sessionId, false)` in maximize button handler
- **`src/renderer/src/components/active-agents-sidebar.tsx`**: Also update sidebar's `handleToggleSnooze` to use the same pattern for consistency

## Testing

1. Start an agent session
2. Minimize it (snooze)
3. Click the maximize button on the tile
4. The floating panel should now show the session content instead of being blank

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author