### PR TITLE
feat: Add WhatsApp integration for agent communication

### DIFF
--- a/apps/desktop/src/main/config.ts
+++ b/apps/desktop/src/main/config.ts
@@ -123,6 +123,8 @@ const getConfig = () => {
 	    remoteServerLogLevel: "info",
 	    remoteServerCorsOrigins: ["*"],
 
+	    // WhatsApp Integration defaults
+	    whatsappEnabled: false,
 
   }
 

--- a/apps/desktop/src/main/whatsapp-handler.ts
+++ b/apps/desktop/src/main/whatsapp-handler.ts
@@ -1,0 +1,162 @@
+/**
+ * WhatsApp Cloud API Integration for SpeakMCP
+ * 
+ * This module handles incoming WhatsApp messages via webhook and sends responses
+ * back through the WhatsApp Cloud API.
+ */
+
+import { configStore } from "./config"
+import { diagnosticsService } from "./diagnostics"
+
+// Types for WhatsApp Cloud API
+export interface WhatsAppMessage {
+  from: string
+  id: string
+  timestamp: string
+  type: "text" | "image" | "audio" | "video" | "document" | "location" | "contacts" | "interactive" | "button" | "unknown"
+  text?: {
+    body: string
+  }
+}
+
+export interface WhatsAppWebhookPayload {
+  object: string
+  entry: Array<{
+    id: string
+    changes: Array<{
+      value: {
+        messaging_product: string
+        metadata: {
+          display_phone_number: string
+          phone_number_id: string
+        }
+        contacts?: Array<{
+          profile: { name: string }
+          wa_id: string
+        }>
+        messages?: WhatsAppMessage[]
+        statuses?: Array<{
+          id: string
+          status: string
+          timestamp: string
+          recipient_id: string
+        }>
+      }
+      field: string
+    }>
+  }>
+}
+
+// In-memory conversation tracking (phone number -> conversation ID)
+const phoneToConversation = new Map<string, string>()
+
+/**
+ * Extract the text message from a WhatsApp webhook payload
+ */
+export function extractTextMessage(payload: WhatsAppWebhookPayload): { from: string; text: string; phoneNumberId: string } | null {
+  try {
+    const entry = payload.entry?.[0]
+    const change = entry?.changes?.[0]
+    const value = change?.value
+    const message = value?.messages?.[0]
+
+    if (!message || message.type !== "text" || !message.text?.body) {
+      return null
+    }
+
+    return {
+      from: message.from,
+      text: message.text.body,
+      phoneNumberId: value.metadata.phone_number_id,
+    }
+  } catch (error) {
+    diagnosticsService.logError("whatsapp-handler", "Failed to extract text message", error)
+    return null
+  }
+}
+
+/**
+ * Send a text message back to WhatsApp
+ */
+export async function sendWhatsAppMessage(
+  to: string,
+  text: string,
+  phoneNumberId: string
+): Promise<boolean> {
+  const cfg = configStore.get()
+  const accessToken = cfg.whatsappAccessToken
+
+  if (!accessToken) {
+    diagnosticsService.logError("whatsapp-handler", "WhatsApp access token not configured")
+    return false
+  }
+
+  const url = `https://graph.facebook.com/v18.0/${phoneNumberId}/messages`
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        recipient_type: "individual",
+        to,
+        type: "text",
+        text: { body: text },
+      }),
+    })
+
+    if (!response.ok) {
+      const errorBody = await response.text()
+      diagnosticsService.logError("whatsapp-handler", `Failed to send message: ${response.status} ${errorBody}`)
+      return false
+    }
+
+    diagnosticsService.logInfo("whatsapp-handler", `Message sent to ${to}`)
+    return true
+  } catch (error) {
+    diagnosticsService.logError("whatsapp-handler", "Error sending WhatsApp message", error)
+    return false
+  }
+}
+
+/**
+ * Get or create a conversation ID for a phone number
+ */
+export function getConversationIdForPhone(phoneNumber: string): string | undefined {
+  return phoneToConversation.get(phoneNumber)
+}
+
+/**
+ * Store conversation ID for a phone number
+ */
+export function setConversationIdForPhone(phoneNumber: string, conversationId: string): void {
+  phoneToConversation.set(phoneNumber, conversationId)
+}
+
+/**
+ * Clear conversation for a phone number (e.g., when user sends "clear" or "reset")
+ */
+export function clearConversationForPhone(phoneNumber: string): void {
+  phoneToConversation.delete(phoneNumber)
+}
+
+/**
+ * Verify WhatsApp webhook token
+ */
+export function verifyWebhookToken(hubMode: string, hubVerifyToken: string, hubChallenge: string): string | null {
+  const cfg = configStore.get()
+  const expectedToken = cfg.whatsappWebhookVerifyToken
+
+  if (hubMode === "subscribe" && hubVerifyToken === expectedToken) {
+    diagnosticsService.logInfo("whatsapp-handler", "Webhook verified successfully")
+    return hubChallenge
+  }
+
+  diagnosticsService.logWarning("whatsapp-handler", "Webhook verification failed")
+  return null
+}
+

