### PR TITLE
fix: preserve tool call visibility during follow-up verification

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -948,12 +948,17 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   const agentProgressById = useAgentStore((s) => s.agentProgressById)
 
   // Helper to toggle expansion state for a specific item
-  // Accepts currentExpanded to handle items that default to expanded (like tool executions)
-  // when they haven't been explicitly toggled yet
-  const toggleItemExpansion = (itemKey: string, currentExpanded: boolean) => {
+  // Uses defaultExpanded fallback for items that haven't been explicitly toggled yet
+  // (like tool executions which default to expanded)
+  // By deriving the current state from prev inside the setter, this is resilient to
+  // batched updates (e.g., double-clicks will correctly round-trip)
+  const toggleItemExpansion = (itemKey: string, defaultExpanded: boolean) => {
     setExpandedItems(prev => {
-      const to = !currentExpanded
-      logExpand("AgentProgress", "toggle", { itemKey, from: currentExpanded, to })
+      // Use prev[itemKey] if it exists (item was explicitly toggled before),
+      // otherwise use the default expanded state for this item type
+      const from = itemKey in prev ? prev[itemKey] : defaultExpanded
+      const to = !from
+      logExpand("AgentProgress", "toggle", { itemKey, from, to })
       return {
         ...prev,
         [itemKey]: to,


### PR DESCRIPTION
## Summary

Fixes #600

This PR fixes the issue where tool calls and assistant messages become hidden/collapsed when the assistant performs supplementary follow-up verification checks.

## Problem

When the agent performs follow-up verification to check if the user's request was achieved, previous tool calls and assistant messages were being hidden/collapsed. This made it difficult for users to see what tools were called during the agent's work.

## Solution

Made tool execution bubbles expanded by default in both the "tile" and "overlay" variants of the `AgentProgress` component. Previously, the default expansion state was `false` for all items. Now:

- Tool execution items (`kind === "tool_execution"`) are expanded by default
- Users can still manually collapse them if they prefer a more compact view
- The final assistant message in overlay mode is still expanded by default when the agent is complete

## Changes

- `apps/desktop/src/renderer/src/components/agent-progress.tsx`:
  - Modified tile variant expansion logic (lines ~1636-1644)
  - Modified overlay variant expansion logic (lines ~1822-1829)

## Testing

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] Desktop app starts successfully with `pnpm dev -- --debug`
- [x] Tool execution bubbles are now expanded by default

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author