### PR TITLE
fix(mobile): pass conversation_id to continue existing chat sessions

### DIFF
--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -117,15 +117,22 @@ export class OpenAIClient {
    * @param messages - Chat messages to send
    * @param onToken - Optional callback for streaming text tokens (legacy, for text-only streaming)
    * @param onProgress - Optional callback for agent progress updates (tool calls, results, etc.)
+   * @param conversationId - Optional server-side conversation ID for continuing existing conversations
    * @returns ChatResponse with content and conversation history
    */
   async chat(
     messages: ChatMessage[],
     onToken?: (token: string) => void,
-    onProgress?: OnProgressCallback
+    onProgress?: OnProgressCallback,
+    conversationId?: string
   ): Promise<ChatResponse> {
     const url = this.getUrl('/chat/completions');
-    const body = { model: this.cfg.model, messages, stream: true };
+    const body: Record<string, any> = { model: this.cfg.model, messages, stream: true };
+
+    // Include conversation_id to continue existing server-side conversation (fixes #501)
+    if (conversationId) {
+      body.conversation_id = conversationId;
+    }
 
     console.log('[OpenAIClient] Starting chat request');
     console.log('[OpenAIClient] URL:', url);

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -436,7 +436,10 @@ export default function ChatScreen({ route, navigation }: any) {
     setInput('');
     try {
       let streamingText = '';
-      console.log('[ChatScreen] Starting chat request with', messages.length + 1, 'messages');
+
+      // Get server conversation ID for continuing existing conversations (fixes #501)
+      const serverConversationId = sessionStore.getServerConversationId();
+      console.log('[ChatScreen] Starting chat request with', messages.length + 1, 'messages, conversationId:', serverConversationId || 'new');
       setDebugInfo('Request sent, waiting for response...');
 
       // Handle real-time progress updates
@@ -470,10 +473,16 @@ export default function ChatScreen({ route, navigation }: any) {
         });
       };
 
-      const response = await client.chat([...messages, userMsg], onToken, onProgress);
+      // Pass serverConversationId to continue the same conversation on the server (fixes #501)
+      const response = await client.chat([...messages, userMsg], onToken, onProgress, serverConversationId);
       const finalText = response.content || streamingText;
-      console.log('[ChatScreen] Chat completed');
+      console.log('[ChatScreen] Chat completed, conversationId:', response.conversationId);
       setDebugInfo(`Completed!`);
+
+      // Store the server conversation ID for follow-up messages (fixes #501)
+      if (response.conversationId) {
+        await sessionStore.setServerConversationId(response.conversationId);
+      }
 
       // Process conversation history to extract tool calls and results
       if (response.conversationHistory && response.conversationHistory.length > 0) {

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -15,18 +15,22 @@ export interface SessionStore {
   sessions: Session[];
   currentSessionId: string | null;
   ready: boolean;
-  
+
   // Session management
   createNewSession: () => Session;
   setCurrentSession: (id: string | null) => void;
   deleteSession: (id: string) => Promise<void>;
   clearAllSessions: () => Promise<void>;
-  
+
   // Message management
   addMessage: (role: 'user' | 'assistant', content: string, toolCalls?: any[], toolResults?: any[]) => Promise<void>;
   getCurrentSession: () => Session | null;
   getSessionList: () => SessionListItem[];
   setMessages: (messages: ChatMessage[]) => Promise<void>;
+
+  // Server conversation ID management (for continuing conversations with SpeakMCP server)
+  setServerConversationId: (serverConversationId: string) => Promise<void>;
+  getServerConversationId: () => string | undefined;
 }
 
 async function loadSessions(): Promise<Session[]> {
@@ -209,6 +213,30 @@ export function useSessions(): SessionStore {
     });
   }, [currentSessionId]);
 
+  // Set the server-side conversation ID for the current session (fixes #501)
+  const setServerConversationId = useCallback(async (serverConversationId: string) => {
+    if (!currentSessionId) return;
+
+    setSessions(prev => {
+      const updated = prev.map(session => {
+        if (session.id !== currentSessionId) return session;
+        return {
+          ...session,
+          serverConversationId,
+          updatedAt: Date.now(),
+        };
+      });
+      saveSessions(updated);
+      return updated;
+    });
+  }, [currentSessionId]);
+
+  // Get the server-side conversation ID for the current session
+  const getServerConversationId = useCallback((): string | undefined => {
+    const session = getCurrentSession();
+    return session?.serverConversationId;
+  }, [getCurrentSession]);
+
   return {
     sessions,
     currentSessionId,
@@ -221,6 +249,8 @@ export function useSessions(): SessionStore {
     getCurrentSession,
     getSessionList,
     setMessages,
+    setServerConversationId,
+    getServerConversationId,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #501 - Mobile app was starting new conversations for follow-up messages instead of continuing the existing chat.

## Problem

When sending follow-up messages in the mobile app, each message was creating a new server-side conversation instead of continuing the existing one. This happened because the mobile app wasn't passing the `conversation_id` back to the SpeakMCP server on subsequent requests.

## Solution

Modified the mobile app to:

1. **`openaiClient.ts`**: Added `conversationId` parameter to the `chat()` method and include it as `conversation_id` in the request body when provided

2. **`sessions.ts`**: Added `setServerConversationId()` and `getServerConversationId()` methods to store and retrieve the server-side conversation ID for each session

3. **`ChatScreen.tsx`**: 
   - Get the `serverConversationId` before sending messages
   - Pass it to `client.chat()` to continue the same server-side conversation
   - Store the returned `conversationId` after receiving responses for use in follow-up messages

## Testing

- Desktop TypeScript compilation passes
- Pre-existing test failures in `tts-preprocessing.test.ts` are unrelated to this change (confirmed they also fail on main)

## Files Changed

- `apps/mobile/src/lib/openaiClient.ts`
- `apps/mobile/src/store/sessions.ts`
- `apps/mobile/src/screens/ChatScreen.tsx`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author