### PR TITLE
feat: Add kill switch tools for agent management (#522)

### DIFF
--- a/apps/desktop/src/main/builtin-tools.ts
+++ b/apps/desktop/src/main/builtin-tools.ts
@@ -535,6 +535,9 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
+    // Cancel any pending tool approvals to prevent sessions from hanging
+    toolApprovalManager.cancelAllApprovals()
+
     // Perform emergency stop
     const { before, after } = await emergencyStopAll()
 


### PR DESCRIPTION
## Summary

Adds three new MCP tools to the built-in `speakmcp-settings` server for managing running agent sessions:

- `list_running_agents` - Lists all currently running agent sessions with details
- `kill_agent` - Terminates a specific agent by session ID
- `kill_all_agents` - Emergency stop for all running agents

## Implementation Details

- Exposes existing emergency stop infrastructure via MCP tools
- Uses `agentSessionTracker` to list and manage sessions
- Uses `agentSessionStateManager` to stop individual sessions
- Uses `emergencyStopAll()` for emergency shutdown of all agents
- All tools return JSON-formatted results with success/error status

## Tool Definitions

### list_running_agents
- **Name:** `speakmcp-settings:list_running_agents`
- **Description:** List all currently running agent sessions with their details (session ID, title, status, iteration count, runtime)
- **Parameters:** None
- **Returns:** JSON with agents array and count

### kill_agent
- **Name:** `speakmcp-settings:kill_agent`
- **Description:** Terminate a specific agent session by its session ID
- **Parameters:** 
  - `sessionId` (string, required): The session ID of the agent to terminate
- **Returns:** JSON with success status and message

### kill_all_agents
- **Name:** `speakmcp-settings:kill_all_agents`
- **Description:** Emergency stop ALL running agent sessions
- **Parameters:** None
- **Returns:** JSON with success status, sessions terminated count, and processes killed count

## Testing

- ✅ TypeScript compilation passes (main process)
- ✅ App builds and runs successfully
- ✅ Tools are registered in the built-in speakmcp-settings server
- ✅ Manual testing guide created (see test-kill-switch.md)
- ⏳ Manual testing pending (requires running app with active agent sessions)

## Related Issue

Closes #522