### PR TITLE
Add iOS build configuration

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -15,6 +15,7 @@
     },
     "ios": {
       "supportsTablet": true,
+      "bundleIdentifier": "com.aj47.speakmcp",
       "infoPlist": {
         "NSMicrophoneUsageDescription": "This app uses the microphone for voice input.",
         "NSSpeechRecognitionUsageDescription": "This app uses speech recognition to transcribe your voice.",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,30 @@
+{
+  "cli": {
+    "version": ">= 16.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "ios": {
+        "resourceClass": "m-medium"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}
+


### PR DESCRIPTION
## Summary
Adds iOS build configuration to enable building `.ipa` files for the mobile app.

## Changes
- **app.json**: Added iOS bundle identifier (`com.aj47.speakmcp`)
- **eas.json**: Added EAS build configuration with three profiles:
  - `development`: For development client builds (simulator)
  - `preview`: For internal distribution (device)
  - `production`: For App Store distribution

## Testing
Successfully built an unsigned `.ipa` file using `expo prebuild` and `xcodebuild`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author