--- a/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
@@ -392,6 +392,111 @@ export function Component() {
             )}
           </ControlGroup>
         )}
+
+        {/* WhatsApp Integration */}
+        {enabled && tunnelStatus?.isRunning && (
+          <ControlGroup
+            title="WhatsApp Integration"
+            endDescription={
+              <div className="break-words whitespace-normal">
+                Connect your WhatsApp Business account to chat with your SpeakMCP agent via WhatsApp. Requires a{" "}
+                <a
+                  href="https://developers.facebook.com/docs/whatsapp/cloud-api/get-started"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="underline"
+                >
+                  Meta WhatsApp Business API
+                </a>{" "}
+                account.
+              </div>
+            }
+          >
+            <Control label="Enable WhatsApp" className="px-3">
+              <Switch
+                checked={cfg.whatsappEnabled ?? false}
+                onCheckedChange={(val) => saveConfig({ whatsappEnabled: val })}
+              />
+            </Control>
+
+            {cfg.whatsappEnabled && (
+              <>
+                <Control label={<ControlLabel label="Phone Number ID" tooltip="Your WhatsApp Business Phone Number ID from Meta Developer Dashboard" />} className="px-3">
+                  <Input
+                    type="text"
+                    placeholder="e.g., 123456789012345"
+                    value={cfg.whatsappPhoneNumberId || ""}
+                    onChange={(e) => saveConfig({ whatsappPhoneNumberId: e.target.value })}
+                  />
+                </Control>
+
+                <Control label={<ControlLabel label="Access Token" tooltip="Permanent access token from Meta Developer Dashboard (starts with EAA...)" />} className="px-3">
+                  <Input
+                    type="password"
+                    placeholder="Your WhatsApp access token"
+                    value={cfg.whatsappAccessToken || ""}
+                    onChange={(e) => saveConfig({ whatsappAccessToken: e.target.value })}
+                  />
+                </Control>
+
+                <Control label={<ControlLabel label="Webhook Verify Token" tooltip="A secret token you create for webhook verification" />} className="px-3">
+                  <div className="flex gap-2">
+                    <Input
+                      type="text"
+                      placeholder="Create a secret verify token"
+                      value={cfg.whatsappWebhookVerifyToken || ""}
+                      onChange={(e) => saveConfig({ whatsappWebhookVerifyToken: e.target.value })}
+                    />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        const token = Math.random().toString(36).substring(2) + Math.random().toString(36).substring(2)
+                        saveConfig({ whatsappWebhookVerifyToken: token })
+                      }}
+                    >
+                      Generate
+                    </Button>
+                  </div>
+                </Control>
+
+                <Control label={<ControlLabel label="Business Account ID" tooltip="Optional: Your WhatsApp Business Account ID" />} className="px-3">
+                  <Input
+                    type="text"
+                    placeholder="e.g., 123456789012345"
+                    value={cfg.whatsappBusinessAccountId || ""}
+                    onChange={(e) => saveConfig({ whatsappBusinessAccountId: e.target.value })}
+                  />
+                </Control>
+
+                {tunnelStatus?.url && (
+                  <Control label={<ControlLabel label="Webhook URL" tooltip="Copy this URL to your Meta Developer Dashboard webhook configuration" />} className="px-3">
+                    <div className="flex flex-col gap-2">
+                      <div className="flex gap-2 items-center">
+                        <code className="text-xs bg-muted px-2 py-1 rounded flex-1 break-all">
+                          {tunnelStatus.url}/webhook/whatsapp
+                        </code>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            navigator.clipboard.writeText(`${tunnelStatus.url}/webhook/whatsapp`)
+                          }}
+                        >
+                          Copy
+                        </Button>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Paste this URL in your Meta Developer Dashboard under WhatsApp → Configuration → Webhook URL.
+                        Subscribe to "messages" webhook field.
+                      </div>
+                    </div>
+                  </Control>
+                )}
+              </>
+            )}
+          </ControlGroup>
+        )}
       </div>
     </div>
   )

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -449,4 +449,11 @@ export type Config = {
   streamStatusWatcherEnabled?: boolean
   streamStatusFilePath?: string
 
+  // WhatsApp Integration Configuration
+  whatsappEnabled?: boolean
+  whatsappPhoneNumberId?: string
+  whatsappAccessToken?: string
+  whatsappWebhookVerifyToken?: string
+  whatsappBusinessAccountId?: string
+
 }


