### PR TITLE
feat(mobile): add animated loading spinners to chat list and home page

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -6,7 +6,7 @@ import ChatScreen from './src/screens/ChatScreen';
 import SessionListScreen from './src/screens/SessionListScreen';
 import { ConfigContext, useConfig, saveConfig } from './src/store/config';
 import { SessionContext, useSessions } from './src/store/sessions';
-import { View, ActivityIndicator, Image } from 'react-native';
+import { View, Image, Text, StyleSheet } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ThemeProvider, useTheme } from './src/ui/ThemeProvider';
 import * as Linking from 'expo-linking';
@@ -14,6 +14,10 @@ import { useEffect } from 'react';
 
 // SpeakMCP icon asset
 const speakMCPIcon = require('./assets/speakmcp-icon.png');
+
+// Animated spinner GIFs for loading state
+const darkSpinner = require('./assets/loading-spinner.gif');
+const lightSpinner = require('./assets/light-spinner.gif');
 
 const Stack = createNativeStackNavigator();
 
@@ -87,8 +91,15 @@ function Navigation() {
 
   if (!cfg.ready || !sessionStore.ready) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: theme.colors.background }}>
-        <ActivityIndicator color={theme.colors.foreground} />
+      <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
+        <Image
+          source={isDark ? darkSpinner : lightSpinner}
+          style={styles.spinner}
+          resizeMode="contain"
+        />
+        <Text style={[styles.loadingText, { color: theme.colors.mutedForeground }]}>
+          Loading...
+        </Text>
       </View>
     );
   }
@@ -139,6 +150,22 @@ function StatusBarWrapper() {
   const { isDark } = useTheme();
   return <StatusBar style={isDark ? 'light' : 'dark'} />;
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  spinner: {
+    width: 48,
+    height: 48,
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 16,
+  },
+});
 
 export default function App() {
   return (

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -5,19 +5,23 @@
  */
 
 import { useLayoutEffect, useMemo } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, Alert, Platform } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, Alert, Platform, Image } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../ui/ThemeProvider';
 import { spacing, radius, Theme } from '../ui/theme';
 import { useSessionContext, SessionStore } from '../store/sessions';
 import { SessionListItem } from '../types/session';
 
+// Animated spinner GIFs for loading state
+const darkSpinner = require('../../assets/loading-spinner.gif');
+const lightSpinner = require('../../assets/light-spinner.gif');
+
 interface Props {
   navigation: any;
 }
 
 export default function SessionListScreen({ navigation }: Props) {
-  const { theme } = useTheme();
+  const { theme, isDark } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   // Add settings button to header
@@ -38,6 +42,20 @@ export default function SessionListScreen({ navigation }: Props) {
   const insets = useSafeAreaInsets();
   const sessionStore = useSessionContext();
   const sessions = sessionStore.getSessionList();
+
+  // Show loading spinner while sessions are loading
+  if (!sessionStore.ready) {
+    return (
+      <View style={[styles.container, styles.loadingContainer]}>
+        <Image
+          source={isDark ? darkSpinner : lightSpinner}
+          style={styles.spinner}
+          resizeMode="contain"
+        />
+        <Text style={styles.loadingText}>Loading chats...</Text>
+      </View>
+    );
+  }
 
   const handleCreateSession = () => {
     sessionStore.createNewSession();
@@ -166,6 +184,19 @@ function createStyles(theme: Theme) {
     container: {
       flex: 1,
       backgroundColor: theme.colors.background,
+    },
+    loadingContainer: {
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    spinner: {
+      width: 48,
+      height: 48,
+    },
+    loadingText: {
+      ...theme.typography.body,
+      color: theme.colors.mutedForeground,
+      marginTop: spacing.md,
     },
     header: {
       flexDirection: 'row',


### PR DESCRIPTION
## Summary

Adds animated loading spinners to the mobile app's chat list page and home page (initial app load) for better UX during loading states.

Fixes #465

## Changes

### App.tsx (Home Page / Initial Load)
- Replaced `ActivityIndicator` with animated GIF spinner during initial config/sessions load
- Uses theme-aware spinners (dark/light mode support)
- Added "Loading..." text below spinner

### SessionListScreen.tsx (Chat List Page)
- Added loading spinner while sessions are loading from AsyncStorage
- Shows "Loading chats..." text below spinner
- Uses existing `loading-spinner.gif` and `light-spinner.gif` assets

## Acceptance Criteria from Issue

- [x] Animated spinner displays on chat list page during loading states
- [x] Animated spinner displays on home page during loading states
- [x] Spinner animation is smooth and consistent across both pages
- [x] Spinner disappears once content is loaded

## Testing

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Spinners use existing assets already used in ChatScreen
- [x] Theme-aware (dark spinner for dark mode, light spinner for light mode)

## Screenshots

The spinners use the existing animated GIF assets that are already used in the ChatScreen header when the agent is processing.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author