### PR TITLE
fix: reduce default tile width to fit two tiles side-by-side

### DIFF
--- a/src/renderer/src/hooks/use-resizable.ts
+++ b/src/renderer/src/hooks/use-resizable.ts
@@ -3,7 +3,7 @@ import { useState, useCallback, useRef } from "react"
 // Shared tile dimension constants
 export const TILE_DIMENSIONS = {
   width: {
-    default: 400,
+    default: 320,
     min: 200,
     max: 1200,
   },


### PR DESCRIPTION
## Summary

Reduces the default tile width in the session view so that two tiles can be visible side-by-side without horizontal scrolling.

## Problem

The session tiles were too wide (400px default) to fit two side-by-side in the default viewport, requiring users to scroll horizontally to see multiple sessions.

## Solution

Changed `TILE_DIMENSIONS.width.default` from 400px to 320px in `src/renderer/src/hooks/use-resizable.ts`.

With 16px gap (Tailwind `gap-4`) and 32px total padding, two 320px tiles now fit comfortably in ~688px, which is typical for the app window width.

## Changes

- **`src/renderer/src/hooks/use-resizable.ts`**: Changed default width from 400 to 320

## Testing

- ✅ Build passes (`pnpm dev d`)
- ✅ All 32 tests pass (`pnpm test`)
- ✅ Tiles now fit two side-by-side in the default viewport

## Notes

- Users can still resize tiles to any width between 200px-1200px (unchanged)
- Only the default/initial width is changed

Fixes #403

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author