### PR DESCRIPTION
## Summary

Implements issue #493 - WhatsApp integration that allows users to communicate with the SpeakMCP agent through WhatsApp, using the same connection infrastructure as the mobile app.

## Changes

### New Files
- **`apps/desktop/src/main/whatsapp-handler.ts`** - WhatsApp Cloud API handler with:
  - Text message extraction from webhook payloads
  - Message sending via WhatsApp Cloud API
  - Per-phone-number conversation ID tracking
  - Webhook verification support

### Modified Files
- **`apps/desktop/src/main/remote-server.ts`**:
  - Added `GET /webhook/whatsapp` for Meta webhook verification
  - Added `POST /webhook/whatsapp` for message handling
  - Skips API key auth for webhook endpoints (uses verify token instead)
  - Handles long messages by splitting into 4000-char chunks

- **`apps/desktop/src/shared/types.ts`** - Added WhatsApp config types:
  - `whatsappEnabled`
  - `whatsappPhoneNumberId`
  - `whatsappAccessToken`
  - `whatsappWebhookVerifyToken`
  - `whatsappBusinessAccountId`

- **`apps/desktop/src/main/config.ts`** - Added default config values

- **`apps/desktop/src/renderer/src/pages/settings-remote-server.tsx`** - Added WhatsApp settings UI:
  - Toggle to enable/disable WhatsApp integration
  - Input fields for API credentials
  - Webhook URL display with copy button
  - Generate button for verify token
  - Link to Meta Developer docs

## How It Works

1. User enables Remote Server and Cloudflare Tunnel in SpeakMCP
2. User enables WhatsApp integration and configures credentials from Meta Developer Dashboard
3. User copies the webhook URL to Meta Developer Dashboard
4. WhatsApp messages are received via webhook → routed through `runAgent()` → response sent back to WhatsApp
5. Conversation context is maintained per phone number

## Special Commands

Users can send these commands via WhatsApp:
- `clear`, `reset`, or `/new` - Clears conversation history and starts fresh

## Requirements

- Meta WhatsApp Business API account
- Cloudflare Tunnel running (exposes local server to internet)
- Remote Server enabled

## Testing

- ✅ TypeScript compilation passes
- ✅ Build completes successfully
- ✅ No breaking changes to existing functionality

## Usage Instructions

1. Enable Remote Server in Settings → Remote Server
2. Start Cloudflare Tunnel
3. Enable WhatsApp integration
4. Get credentials from [Meta Developer Dashboard](https://developers.facebook.com/docs/whatsapp/cloud-api/get-started)
5. Enter Phone Number ID and Access Token
6. Generate a Webhook Verify Token
7. Copy the Webhook URL to Meta Developer Dashboard → WhatsApp → Configuration
8. Subscribe to `messages` webhook field
9. Start chatting with your agent via WhatsApp!

Fixes #493

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author