### PR TITLE
feat(ui): add resizable textareas for guidelines and system prompt

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings-tools.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-tools.tsx
@@ -396,7 +396,7 @@ DOMAIN-SPECIFIC RULES:
                 value={additionalGuidelines}
                 onChange={(e) => handleGuidelinesChange(e.target.value)}
                 rows={8}
-                className="font-mono text-sm"
+                className="font-mono text-sm resize-y min-h-[120px] max-h-[400px]"
                 placeholder={defaultAdditionalGuidelines}
               />
 
@@ -474,7 +474,7 @@ DOMAIN-SPECIFIC RULES:
                       value={customSystemPrompt}
                       onChange={(e) => handleSystemPromptChange(e.target.value)}
                       rows={12}
-                      className="font-mono text-xs"
+                      className="font-mono text-xs resize-y min-h-[180px] max-h-[500px]"
                     />
                     <div className="flex gap-2 flex-wrap">
                       <Button
@@ -556,6 +556,7 @@ DOMAIN-SPECIFIC RULES:
                   onChange={(e) => setNewProfileGuidelines(e.target.value)}
                   placeholder="Optional additional guidelines for this profile"
                   rows={6}
+                  className="resize-y min-h-[100px] max-h-[300px]"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary

Fixes #621 - Adds CSS resize functionality to the textarea components in profile settings.

## Changes

### UI Enhancements
- **Additional Guidelines textarea** - Added `resize-y` with `min-h-[120px]` and `max-h-[400px]`
- **Base System Prompt textarea** - Added `resize-y` with `min-h-[180px]` and `max-h-[500px]`
- **New Profile Guidelines textarea** (in Create Profile dialog) - Added `resize-y` with `min-h-[100px]` and `max-h-[300px]`

### How It Works
The `resize-y` Tailwind class overrides the default `resize-none` from the Textarea component, enabling vertical resizing. The `min-h` and `max-h` constraints prevent the textareas from becoming too small (unreadable) or too large (layout-breaking).

## Benefits

- ✅ Better user experience when working with longer prompts
- ✅ Users can expand textareas to see more content at once
- ✅ Height constraints prevent layout issues
- ✅ Consistent with modern web UI patterns

## Testing

- [x] TypeScript compilation passes
- [x] Build completes successfully
- [x] Resize handle visible on all three textareas

## Files Changed

- `apps/desktop/src/renderer/src/pages/settings-tools.tsx`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author