### PR TITLE
feat(sessions): Display latest session at the top of sessions view

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -120,8 +120,18 @@ export function Component() {
     const newIds = currentIds.filter(id => !sessionOrder.includes(id))
 
     if (newIds.length > 0) {
-      // Add new sessions to the beginning of the order
-      setSessionOrder(prev => [...newIds, ...prev.filter(id => currentIds.includes(id))])
+      // Sort new sessions by timestamp (most recent first) before prepending
+      // This ensures correct order when multiple sessions appear at once (e.g., on page load)
+      const sortedNewIds = [...newIds].sort((a, b) => {
+        const progressA = agentProgressById.get(a)
+        const progressB = agentProgressById.get(b)
+        // Use first step timestamp, or fall back to 0
+        const timestampA = progressA?.steps?.[0]?.timestamp ?? 0
+        const timestampB = progressB?.steps?.[0]?.timestamp ?? 0
+        return timestampB - timestampA // Descending (newest first)
+      })
+      // Add new sessions to the beginning of the order (newest first)
+      setSessionOrder(prev => [...sortedNewIds, ...prev.filter(id => currentIds.includes(id))])
     } else {
       // Remove sessions that no longer exist
       const validOrder = sessionOrder.filter(id => currentIds.includes(id))


### PR DESCRIPTION
## Summary

This PR ensures that session tiles in the sessions view are displayed with the most recent session first (top-left position).

## Problem

Previously, when multiple sessions appeared at once (e.g., on page load), they could be displayed in an inconsistent order because the code was relying on Map iteration order rather than timestamp-based ordering.

## Solution

When new sessions are added to the session order:
1. Sort them by timestamp (most recent first) before prepending to the order list
2. Use the first step's timestamp as the session creation time indicator
3. Sessions without timestamps fall back to position 0 (at the end of the sorted batch)

## Changes

- **`apps/desktop/src/renderer/src/pages/sessions.tsx`**:
  - Modified the `useEffect` that syncs session order to sort new sessions by timestamp before prepending them
  - Added comments explaining the sorting behavior

## Testing

- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ All 32 existing tests pass (`npx vitest run`)
- ✅ Desktop app starts successfully (`pnpm dev d`)

## Acceptance Criteria from Issue #447

- [x] Newly spawned session tiles should appear in the top-left position
- [x] Sessions should be ordered with the most recent first
- [x] This applies to the sessions view where tiles are displayed

Fixes #447

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author