### PR TITLE
feat: add setting to disable floating panel auto-show

### DIFF
--- a/apps/desktop/src/main/config.ts
+++ b/apps/desktop/src/main/config.ts
@@ -64,6 +64,8 @@ const getConfig = () => {
     panelNormalModeSize: undefined,
     panelAgentModeSize: undefined,
     panelTextInputModeSize: undefined,
+    // Floating panel auto-show - when true, panel auto-shows during agent sessions
+    floatingPanelAutoShow: true,
     // Theme preference defaults
     themePreference: "system",
 

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -4,6 +4,7 @@ import { RendererHandlers } from "./renderer-handlers"
 import { AgentProgressUpdate } from "../shared/types"
 import { isPanelAutoShowSuppressed, agentSessionStateManager } from "./state"
 import { agentSessionTracker } from "./agent-session-tracker"
+import { configStore } from "./config"
 import { logApp } from "./debug"
 
 export async function emitAgentProgress(update: AgentProgressUpdate): Promise<void> {
@@ -44,11 +45,17 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
 
   logApp(`[emitAgentProgress] Panel visible: ${panel.isVisible()}`)
 
+  // Check if floating panel auto-show is globally disabled in settings
+  const config = configStore.get()
+  const floatingPanelAutoShowEnabled = config.floatingPanelAutoShow !== false
+
   if (!panel.isVisible() && update.sessionId) {
     const isSnoozed = agentSessionTracker.isSessionSnoozed(update.sessionId)
-    logApp(`[emitAgentProgress] Panel not visible. Session ${update.sessionId} snoozed check: ${isSnoozed}`)
+    logApp(`[emitAgentProgress] Panel not visible. Session ${update.sessionId} snoozed check: ${isSnoozed}, floatingPanelAutoShow: ${floatingPanelAutoShowEnabled}`)
 
-    if (isPanelAutoShowSuppressed()) {
+    if (!floatingPanelAutoShowEnabled) {
+      logApp(`[emitAgentProgress] Floating panel auto-show disabled in settings; NOT showing panel for session ${update.sessionId}`)
+    } else if (isPanelAutoShowSuppressed()) {
       logApp(`[emitAgentProgress] Panel auto-show suppressed; NOT showing panel for session ${update.sessionId}`)
     } else if (!isSnoozed) {
       logApp(`[emitAgentProgress] Showing panel for non-snoozed session ${update.sessionId}`)

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -705,6 +705,16 @@ export function Component() {
             />
           </Control>
 
+          <Control label={<ControlLabel label="Auto-Show Floating Panel" tooltip="When enabled, the floating panel automatically appears during agent sessions. When disabled, the panel only appears when manually triggered via hotkeys or menu. You can still access agent progress in the main window." />} className="px-3">
+            <Switch
+              checked={configQuery.data?.floatingPanelAutoShow !== false}
+              onCheckedChange={(value) => {
+                saveConfig({
+                  floatingPanelAutoShow: value,
+                })
+              }}
+            />
+          </Control>
 
         </ControlGroup>
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -380,6 +380,11 @@ export type Config = {
   panelAgentModeSize?: { width: number; height: number }
   panelTextInputModeSize?: { width: number; height: number }
 
+  // Floating Panel Auto-Show Configuration
+  // When false, the floating panel will not automatically appear during agent sessions
+  // Users can still manually access the panel via hotkeys, tray menu, or UI
+  floatingPanelAutoShow?: boolean
+
   // API Retry Configuration
   apiRetryCount?: number
   apiRetryBaseDelay?: number


### PR DESCRIPTION
## Summary

Adds a new setting to completely disable the floating panel from automatically appearing during agent sessions.

## Changes

- **New config option**: `floatingPanelAutoShow` (default: `true`)
- **Settings UI**: Added toggle in Settings > Panel Position section
- **State management**: Updated `emit-agent-progress.ts` to check this setting before auto-showing the panel

## Behavior

- When **enabled** (default): Floating panel auto-shows during agent sessions (existing behavior)
- When **disabled**: Floating panel will NOT auto-appear during agent sessions
  - Users can still manually access the panel via:
    - Hotkeys (voice dictation, text input)
    - Tray menu
    - "Show in panel" buttons in the main window
  - Agent progress is still visible in the main window

## Testing

1. Open Settings > Panel Position
2. Toggle "Auto-Show Floating Panel" off
3. Start an agent session (via voice or text)
4. Verify the floating panel does NOT auto-appear
5. Verify you can still manually show the panel via hotkeys/tray
6. Toggle the setting back on and verify auto-show works again

Fixes #566

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author