### PR TITLE
fix(mobile): update metro.config.js to support pnpm symlinks

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,0 +1,58 @@
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+const fs = require('fs');
+
+// Find the project and workspace directories
+const projectRoot = __dirname;
+// This can be replaced with `find-yarn-workspace-root`
+const monorepoRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+
+// 1. Watch all files within the monorepo
+config.watchFolders = [monorepoRoot];
+
+// 2. Let Metro know where to resolve packages and in what order
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(monorepoRoot, 'node_modules'),
+];
+
+// 3. Enable symlinks for pnpm
+config.resolver.unstable_enableSymlinks = true;
+
+// 4. Enable package exports for pnpm
+config.resolver.unstable_enablePackageExports = true;
+
+// 5. Resolve symlinks to real paths for pnpm compatibility
+const originalResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  // Try default resolution first
+  if (originalResolveRequest) {
+    try {
+      return originalResolveRequest(context, moduleName, platform);
+    } catch (error) {
+      // Fall through to custom resolution
+    }
+  }
+
+  // For pnpm, try to resolve from the project's node_modules first
+  const projectModulePath = path.resolve(projectRoot, 'node_modules', moduleName);
+  if (fs.existsSync(projectModulePath)) {
+    try {
+      const realPath = fs.realpathSync(projectModulePath);
+      return {
+        filePath: require.resolve(moduleName, { paths: [projectRoot] }),
+        type: 'sourceFile',
+      };
+    } catch (e) {
+      // Fall through
+    }
+  }
+
+  // Let Metro handle it
+  return context.resolveRequest(context, moduleName, platform);
+};
+
+module.exports = config;
+


### PR DESCRIPTION
## Summary

Fixes the Metro bundler failing to resolve `react` and other packages when running the mobile app in web mode with pnpm.

## Changes

- Enable `unstable_enableSymlinks` for pnpm compatibility
- Enable `unstable_enablePackageExports` for package exports resolution  
- Add custom `resolveRequest` to handle pnpm symlinked modules

## Problem

When running `npm run web` (or `npx expo start --web`), Metro bundler was failing with:

```
Unable to resolve "react" from "apps/mobile/App.tsx"
```

This was caused by pnpm's symlinked node_modules structure not being properly resolved by Metro's default configuration.

## Testing

- [x] Verified app loads successfully in web mode at http://localhost:8081
- [x] Settings screen renders correctly

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author