### PR TITLE
fix: hide scrollbar by default in active sessions, show on hover

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -385,9 +385,9 @@ export function Component() {
   }, [allProgressEntries])
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="group/tile flex h-full flex-col">
       {/* Main content area */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto scrollbar-hide-until-hover">
         {/* Show empty state when no sessions and no pending */}
         {allProgressEntries.length === 0 && !pendingProgress ? (
           <EmptyState onTextClick={handleTextClick} onVoiceClick={handleVoiceStart} />


### PR DESCRIPTION
## Summary

Fixes #442

The scrollbar in the active sessions view is now hidden by default and only appears when the mouse hovers over it.

## Changes

- Added `group/tile` class to the parent container in `sessions.tsx`
- Added `scrollbar-hide-until-hover` class to the scrollable content area

This leverages the existing CSS utility class that was already designed for this exact purpose with the `group/tile` hover mechanism, matching the behavior of session tiles.

## Testing

- All existing tests pass
- The scrollbar is hidden by default in the sessions view
- The scrollbar appears when hovering over the sessions area

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author