### PR TITLE
fix(mobile): remove duplicate new chat button in header

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -237,16 +237,6 @@ export default function ChatScreen({ route, navigation }: any) {
             </View>
           </TouchableOpacity>
           <TouchableOpacity
-            onPress={() => {
-              sessionStore.createNewSession();
-            }}
-            accessibilityRole="button"
-            accessibilityLabel="Start new chat"
-            style={{ paddingHorizontal: 8, paddingVertical: 6 }}
-          >
-            <Text style={{ fontSize: 18, color: theme.colors.foreground }}>✏️</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
             onPress={() => navigation.navigate('Settings')}
             accessibilityRole="button"
             accessibilityLabel="Settings"


### PR DESCRIPTION
## Summary

Removes the duplicate "new chat" button from the mobile chat screen header.

Fixes #546

## Problem

The mobile chat screen header contained two buttons that performed the same action (starting a new chat):

- **✚ (plus icon)** - called `handleNewChat`
- **✏️ (pencil icon)** - called `sessionStore.createNewSession()`

This was confusing for users and cluttered the header UI.

## Solution

Removed the duplicate pencil icon (✏️) button, keeping only the plus icon (✚) which is more universally recognized for "new" actions.

### Header Icons After Fix

1. Loading spinner (when responding)
2. ✚ New chat
3. ⏹ Emergency stop
4. 🎙️ Hands-free toggle
5. ⚙️ Settings

## Testing

- [x] TypeScript compilation passes
- [x] Mobile app starts in web mode and bundles successfully
- [x] No breaking changes

## Changes

- **`apps/mobile/src/screens/ChatScreen.tsx`**: Removed duplicate pencil icon button from headerRight section (lines 239-248)

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author