### PR TITLE
fix(mobile): pass conversation ID in follow-up messages to continue same server conversation

### DIFF
--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -117,15 +117,22 @@ export class OpenAIClient {
    * @param messages - Chat messages to send
    * @param onToken - Optional callback for streaming text tokens (legacy, for text-only streaming)
    * @param onProgress - Optional callback for agent progress updates (tool calls, results, etc.)
+   * @param conversationId - Optional conversation ID to continue an existing conversation on the server
    * @returns ChatResponse with content and conversation history
    */
   async chat(
     messages: ChatMessage[],
     onToken?: (token: string) => void,
-    onProgress?: OnProgressCallback
+    onProgress?: OnProgressCallback,
+    conversationId?: string
   ): Promise<ChatResponse> {
     const url = this.getUrl('/chat/completions');
-    const body = { model: this.cfg.model, messages, stream: true };
+    const body: Record<string, any> = { model: this.cfg.model, messages, stream: true };
+
+    // Include conversation_id for follow-up messages to continue existing conversations
+    if (conversationId) {
+      body.conversation_id = conversationId;
+    }
 
     console.log('[OpenAIClient] Starting chat request');
     console.log('[OpenAIClient] URL:', url);

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -15,18 +15,21 @@ export interface SessionStore {
   sessions: Session[];
   currentSessionId: string | null;
   ready: boolean;
-  
+
   // Session management
   createNewSession: () => Session;
   setCurrentSession: (id: string | null) => void;
   deleteSession: (id: string) => Promise<void>;
   clearAllSessions: () => Promise<void>;
-  
+
   // Message management
   addMessage: (role: 'user' | 'assistant', content: string, toolCalls?: any[], toolResults?: any[]) => Promise<void>;
   getCurrentSession: () => Session | null;
   getSessionList: () => SessionListItem[];
   setMessages: (messages: ChatMessage[]) => Promise<void>;
+
+  // Server conversation management (for continuing conversations on SpeakMCP server)
+  setServerConversationId: (conversationId: string) => Promise<void>;
 }
 
 async function loadSessions(): Promise<Session[]> {
@@ -209,6 +212,24 @@ export function useSessions(): SessionStore {
     });
   }, [currentSessionId]);
 
+  // Set server conversation ID for continuing conversations on SpeakMCP server
+  const setServerConversationId = useCallback(async (conversationId: string) => {
+    if (!currentSessionId) return;
+
+    setSessions(prev => {
+      const updated = prev.map(session => {
+        if (session.id !== currentSessionId) return session;
+        return {
+          ...session,
+          serverConversationId: conversationId,
+          updatedAt: Date.now(),
+        };
+      });
+      saveSessions(updated);
+      return updated;
+    });
+  }, [currentSessionId]);
+
   return {
     sessions,
     currentSessionId,
@@ -221,6 +242,7 @@ export function useSessions(): SessionStore {
     getCurrentSession,
     getSessionList,
     setMessages,
+    setServerConversationId,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes #501 - Mobile app was starting new conversations/sessions for follow-up messages instead of continuing the existing chat.

## Root Cause

The mobile client was receiving `conversation_id` from the server response but not sending it back in follow-up requests. This caused the server to create a new conversation for each message.

## Changes

### `apps/mobile/src/lib/openaiClient.ts`
- Accept optional `conversationId` parameter in `chat()` method
- Include `conversation_id` in request body when provided

### `apps/mobile/src/screens/ChatScreen.tsx`
- Get `serverConversationId` from current session before sending messages
- Pass it to `client.chat()` for follow-up messages
- Save the returned `conversationId` to the session store after receiving response

### `apps/mobile/src/store/sessions.ts`
- Add `setServerConversationId()` method to persist the server's conversation ID for follow-up messages

## Testing

- TypeScript compilation passes for all packages (mobile, desktop, shared)
- Mobile web mode starts successfully

## How it works

1. First message in a chat: No `conversation_id` sent → Server creates new conversation → Returns `conversation_id` in response
2. Mobile stores the `conversation_id` in the session's `serverConversationId` field
3. Follow-up messages: Mobile sends `conversation_id` in request → Server continues the same conversation
4. Session persistence ensures the `serverConversationId` survives app restarts

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author