### PR TITLE
fix: add .ipa to gitignore to prevent binary commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ augment.mjs
 *.mobileprovision
 *.orig.*
 web-build/
+*.ipa
 
 # Turborepo / build cache
 .turbo


### PR DESCRIPTION
## Summary

Add `*.ipa` to root `.gitignore` to prevent accidentally committing iOS app bundles.

## Changes

- Add `*.ipa` pattern to root `.gitignore`

---
Split from #539 to keep PRs focused.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author