### PR TITLE
fix: clear conversation ID when triggering agent mode via keybind

### DIFF
--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -481,6 +481,11 @@ export function Component() {
       textInputMutation.reset()
       mcpTextInputMutation.reset()
 
+      // Clear any existing conversation ID to ensure a fresh conversation is started
+      // This prevents the bug where previous session messages are included when
+      // submitting a new message via the text input keybind
+      endConversation()
+
       // Show text input and focus
       setShowTextInput(true)
       // Panel window is already shown by the keyboard handler
@@ -491,7 +496,7 @@ export function Component() {
     })
 
     return unlisten
-  }, [])
+  }, [endConversation])
 
   useEffect(() => {
     const unlisten = rendererHandlers.hideTextInput.listen(() => {
@@ -540,6 +545,15 @@ export function Component() {
       // Track if recording was triggered via UI button click vs keyboard shortcut
       // When true, we show "Enter" as the submit hint instead of "Release keys"
       setFromButtonClick(data?.fromButtonClick ?? false)
+
+      // If recording is NOT from a tile and no explicit conversationId was passed,
+      // clear any existing conversation ID to ensure a fresh conversation is started.
+      // This prevents the bug where previous session messages are included when
+      // submitting a new message via the agent mode keybind.
+      if (!data?.fromTile && !data?.conversationId) {
+        endConversation()
+      }
+
       setMcpMode(true)
       mcpModeRef.current = true
       // Mode sizing is now applied in main before show; avoid duplicate calls here
@@ -548,7 +562,7 @@ export function Component() {
     })
 
     return unlisten
-  }, [])
+  }, [endConversation])
 
   useEffect(() => {
     const unlisten = rendererHandlers.finishMcpRecording.listen(() => {


### PR DESCRIPTION
## Summary

Fixes #553

When submitting a new message using the agent mode keybind (command/control/alt), the submission was incorrectly including all the previous active session initial user messages. This was because the `currentConversationId` was not being cleared when the text input or MCP recording was triggered via keybind.

## Changes

The fix clears the `currentConversationId` (by calling `endConversation()`) when:

1. **Text input is shown via keybind** (`showTextInput` handler) - ensures that typing a new message via the text input keybind starts a fresh conversation

2. **MCP recording is started via keybind** (`startMcpRecording` handler) - but only when:
   - Not from a tile (`!data?.fromTile`)
   - No explicit conversationId was passed (`!data?.conversationId`)

This ensures that new messages submitted via keybinds start fresh conversations instead of inheriting history from previous sessions, while still allowing explicit conversation continuation from tiles or history.

## Testing

1. Start an agent session and let it complete
2. Use the text input keybind (e.g., Ctrl+T) to open text input
3. Submit a new message
4. Verify that the new message does NOT include history from the previous session

Same test for MCP recording:
1. Start an agent session and let it complete
2. Use the agent mode keybind (e.g., hold Ctrl+Alt) to start recording
3. Speak and release to submit
4. Verify that the new message does NOT include history from the previous session

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author