### PR TITLE
feat(desktop): add button to clear completed sessions from view

### DIFF
--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -326,6 +326,16 @@ class AgentSessionTracker {
   clearAllSessions(): void {
     this.sessions.clear()
   }
+
+  /**
+   * Clear all completed/recent sessions (move to history)
+   * Active sessions are preserved
+   */
+  clearCompletedSessions(): void {
+    logApp(`[AgentSessionTracker] Clearing ${this.completedSessions.length} completed sessions`)
+    this.completedSessions = []
+    emitSessionUpdate()
+  }
 }
 
 export const agentSessionTracker = AgentSessionTracker.getInstance()

--- a/apps/desktop/src/main/renderer-handlers.ts
+++ b/apps/desktop/src/main/renderer-handlers.ts
@@ -23,6 +23,7 @@ export type RendererHandlers = {
   clearAgentProgress: () => void
   emergencyStopAgent: () => void
   clearAgentSessionProgress: (sessionId: string) => void
+  clearInactiveSessions: () => void
 
   // Agent Session tracking - push-based updates instead of polling
   agentSessionsUpdated: (data: { activeSessions: AgentSession[], recentSessions: AgentSession[] }) => void

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -548,6 +548,24 @@ export const router = {
       return { success: true }
     }),
 
+  clearInactiveSessions: t.procedure.action(async () => {
+    const { agentSessionTracker } = await import("./agent-session-tracker")
+
+    // Clear completed sessions from the tracker
+    agentSessionTracker.clearCompletedSessions()
+
+    // Send to all windows so both main and panel can update their state
+    for (const [id, win] of WINDOWS.entries()) {
+      try {
+        getRendererHandlers<RendererHandlers>(win.webContents).clearInactiveSessions?.send()
+      } catch (e) {
+        logApp(`[tipc] clearInactiveSessions send to ${id} failed:`, e)
+      }
+    }
+
+    return { success: true }
+  }),
+
   closeAgentModeAndHidePanelWindow: t.procedure.action(async () => {
     closeAgentModeAndHidePanelWindow()
     return { success: true }

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -13,6 +13,7 @@ export function useStoreSync() {
   const updateSessionProgress = useAgentStore((s) => s.updateSessionProgress)
   const clearAllProgress = useAgentStore((s) => s.clearAllProgress)
   const clearSessionProgress = useAgentStore((s) => s.clearSessionProgress)
+  const clearInactiveSessions = useAgentStore((s) => s.clearInactiveSessions)
   const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
   const setScrollToSessionId = useAgentStore((s) => s.setScrollToSessionId)
   const markConversationCompleted = useConversationStore((s) => s.markConversationCompleted)
@@ -70,6 +71,17 @@ export function useStoreSync() {
     )
     return unlisten
   }, [clearSessionProgress])
+
+  // Listen for clear inactive sessions
+  useEffect(() => {
+    const unlisten = (rendererHandlers as any).clearInactiveSessions?.listen?.(
+      () => {
+        logUI('[useStoreSync] Clearing all inactive sessions')
+        clearInactiveSessions()
+      }
+    )
+    return unlisten
+  }, [clearInactiveSessions])
 
   // Cross-window: focus a specific agent session
   // When a new agent is spawned and focused, clear the scroll target so the

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -5,7 +5,7 @@ import { tipcClient } from "@renderer/lib/tipc-client"
 import { useAgentStore } from "@renderer/stores"
 import { SessionGrid, SessionTileWrapper } from "@renderer/components/session-grid"
 import { AgentProgress } from "@renderer/components/agent-progress"
-import { MessageCircle, Mic, Plus, Calendar, Trash2, Search, ChevronDown, FolderOpen } from "lucide-react"
+import { MessageCircle, Mic, Plus, Calendar, Trash2, Search, ChevronDown, FolderOpen, CheckCircle2 } from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
 import { Input } from "@renderer/components/ui/input"
 import { Card, CardContent } from "@renderer/components/ui/card"
@@ -383,6 +383,20 @@ export function Component() {
     }
   }
 
+  const handleClearInactiveSessions = async () => {
+    try {
+      await tipcClient.clearInactiveSessions()
+      toast.success("Inactive sessions cleared")
+    } catch (error) {
+      toast.error("Failed to clear inactive sessions")
+    }
+  }
+
+  // Count inactive (completed) sessions
+  const inactiveSessionCount = useMemo(() => {
+    return allProgressEntries.filter(([_, progress]) => progress?.isComplete).length
+  }, [allProgressEntries])
+
   return (
     <div className="flex h-full flex-col">
       {/* Main content area */}
@@ -392,6 +406,21 @@ export function Component() {
           <EmptyState onTextClick={handleTextClick} onVoiceClick={handleVoiceStart} />
         ) : (
           <>
+            {/* Header with clear inactive button */}
+            {inactiveSessionCount > 0 && (
+              <div className="px-4 py-2 flex items-center justify-end bg-muted/20 border-b">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleClearInactiveSessions}
+                  className="gap-2 text-muted-foreground hover:text-foreground"
+                  title="Clear all completed sessions from view (conversations are saved to history)"
+                >
+                  <CheckCircle2 className="h-4 w-4" />
+                  Clear {inactiveSessionCount} completed
+                </Button>
+              </div>
+            )}
             {/* Active sessions grid - includes pending continuation if any */}
             <SessionGrid sessionCount={allProgressEntries.length + (pendingProgress ? 1 : 0)}>
               {/* Pending continuation tile first */}


### PR DESCRIPTION
## Summary

Implements a feature to clear all inactive/completed agents from the sessions view, moving them to history.

Fixes #504

## Changes

### Backend (`apps/desktop/src/main/`)

- **`agent-session-tracker.ts`**: Added `clearCompletedSessions()` method to clear the completed sessions array
- **`renderer-handlers.ts`**: Added `clearInactiveSessions` renderer handler type
- **`tipc.ts`**: Added `clearInactiveSessions` TIPC procedure that:
  - Clears completed sessions from the AgentSessionTracker
  - Broadcasts to all renderer windows to update their stores

### Renderer (`apps/desktop/src/renderer/src/`)

- **`stores/agent-store.ts`**: Added `clearInactiveSessions` action that removes all sessions with `isComplete: true` from `agentProgressById`
- **`hooks/use-store-sync.ts`**: Added listener for `clearInactiveSessions` renderer handler
- **`pages/sessions.tsx`**: 
  - Added "Clear X completed" button that appears when there are completed sessions
  - Button shows count of completed sessions
  - Clicking clears completed sessions from view (conversations remain in Past Sessions history)

## Behavior

**Before:** Completed agent sessions remained in the sessions grid indefinitely, cluttering the view.

**After:**
- When completed sessions exist, a "Clear X completed" button appears in the header
- Clicking the button removes all completed sessions from the current view
- Conversation data is preserved and accessible in "Past Sessions" history
- Active sessions remain unaffected
- Toast notification confirms the action

## Testing

- ✅ TypeScript compilation passes (`pnpm exec tsc --noEmit`)
- ✅ Development build runs successfully (`pnpm dev`)
- ✅ No breaking changes to existing functionality

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author