### PR TITLE
fix: Stop logging entire conversation history

### DIFF
--- a/src/main/conversation-service.ts
+++ b/src/main/conversation-service.ts
@@ -142,25 +142,17 @@ export class ConversationService {
   async getConversationHistory(): Promise<ConversationHistoryItem[]> {
     try {
       const indexPath = this.getConversationIndexPath()
-      logApp("[ConversationService] getConversationHistory - indexPath:", indexPath)
 
       if (!fs.existsSync(indexPath)) {
-        logApp("[ConversationService] Index file does not exist, returning empty array")
         return []
       }
 
       const indexData = fs.readFileSync(indexPath, "utf8")
-      logApp("[ConversationService] Index file content length:", indexData.length)
 
       const history: ConversationHistoryItem[] = JSON.parse(indexData)
-      logApp("[ConversationService] Parsed history items:", history.length)
 
       // Sort by updatedAt descending (most recent first)
       const sorted = history.sort((a, b) => b.updatedAt - a.updatedAt)
-      logApp("[ConversationService] Returning sorted history:", {
-        count: sorted.length,
-        items: sorted.map(h => ({ id: h.id, title: h.title, messageCount: h.messageCount })),
-      })
       return sorted
     } catch (error) {
       logApp("[ConversationService] Error loading conversation history:", error)

--- a/src/main/emit-agent-progress.ts
+++ b/src/main/emit-agent-progress.ts
@@ -41,7 +41,6 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
   }
 
   logApp(`[emitAgentProgress] Called for session ${update.sessionId}, isSnoozed: ${update.isSnoozed}`)
-  logApp(`[emitAgentProgress] conversationHistory length: ${update.conversationHistory?.length || 0}, roles: [${update.conversationHistory?.map(m => m.role).join(', ') || 'none'}]`)
 
   // Always send updates to main window if it's open for live progress visualization
   // This is done first to ensure main window updates even if panel is unavailable

--- a/src/renderer/src/lib/queries.ts
+++ b/src/renderer/src/lib/queries.ts
@@ -48,13 +48,7 @@ export const useConversationHistoryQuery = () =>
   useQuery({
     queryKey: ["conversation-history"],
     queryFn: async () => {
-      console.log("[Query Client] Fetching conversation history...")
       const result = await tipcClient.getConversationHistory()
-      console.log("[Query Client] Conversation history result:", {
-        isArray: Array.isArray(result),
-        length: Array.isArray(result) ? result.length : "N/A",
-        result,
-      })
       return result
     },
   })

--- a/src/renderer/src/pages/history.tsx
+++ b/src/renderer/src/pages/history.tsx
@@ -60,17 +60,6 @@ export function Component() {
 
   const continueConversation = useConversationStore((s) => s.continueConversation)
 
-  // Debug logging
-  useEffect(() => {
-    console.log("[History Page] historyQuery state:", {
-      isLoading: historyQuery.isLoading,
-      isError: historyQuery.isError,
-      error: historyQuery.error,
-      dataLength: historyQuery.data?.length,
-      data: historyQuery.data,
-    })
-  }, [historyQuery.isLoading, historyQuery.isError, historyQuery.data])
-
   // Handle route parameter for deep-linking to specific history item
   useEffect(() => {
     if (routeHistoryItemId) {
@@ -80,12 +69,6 @@ export function Component() {
   }, [routeHistoryItemId])
 
   const filteredHistory = useMemo(() => {
-    console.log("[History Page] Computing filteredHistory:", {
-      hasData: !!historyQuery.data,
-      dataLength: historyQuery.data?.length,
-      searchQuery,
-    })
-
     if (!historyQuery.data) return []
 
     const filtered = historyQuery.data.filter(
@@ -94,18 +77,10 @@ export function Component() {
         historyItem.preview.toLowerCase().includes(searchQuery.toLowerCase()),
     )
 
-    console.log("[History Page] Filtered history:", {
-      originalLength: historyQuery.data.length,
-      filteredLength: filtered.length,
-    })
-
     return filtered
   }, [historyQuery.data, searchQuery])
 
   const groupedHistory = useMemo(() => {
-    console.log("[History Page] Computing groupedHistory from filteredHistory:", {
-      filteredLength: filteredHistory.length,
-    })
 
     const groups = new Map<string, ConversationHistoryItem[]>()
     const today = dayjs().format("YYYY-MM-DD")


### PR DESCRIPTION
## Summary

Fixes issue #400 where the application was randomly logging history of past conversations, creating unnecessary noise in the logs and potentially exposing sensitive information.

## Problem

The application was logging conversation history at random times, not just when the user clicked on the history view. This was due to:

1. `getConversationHistory()` in `conversation-service.ts` logging detailed history items including titles, IDs, and message counts
2. `emitAgentProgress()` logging conversation history length and roles on every progress update
3. `useConversationHistoryQuery` in `queries.ts` logging the entire history result to console
4. `history.tsx` having debug useEffect and console.log statements that logged full history data

## Changes

### `src/main/conversation-service.ts`
- Removed verbose logging statements from `getConversationHistory()` that logged:
  - Index path
  - File content length
  - Parsed history items count
  - All history items with their IDs, titles, and message counts
- Kept error logging for debugging actual issues

### `src/main/emit-agent-progress.ts`
- Removed logging of `conversationHistory` length and roles on every agent progress update
- This was particularly noisy as progress updates happen frequently during agent execution

### `src/renderer/src/lib/queries.ts`
- Removed `console.log` statements in `useConversationHistoryQuery` that logged:
  - "Fetching conversation history..."
  - The full result object including all history data

### `src/renderer/src/pages/history.tsx`
- Removed debug `useEffect` that logged full `historyQuery` state on every update
- Removed `console.log` statements in `filteredHistory` useMemo
- Removed `console.log` statements in `groupedHistory` useMemo

## Testing

- ✅ TypeScript compilation passes (`pnpm typecheck`)
- ✅ All 32 tests pass (`pnpm test`)
- ✅ Build succeeds (`pnpm build`)

## Impact

- Significantly reduces log noise during normal application usage
- Prevents potential exposure of conversation titles/content in logs
- Debug logging for LLM calls (via `logLLM`) is preserved and only shown when debug flags are enabled
- Error logging is preserved for actual issues

Fixes #400

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author