### PR TITLE
Move max iterations setting from profile to general settings

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -736,6 +736,31 @@ export function Component() {
           <Control
             label={
               <ControlLabel
+                label="Max Iterations"
+                tooltip="Maximum number of iterations the agent can perform before stopping. Higher values allow more complex tasks but may take longer."
+              />
+            }
+            className="px-3"
+          >
+            <Input
+              id="mcp-max-iterations"
+              type="number"
+              min="1"
+              max="50"
+              step="1"
+              value={configQuery.data?.mcpMaxIterations ?? 10}
+              onChange={(e) =>
+                saveConfig({
+                  mcpMaxIterations: parseInt(e.target.value) || 1,
+                })
+              }
+              className="w-32"
+            />
+          </Control>
+
+          <Control
+            label={
+              <ControlLabel
                 label="Emergency Kill Switch"
                 tooltip="Provides a global hotkey to immediately stop agent mode and kill all agent-created processes"
               />

--- a/apps/desktop/src/renderer/src/pages/settings-tools.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-tools.tsx
@@ -2,7 +2,6 @@ import { useConfigQuery } from "@renderer/lib/query-client"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Button } from "@renderer/components/ui/button"
-import { Input } from "@renderer/components/ui/input"
 import { Label } from "@renderer/components/ui/label"
 import { Textarea } from "@renderer/components/ui/textarea"
 import {
@@ -171,25 +170,6 @@ DOMAIN-SPECIFIC RULES:
           </div>
 
           <div className="space-y-4">
-            <div className="space-y-2">
-              <LabelWithTooltip htmlFor="mcp-max-iterations" tooltip="Maximum number of iterations the agent can perform before stopping. Higher values allow more complex tasks but may take longer.">Max Iterations</LabelWithTooltip>
-              <Input
-                id="mcp-max-iterations"
-                type="number"
-                min="1"
-                max="50"
-                step="1"
-                value={config.mcpMaxIterations ?? 10}
-                onChange={(e) =>
-                  updateConfig({
-                    mcpMaxIterations: parseInt(e.target.value) || 1,
-                  })
-                }
-                className="w-32"
-              />
-            </div>
-
-            <div className="space-y-4">
               <div className="rounded-lg border p-4 space-y-4">
                 <div>
                   <h3 className="text-sm font-semibold mb-1">Profile Management</h3>
@@ -268,7 +248,6 @@ DOMAIN-SPECIFIC RULES:
                   them.
                 </p>
               )}
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Moves the "Max Iterations" setting from the Profile settings page to the General settings page under the "Agent Safety" section.

## Changes

- Removed Max Iterations control from `settings-tools.tsx` (profile settings)
- Added Max Iterations control to `settings-general.tsx` in the "Agent Safety" ControlGroup
- Removed unused `Input` import from `settings-tools.tsx`

The setting continues to use the same `mcpMaxIterations` config property with the same constraints (min=1, max=50).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author