### PR TITLE
fix(agent): require explicit needsMoreWork=false to terminate agent loop

### DIFF
--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -1272,32 +1272,14 @@ async function makeLLMCallAttempt(
     return { content: cleaned, needsMoreWork: true }
   }
 
-  // Check for continuation phrases that indicate the LLM intends to continue working
-  // even though it didn't return proper JSON. This prevents premature termination
-  // when the LLM says things like "Let me..." or "I'll..." but fails to format as JSON.
-  // Fixes: https://github.com/aj47/SpeakMCP/issues/443
-  // Note: Uses (?:^|[.!?\n]\s*) to detect phrases at start, after sentence endings,
-  // or after newlines (LLMs often start new lines without punctuation)
-  // Note: Uses ["\u201C']* to allow optional opening quotes (straight ", curly ", or ')
-  // Note: Uses ['\u2019] to match both ASCII apostrophe (') and curly apostrophe (')
-  // since LLMs often output curly quotes like "I'll" instead of "I'll"
-  const continuationPhrases = /(?:^|[.!?\n]\s*)["\u201C']*(let me|i['\u2019]ll|i will|i['\u2019]m going to|i am going to|next,|now,|first,|then,|allow me to|proceeding to|starting to|going to|about to)/i
-  const hasContinuationPhrase = continuationPhrases.test((cleaned || content || "").trim())
-  if (hasContinuationPhrase) {
-    if (isDebugLLM()) {
-      logLLM("✅ Returning plain text with continuation phrase (needsMoreWork=true)", {
-        contentPreview: (cleaned || content)?.substring(0, 100)
-      })
-    }
-    return { content: cleaned || content, needsMoreWork: true }
-  }
-
   // For plain text responses without JSON structure, set needsMoreWork=undefined
   // rather than false. This allows the agent loop to decide whether the response
   // is acceptable or if it needs to nudge the LLM for a properly formatted response.
   // This prevents poor-quality plain text responses from being automatically accepted.
+  // Fix for https://github.com/aj47/SpeakMCP/issues/443 - agent loop will now
+  // always nudge for proper JSON format when needsMoreWork is undefined.
   if (isDebugLLM()) {
-    logLLM("✅ Returning plain text response (needsMoreWork=undefined - let agent decide)", {
+    logLLM("✅ Returning plain text response (needsMoreWork=undefined - agent will nudge for JSON)", {
       contentLength: (cleaned || content)?.length || 0
     })
   }


### PR DESCRIPTION
## Summary

Fixes #443 - Agent stops prematurely when LLM returns plain text instead of structured JSON

## Problem

The agent loop was terminating prematurely when the LLM returned plain text responses (like `"Slot 4 didn't start properly. Let me navigate it..."`) instead of the expected JSON structure. This happened because:

1. The continuation phrase regex didn't catch all cases
2. For non-actionable requests (no relevant tools), plain text with `needsMoreWork: undefined` was being accepted as a final answer

## Solution

Implemented **Option 2** from the issue: Only terminate when `needsMoreWork` is **explicitly `false`**, not when undefined.

### Changes

**`llm-fetch.ts`:**
- Removed the hardcoded continuation phrase regex matching (`/let me|i'll|i will|.../i`)
- Plain text responses now return `needsMoreWork: undefined` and let the agent loop decide

**`llm.ts`:**
- Removed the early exit logic that accepted plain text as final for non-actionable requests
- Always nudge for proper JSON format when `needsMoreWork` is undefined
- For actionable requests (with relevant tools): nudge immediately
- For non-actionable requests (simple Q&A): allow 1 no-op before nudging

## Testing

- [x] All existing tests pass (`npm run test`)
- [x] TypeScript compiles without new errors

## Notes

This fix avoids hardcoded word matching as requested, instead relying on the LLM to explicitly signal completion with `needsMoreWork: false`.

---

Pull Request updated by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author