### PR TITLE
fix(mobile): prevent duplicate tool output display

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -617,13 +617,24 @@ export default function ChatScreen({ route, navigation }: any) {
           if (historyMsg.role === 'tool' && messages.length > 0) {
             const lastMessage = messages[messages.length - 1];
             if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              // Merge toolResults into the existing assistant message
-              lastMessage.toolResults = [
-                ...(lastMessage.toolResults || []),
-                ...(historyMsg.toolResults || []),
-              ];
-              // Skip adding this as a separate message
-              continue;
+              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
+              const hasContent = historyMsg.content && historyMsg.content.trim().length > 0;
+
+              if (hasToolResults) {
+                // Merge toolResults into the existing assistant message
+                lastMessage.toolResults = [
+                  ...(lastMessage.toolResults || []),
+                  ...historyMsg.toolResults,
+                ];
+                // Also preserve any content from the tool message (e.g., error messages)
+                if (hasContent) {
+                  lastMessage.content = (lastMessage.content || '') +
+                    (lastMessage.content ? '\n' : '') + historyMsg.content;
+                }
+                // Skip adding this as a separate message only when we merged results
+                continue;
+              }
+              // If tool message has content but no toolResults, fall through to add it as a message
             }
           }
 
@@ -819,13 +830,24 @@ export default function ChatScreen({ route, navigation }: any) {
           if (historyMsg.role === 'tool' && newMessages.length > 0) {
             const lastMessage = newMessages[newMessages.length - 1];
             if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              // Merge toolResults into the existing assistant message
-              lastMessage.toolResults = [
-                ...(lastMessage.toolResults || []),
-                ...(historyMsg.toolResults || []),
-              ];
-              // Skip adding this as a separate message
-              continue;
+              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
+              const hasContent = historyMsg.content && historyMsg.content.trim().length > 0;
+
+              if (hasToolResults) {
+                // Merge toolResults into the existing assistant message
+                lastMessage.toolResults = [
+                  ...(lastMessage.toolResults || []),
+                  ...historyMsg.toolResults,
+                ];
+                // Also preserve any content from the tool message (e.g., error messages)
+                if (hasContent) {
+                  lastMessage.content = (lastMessage.content || '') +
+                    (lastMessage.content ? '\n' : '') + historyMsg.content;
+                }
+                // Skip adding this as a separate message only when we merged results
+                continue;
+              }
+              // If tool message has content but no toolResults, fall through to add it as a message
             }
           }
 


### PR DESCRIPTION
## Summary

Fixes #614 - Mobile UI: Tool output displayed twice

## Problem

On mobile UI, tool call output was appearing twice. This happened because the server sends conversation history as:
1. An `assistant` message with `toolCalls` (the calls to make)
2. A `tool` message with `toolResults` (the results)

The mobile app was rendering both as separate messages, causing duplication.

## Solution

Merge tool results from `tool` role messages into the preceding `assistant` message that contains the corresponding `toolCalls`. This creates a single unified message with both the tool calls and their results.

The fix was applied in two places in `ChatScreen.tsx`:
1. `convertProgressToMessages()` - handles streaming progress updates
2. Final response handling - handles completed responses

## Testing

- [ ] Trigger a tool call on mobile UI
- [ ] Verify tool output appears only once
- [ ] Verify both tool call parameters and results are visible in the same card

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author