### PR TITLE
fix: Profile text truncated after save - sync guidelines with profile

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings-tools.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-tools.tsx
@@ -123,7 +123,9 @@ export function Component() {
   }
 
   // Combined saving state for the guidelines save operation
+  // Also check if profile query is still loading to prevent saving before profile data is available
   const isSavingGuidelines = saveConfigMutation.isPending || updateProfileMutation.isPending
+  const isProfileLoading = currentProfileQuery.isLoading
 
   const saveAdditionalGuidelines = async () => {
     try {
@@ -381,14 +383,16 @@ DOMAIN-SPECIFIC RULES:
                       size="sm"
                       onClick={saveAdditionalGuidelines}
                       disabled={
-                        !hasUnsavedChanges || isSavingGuidelines
+                        !hasUnsavedChanges || isSavingGuidelines || isProfileLoading
                       }
                       className="gap-1"
                     >
                       <Save className="h-3 w-3" />
                       {isSavingGuidelines
                         ? "Saving..."
-                        : "Save Changes"}
+                        : isProfileLoading
+                          ? "Loading..."
+                          : "Save Changes"}
                     </Button>
                   </div>
                   {hasUnsavedChanges && (


### PR DESCRIPTION
## Summary

Fixes #424 - Profile text truncated after save - only first line retained

## Problem

When a user:
1. Created a new profile using "Save as New"
2. Edited the profile text (guidelines) in the textarea
3. Clicked "Save Changes"
4. Switched to a different profile
5. Switched back to the newly created profile

The text was truncated - only the original content was displayed, not the edited content.

## Root Cause

When the user clicked "Save Changes", the `saveAdditionalGuidelines()` function only saved the guidelines to `mcpToolsSystemPrompt` in the config. However, it did **not** update the current profile's `guidelines` field in the profile service.

When switching back to the profile, `setCurrentProfile` loaded the profile's stored `guidelines` (which was stale - containing only the original content from profile creation) and wrote it to `mcpToolsSystemPrompt`, overwriting the user's changes.

## Solution

Modified the `saveAdditionalGuidelines()` function in `settings-tools.tsx` to:
1. Save the guidelines to the config (existing behavior)
2. **Also update the current profile's guidelines** if it's a non-default profile

This ensures the profile stays in sync with what the user saves in the textarea.

## Changes

- Added `currentProfileQuery` to fetch the current profile
- Added `updateProfileMutation` to update profile guidelines
- Modified `saveAdditionalGuidelines()` to also update the profile when saving

## Testing

- ✅ TypeScript compilation passes
- ✅ All 32 tests pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author