### PR TITLE
feat(mobile): add new chat button in conversation view header

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -214,6 +214,16 @@ export default function ChatScreen({ route, navigation }: any) {
             </View>
           </TouchableOpacity>
           <TouchableOpacity
+            onPress={() => {
+              sessionStore.createNewSession();
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Start new chat"
+            style={{ paddingHorizontal: 8, paddingVertical: 6 }}
+          >
+            <Text style={{ fontSize: 18, color: theme.colors.foreground }}>✏️</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
             onPress={() => navigation.navigate('Settings')}
             accessibilityRole="button"
             accessibilityLabel="Settings"
@@ -224,7 +234,7 @@ export default function ChatScreen({ route, navigation }: any) {
         </View>
       ),
     });
-  }, [navigation, handsFree, handleKillSwitch, responding, theme, isDark]);
+  }, [navigation, handsFree, handleKillSwitch, responding, theme, isDark, sessionStore]);
 
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);


### PR DESCRIPTION
## Summary

Adds a new chat button to the conversation view header on mobile, allowing users to quickly create a new chat without navigating away from the current conversation.

## Changes

- Added a pencil icon button (✏️) to the `headerRight` section of `ChatScreen`
- Button calls `sessionStore.createNewSession()` to create a new chat
- Positioned before the settings button for easy access
- Added proper accessibility label ("Start new chat")
- Added `sessionStore` to the `useLayoutEffect` dependency array

## Current Behavior

There is no easy way to create a new chat when viewing an individual conversation on mobile. Users have to navigate back to the session list to create a new chat.

## New Behavior

A pencil icon button (✏️) is now available in the conversation view header that allows users to quickly create a new chat without having to navigate away from the current conversation.

## Testing

- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ⚠️ Mobile app web mode has a pre-existing expo/dotenv-expand compatibility issue on Node.js v25.2.1 (exists on main as well)

## Platform

- Mobile

Fixes #535

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author