### PR TITLE
fix(mobile): Only submit hold-to-talk on button release, not on voice breaks

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -589,6 +589,18 @@ export default function ChatScreen({ route, navigation }: any) {
             return;
           } catch (restartErr) {
             console.warn('[Voice] Failed to restart web recognition after voice break:', restartErr);
+            // On restart failure, stop gracefully without submitting
+            // This maintains the "only submit on button release" guarantee
+            setListening(false);
+            setLiveTranscript('');
+            // Place accumulated text in input field so user doesn't lose it
+            const accumulatedText = (webFinalRef.current || '').trim() || (liveTranscriptRef.current || '').trim();
+            if (accumulatedText) {
+              setInput((t) => (t ? `${t} ${accumulatedText}` : accumulatedText));
+            }
+            webFinalRef.current = '';
+            pendingHandsFreeFinalRef.current = '';
+            return;
           }
         }
 
@@ -705,6 +717,18 @@ export default function ChatScreen({ route, navigation }: any) {
                   }
                 } catch (restartErr) {
                   console.warn('[Voice] Failed to restart recognition after voice break:', restartErr);
+                  // On restart failure, stop gracefully without submitting
+                  // This maintains the "only submit on button release" guarantee
+                  setListening(false);
+                  setLiveTranscript('');
+                  // Place accumulated text in input field so user doesn't lose it
+                  const accumulatedText = (nativeFinalRef.current || '').trim() || (liveTranscriptRef.current || '').trim();
+                  if (accumulatedText) {
+                    setInput((t) => (t ? `${t} ${accumulatedText}` : accumulatedText));
+                  }
+                  nativeFinalRef.current = '';
+                  pendingHandsFreeFinalRef.current = '';
+                  return;
                 }
               }
 


### PR DESCRIPTION
## Summary

Fixes the issue where the mobile app's hold-to-talk voice mode submits the message prematurely when there's a break/pause in the user's voice.

Fixes #450

## Problem

When using hold-to-talk mode, the speech recognizer's `end` event could fire prematurely due to voice breaks or pauses (even with `continuous: true` set). This caused the message to be submitted while the user was still holding the button, which was unexpected and disruptive.

## Solution

1. **Added `userReleasedButtonRef`** - A new ref that tracks whether the user has explicitly released the hold-to-talk button

2. **Reset on recording start** - When `startRecording()` is called, the flag is reset to `false`

3. **Set on button release** - When `stopRecordingAndHandle()` is called (from `onPressOut`), the flag is set to `true`

4. **Modified `end` event handlers** (both native and web):
   - In hold-to-speak mode, only submit if `userReleasedButtonRef.current === true`
   - If the recognizer ended on its own (voice break/pause), **restart recognition** instead of submitting
   - Accumulated transcript is preserved across restarts

## Changes

- **`apps/mobile/src/screens/ChatScreen.tsx`**
  - Added `userReleasedButtonRef` to track explicit button release
  - Updated native `end` event listener to restart recognition on voice breaks
  - Updated web `onend` handler to restart recognition on voice breaks
  - Set flag in `stopRecordingAndHandle()` when user releases button
  - Reset flag in `startRecording()` when starting new session

## Behavior

**Before:** Message could submit mid-sentence when the user paused to think

**After:** Message only submits when the user physically lifts their thumb from the button

## Testing

- ✅ TypeScript compilation passes (no new errors in ChatScreen.tsx)
- ✅ Logic review confirms hold-to-speak mode only submits on `onPressOut`
- ✅ Hands-free mode behavior unchanged (uses debounce-based submission)

## Technical Notes

- The fix works by detecting when the `end` event fires without user action (voice break) and restarting the speech recognizer
- Accumulated `nativeFinalRef`/`webFinalRef` text is preserved across restarts
- The `continuous: true` setting helps but doesn't guarantee the recognizer won't stop on silence
- This fix handles that edge case gracefully by auto-restarting

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author