### PR TITLE
fix: Detect continuation phrases in plain text LLM responses

### DIFF
--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -403,5 +403,59 @@ describe('Continuation Phrase Detection (Issue #443)', () => {
     expect(result.content).toContain('need to')
     expect(result.needsMoreWork).toBe(true)
   })
+
+  it("should set needsMoreWork=true when response contains curly apostrophe I\u2019ll", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              // Using curly apostrophe (') U+2019 instead of straight apostrophe (')
+              content: "I\u2019ll check the file and fix the issue.",
+            },
+          },
+        ],
+      }),
+    })
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    const result = await makeLLMCallWithFetch(
+      [{ role: 'user', content: 'test' }],
+      'openai'
+    )
+
+    expect(result.content).toContain("I\u2019ll")
+    expect(result.needsMoreWork).toBe(true)
+  })
+
+  it("should set needsMoreWork=true when response contains curly apostrophe let\u2019s", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              // Using curly apostrophe (') U+2019 instead of straight apostrophe (')
+              content: "Let\u2019s start by running the tests.",
+            },
+          },
+        ],
+      }),
+    })
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    const result = await makeLLMCallWithFetch(
+      [{ role: 'user', content: 'test' }],
+      'openai'
+    )
+
+    expect(result.content).toContain("Let\u2019s")
+    expect(result.needsMoreWork).toBe(true)
+  })
 })
 

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -1275,9 +1275,11 @@ async function makeLLMCallAttempt(
   // Check for continuation phrases that indicate the LLM intends to continue working
   // These phrases suggest the agent wants to take action but failed to return proper JSON
   // Fixes issue #443: Agent stops prematurely when LLM returns plain text instead of structured JSON
+  // Note: We use ['\u2019] character class to match both straight (') and curly (') apostrophes
+  // since LLMs often produce typographic/curly quotes (U+2019 = RIGHT SINGLE QUOTATION MARK)
   const continuationPhrases = [
     /\blet me\b/i,
-    /\bi'll\b/i,
+    /\bi['\u2019]ll\b/i,
     /\bi will\b/i,
     /\bnext[,\s]/i,
     /\bnow i\b/i,
@@ -1287,7 +1289,7 @@ async function makeLLMCallAttempt(
     /\bproceed to\b/i,
     /\bstart by\b/i,
     /\bbegin by\b/i,
-    /\blet's\b/i,
+    /\blet['\u2019]s\b/i,
     /\bshould\s+(now|first|next)\b/i,
     /\bneed to\b/i,
     /\bwill now\b/i,


### PR DESCRIPTION
## Summary

Fixes #443 - Agent stops prematurely when LLM returns plain text instead of structured JSON.

## Problem

When the LLM returns a plain text response like:
```
"Slot 4 didn't start properly. Let me navigate it to the correct directory and start the agent."
```

Instead of the expected JSON structure:
```json
{"toolCalls": [...], "content": "...", "needsMoreWork": true}
```

The agent would terminate prematurely because `needsMoreWork` was set to `undefined`, which could be treated as falsy in certain code paths.

## Solution

Implemented **Option 1** from the issue: Detect continuation phrases in plain text responses and set `needsMoreWork=true` when found.

### Continuation Phrases Detected

The following phrases indicate the LLM intends to continue working:
- `let me`, `I'll`, `I will`
- `next,`, `now I`, `first,`, `then I`
- `going to`, `proceed to`, `start by`, `begin by`
- `let's`, `should now/first/next`, `need to`, `will now`

### Code Changes

**`apps/desktop/src/main/llm-fetch.ts`**
- Added continuation phrase detection after tool marker check
- When a continuation phrase is found, returns `{ content, needsMoreWork: true }` instead of `undefined`
- Added debug logging for continuation phrase detection

**`apps/desktop/src/main/llm-fetch.test.ts`**
- Added 6 new tests for continuation phrase detection:
  - "Let me" detection
  - "I'll" detection
  - "I will" detection
  - "going to" detection
  - "need to" detection
  - Plain text without continuation phrases (should remain `undefined`)

## Testing

- ✅ All 38 tests pass (32 existing + 6 new)
- ✅ No TypeScript errors in modified files (pre-existing errors in other files are unrelated)

## Impact

- **Prevents premature agent termination** when LLM returns plain text with continuation intent
- **Backward compatible** - plain text without continuation phrases still returns `needsMoreWork: undefined`
- **Conservative approach** - only triggers on clear continuation phrases

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author