### PR TITLE
fix: display latest session at top of sessions view

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -93,14 +93,18 @@ export function Component() {
 
     // If we have a custom order, use it; otherwise sort by default
     if (sessionOrder.length > 0) {
-      // Sort by custom order, putting unknown sessions at the end
+      // Sort by custom order, putting unknown (new) sessions at the BEGINNING
+      // This ensures newly created sessions appear at the top immediately
       return entries.sort((a, b) => {
         const aIndex = sessionOrder.indexOf(a[0])
         const bIndex = sessionOrder.indexOf(b[0])
-        // If not in order list, put at end
-        if (aIndex === -1 && bIndex === -1) return 0
-        if (aIndex === -1) return 1
-        if (bIndex === -1) return -1
+        // New sessions (not in order list) should appear first (at top)
+        if (aIndex === -1 && bIndex === -1) {
+          // Both are new - sort by timestamp (newest first)
+          return (b[1]?.steps?.[0]?.timestamp ?? 0) - (a[1]?.steps?.[0]?.timestamp ?? 0)
+        }
+        if (aIndex === -1) return -1  // a is new, put it first
+        if (bIndex === -1) return 1   // b is new, put it first
         return aIndex - bIndex
       })
     }


### PR DESCRIPTION
## Summary

Fixes #447

This PR ensures that newly created sessions appear at the top-left position in the sessions view, rather than at the bottom.

## Problem

When a user creates a new session, it was appearing at the end of the session list. This was counterintuitive since users typically want to see and interact with their most recent sessions first.

## Solution

Modified the sort logic in `sessions.tsx` to put new sessions (those not yet in the custom order list) at the BEGINNING instead of the END:

- Changed `if (aIndex === -1) return 1` to `if (aIndex === -1) return -1`
- Changed `if (bIndex === -1) return -1` to `if (bIndex === -1) return 1`
- Added timestamp-based sorting for multiple new sessions (newest first)

## Testing

- [x] TypeScript compilation passes
- [x] All 32 unit tests pass
- [x] Manual testing via CDP confirmed sessions now appear in correct order (newest first)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author