### PR TITLE
feat: Add ability to create new profile from profile dropdown

### DIFF
--- a/apps/desktop/src/renderer/src/components/sidebar-profile-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar-profile-selector.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Profile } from "@shared/types"
@@ -6,12 +7,30 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "./ui/select"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog"
+import { Button } from "./ui/button"
+import { Input } from "./ui/input"
+import { Label } from "./ui/label"
+import { Textarea } from "./ui/textarea"
+
+const CREATE_NEW_PROFILE_VALUE = "__create_new__"
 
 export function SidebarProfileSelector() {
   const queryClient = useQueryClient()
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [newProfileName, setNewProfileName] = useState("")
+  const [newProfileGuidelines, setNewProfileGuidelines] = useState("")
 
   // Fetch profiles
   const profilesQuery = useQuery({
@@ -63,24 +82,114 @@ export function SidebarProfileSelector() {
     },
   })
 
+  // Create profile mutation
+  const createProfileMutation = useMutation({
+    mutationFn: async ({ name, guidelines }: { name: string; guidelines: string }) => {
+      return await tipcClient.createProfile({ name, guidelines })
+    },
+    onSuccess: (newProfile: Profile) => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] })
+      queryClient.invalidateQueries({ queryKey: ["current-profile"] })
+      setIsCreateDialogOpen(false)
+      setNewProfileName("")
+      setNewProfileGuidelines("")
+      toast.success(`Profile "${newProfile.name}" created successfully`)
+      // Automatically switch to the new profile
+      setCurrentProfileMutation.mutate(newProfile.id)
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to create profile: ${error.message}`)
+    },
+  })
+
+  const handleValueChange = (value: string) => {
+    if (value === CREATE_NEW_PROFILE_VALUE) {
+      setIsCreateDialogOpen(true)
+    } else {
+      setCurrentProfileMutation.mutate(value)
+    }
+  }
+
+  const handleCreateProfile = () => {
+    if (!newProfileName.trim()) {
+      toast.error("Profile name is required")
+      return
+    }
+    createProfileMutation.mutate({
+      name: newProfileName.trim(),
+      guidelines: newProfileGuidelines,
+    })
+  }
+
   return (
-    <Select
-      value={currentProfile?.id || ""}
-      onValueChange={(value) => setCurrentProfileMutation.mutate(value)}
-    >
-      <SelectTrigger className="h-8 text-xs">
-        <span className="i-mingcute-user-3-line mr-1.5 h-3.5 w-3.5 shrink-0" />
-        <SelectValue placeholder="Select profile" />
-      </SelectTrigger>
-      <SelectContent>
-        {profiles.map((profile) => (
-          <SelectItem key={profile.id} value={profile.id}>
-            {profile.name}
-            {profile.isDefault && " (Default)"}
+    <>
+      <Select
+        value={currentProfile?.id || ""}
+        onValueChange={handleValueChange}
+      >
+        <SelectTrigger className="h-8 text-xs">
+          <span className="i-mingcute-user-3-line mr-1.5 h-3.5 w-3.5 shrink-0" />
+          <SelectValue placeholder="Select profile" />
+        </SelectTrigger>
+        <SelectContent>
+          {profiles.map((profile) => (
+            <SelectItem key={profile.id} value={profile.id}>
+              {profile.name}
+              {profile.isDefault && " (Default)"}
+            </SelectItem>
+          ))}
+          <SelectSeparator />
+          <SelectItem value={CREATE_NEW_PROFILE_VALUE}>
+            <span className="flex items-center gap-1.5">
+              <span className="i-mingcute-add-line h-3.5 w-3.5" />
+              Create New Profile
+            </span>
           </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+        </SelectContent>
+      </Select>
+
+      {/* Create Profile Dialog */}
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Profile</DialogTitle>
+            <DialogDescription>
+              Create a new profile with custom guidelines for your AI agent.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="sidebar-profile-name">Profile Name</Label>
+              <Input
+                id="sidebar-profile-name"
+                value={newProfileName}
+                onChange={(e) => setNewProfileName(e.target.value)}
+                placeholder="e.g., My Custom Profile"
+              />
+            </div>
+            <div>
+              <Label htmlFor="sidebar-profile-guidelines">Guidelines (optional)</Label>
+              <Textarea
+                id="sidebar-profile-guidelines"
+                value={newProfileGuidelines}
+                onChange={(e) => setNewProfileGuidelines(e.target.value)}
+                rows={6}
+                className="font-mono text-sm"
+                placeholder="Enter custom guidelines..."
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateProfile} disabled={createProfileMutation.isPending}>
+              {createProfileMutation.isPending ? "Creating..." : "Create Profile"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

Adds the ability to create a new profile directly from the profile dropdown menu in the sidebar, making it easily accessible from any screen in the application.

## Changes

### Enhanced `SidebarProfileSelector` component
- Added "Create New Profile" option at the bottom of the profile dropdown
- Implemented create profile dialog with name and guidelines fields
- Automatically switches to newly created profile after creation
- Uses consistent UI components matching existing profile management

## Features

- **Quick Access**: Users can create profiles from any screen without navigating to settings
- **Consistent UI**: Uses the same Dialog, Input, and Textarea components as the ProfileManager
- **Smart Defaults**: New profiles start with empty guidelines (can be filled in)
- **Auto-Switch**: After creating a profile, it becomes the active profile automatically

## Screenshots

The profile dropdown now shows:
1. All existing profiles (with Default indicator)
2. A separator
3. "Create New Profile" option with a plus icon

Clicking "Create New Profile" opens a dialog to enter:
- Profile name (required)
- Guidelines (optional)

## Testing

- ✅ All existing tests pass (32/32)
- ✅ Vite build succeeds
- ✅ Component follows existing patterns from ProfileManager

**Note**: Pre-existing TypeScript errors in `keyboard.ts`, `llm.ts`, `mcp-service.ts`, etc. (Timeout type errors) are unrelated to this change.

## Fixes

Closes #423

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author