### PR TITLE
feat: expand settings dropdown by default

### DIFF
--- a/src/renderer/src/components/app-layout.tsx
+++ b/src/renderer/src/components/app-layout.tsx
@@ -15,10 +15,8 @@ type NavLinkItem = {
 export const Component = () => {
   const navigate = useNavigate()
   const location = useLocation()
-  const [settingsExpanded, setSettingsExpanded] = useState(() => {
-    // Auto-expand if currently on a settings page
-    return location.pathname.startsWith("/settings")
-  })
+  // Settings dropdown is expanded by default for better discoverability
+  const [settingsExpanded, setSettingsExpanded] = useState(true)
 
   // Primary navigation - always visible
   const primaryNavLinks: NavLinkItem[] = [
@@ -62,13 +60,6 @@ export const Component = () => {
       icon: "i-mingcute-server-line",
     },
   ]
-
-  // Auto-expand settings when navigating to a settings page
-  useEffect(() => {
-    if (location.pathname.startsWith("/settings")) {
-      setSettingsExpanded(true)
-    }
-  }, [location.pathname])
 
   useEffect(() => {
     return rendererHandlers.navigate.listen((url) => {


### PR DESCRIPTION
## Summary

Makes the settings dropdown in the sidebar expanded by default so users can immediately see and access all settings options without an extra click.

## Changes

- Changed `settingsExpanded` initial state from conditional (only on settings pages) to always `true`
- Removed redundant `useEffect` that auto-expanded settings when navigating to settings pages (no longer needed since it's always expanded)

## Before
- Settings dropdown was collapsed by default
- Users had to click to expand and see settings options

## After
- Settings dropdown is expanded by default
- Users can immediately see all settings options (General, Models, Agents, MCP Tools, Remote Server)
- Users can still collapse the dropdown if they prefer

## Testing

- ✅ TypeScript compilation passes (`pnpm typecheck`)
- ✅ All 32 tests pass (`pnpm test`)

Fixes #391

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author