### PR TITLE
fix: Prevent sessions view from overlapping macOS window controls

### DIFF
--- a/src/renderer/src/components/app-layout.tsx
+++ b/src/renderer/src/components/app-layout.tsx
@@ -103,8 +103,8 @@ export const Component = () => {
           {primaryNavLinks.map(renderNavLink)}
         </div>
 
-        {/* Active Agents Section */}
-        <div className="mt-4">
+        {/* Active Agents Section - with max-height and scroll to prevent overflow into macOS traffic lights */}
+        <div className="mt-4 max-h-[40vh] overflow-y-auto">
           <ActiveAgentsSidebar />
         </div>
 


### PR DESCRIPTION
## Summary

Fixes #404 - Sessions view overlaps macOS window controls when many agents active.

## Problem

When there are too many recent active agents, the sessions view gets pushed above the minimize and close buttons on macOS, making them hard to click.

## Solution

Added `max-h-[40vh] overflow-y-auto` to the Active Agents Section container in `app-layout.tsx`. This:

- Limits the maximum height of the Active Agents section to 40% of the viewport height
- Enables internal scrolling when the content exceeds this limit
- Prevents the section from pushing other elements or overlapping with macOS traffic light buttons (close/minimize/maximize)

## Testing

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (32 tests)
- [x] Manual testing with `pnpm dev d` - app launches successfully

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author