### PR TITLE
Fix: Unable to type in text box after agent work completes

### DIFF
--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -624,6 +624,12 @@ export function Component() {
   useEffect(() => {
     const isTextSubmissionPending = textInputMutation.isPending || mcpTextInputMutation.isPending
 
+    // If text input is active, don't override the mode - keep it as textInput
+    // This prevents the panel from becoming unfocusable while user is typing
+    if (showTextInput) {
+      return undefined
+    }
+
     let targetMode: "agent" | "normal" | null = null
     if (anyActiveNonSnoozed) {
       targetMode = "agent"
@@ -652,7 +658,7 @@ export function Component() {
     return () => {
       if (tid) clearTimeout(tid)
     }
-  }, [anyActiveNonSnoozed, textInputMutation.isPending, mcpTextInputMutation.isPending])
+  }, [anyActiveNonSnoozed, textInputMutation.isPending, mcpTextInputMutation.isPending, showTextInput])
 
   // Note: We don't need to hide text input when agentProgress changes because:
   // 1. handleTextSubmit already hides it immediately on submit (line 375)


### PR DESCRIPTION
## Summary

Fixes #416 - Text input becomes unresponsive after the AI agent finishes work in the floating UI.

## Root Cause

The `useEffect` hook in `panel.tsx` that handles agent progress mode changes was overriding the "textInput" panel mode with "normal" mode when the agent completed work. This caused the window to become unfocusable because:

1. When user presses Ctrl+T to show text input, the panel mode is set to "textInput" which makes the window focusable
2. However, the agent progress handler `useEffect` would check `anyActiveNonSnoozed` and `isTextSubmissionPending`
3. If both were false (agent completed, no pending mutation), it would set `targetMode = "normal"`
4. This called `requestPanelMode("normal")` which sets `focusable: false` on the panel window
5. The effect did NOT consider the `showTextInput` state, allowing it to override the textInput mode

## Fix

Added an early return in the `useEffect` when `showTextInput` is true to prevent the mode from being overridden while the user is typing:

```typescript
// If text input is active, don't override the mode - keep it as textInput
// This prevents the panel from becoming unfocusable while user is typing
if (showTextInput) {
  return undefined
}
```

Also added `showTextInput` to the dependency array to ensure the effect re-runs when text input state changes.

## Testing

- [x] TypeScript check passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Manual testing: Text input remains focusable and responsive after agent completes work

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author