### PR TITLE
fix: prevent message clicks in session tiles from opening blank panel

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1625,7 +1625,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         {!isCollapsed && (
           <>
             {/* Message Stream */}
-            <div className="relative flex-1 min-h-0">
+            <div className="relative flex-1 min-h-0" onClick={(e) => e.stopPropagation()}>
               <div
                 ref={scrollContainerRef}
                 onScroll={handleScroll}

--- a/apps/desktop/src/renderer/src/components/session-tile.tsx
+++ b/apps/desktop/src/renderer/src/components/session-tile.tsx
@@ -206,7 +206,7 @@ export function SessionTile({
         <>
           {/* Conversation content - scrollable */}
           <ScrollArea className="flex-1 min-h-0">
-            <div className="p-3 space-y-3">
+            <div className="p-3 space-y-3" onClick={(e) => e.stopPropagation()}>
               {messages.length === 0 ? (
                 <div className="text-center text-muted-foreground text-sm py-4">
                   {isActive ? "Starting..." : "No messages"}


### PR DESCRIPTION
## Summary

Fixes #582 - Bug: Clicking message in tiled session opens blank always-on-top panel

## Problem

When clicking on any message in a tiled session within the main app session view, a blank always-on-top panel would open. This happened because click events on messages inside the tile were bubbling up to the tile's `onClick` handler, which triggered `handleFocusSession` and opened the panel window.

## Solution

Added `stopPropagation()` to the message content areas in both:
- `session-tile.tsx`: Added onClick handler with stopPropagation to the conversation content div
- `agent-progress.tsx`: Added onClick handler with stopPropagation to the message stream div in the tile variant

This allows users to interact with message content (e.g., selecting text, clicking links) without triggering the panel to open.

## Testing

- [x] Build passes
- [x] All tests pass (36 tests)
- [ ] Manual testing: Click on messages in tiled sessions - panel should not open
- [ ] Manual testing: Click on tile header/empty areas - panel should still open as expected

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author