### PR TITLE
feat: show subtle 'Press Esc to close' hint in agent progress overlay panel

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1901,14 +1901,12 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         className="flex-shrink-0"
       />
 
-      {/* Esc hint and progress bar footer - only render when there's content to display */}
-      {(variant === "overlay" || !isComplete) && (
+      {/* Overlay variant: Esc hint and progress bar in styled footer */}
+      {variant === "overlay" && (
         <div className="flex items-center justify-between px-3 py-1 bg-muted/10 border-t border-border/20 flex-shrink-0">
-          {variant === "overlay" && (
-            <span className="text-[10px] text-muted-foreground/50">Press Esc to close</span>
-          )}
+          <span className="text-[10px] text-muted-foreground/50">Press Esc to close</span>
           {!isComplete && (
-            <div className={`flex-1 h-0.5 bg-muted/50 rounded-full overflow-hidden ${variant === "overlay" ? "ml-3" : ""}`}>
+            <div className="flex-1 ml-3 h-0.5 bg-muted/50 rounded-full overflow-hidden">
               <div
                 className="h-full bg-primary transition-all duration-500 ease-out"
                 style={{
@@ -1917,6 +1915,18 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               />
             </div>
           )}
+        </div>
+      )}
+
+      {/* Default variant: Original slim full-width progress bar */}
+      {variant !== "overlay" && !isComplete && (
+        <div className="h-0.5 w-full bg-muted/50">
+          <div
+            className="h-full bg-primary transition-all duration-500 ease-out"
+            style={{
+              width: `${Math.min(100, (currentIteration / maxIterations) * 100)}%`,
+            }}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Adds a subtle "Press Esc to close" hint to the agent progress overlay panel, improving discoverability of the keyboard shortcut.

Fixes #617

## Changes

### Agent Progress Panel (`agent-progress.tsx`)
- Added footer section with "Press Esc to close" hint text
- Hint only appears in the `overlay` variant (floating panel window)
- Text is visually de-emphasized with very small size (`text-[10px]`) and muted color (`text-muted-foreground/50`)
- Integrated with existing progress bar in a unified footer section

## Acceptance Criteria

- ✅ When agent progress overlay is visible, a subtle hint `Press Esc to close` is displayed
- ✅ Hint is visually de-emphasized (small text) and doesn't interfere with progress content/layout
- ✅ Pressing Esc closes the panel as before

## Testing

- ✅ TypeScript compilation passes
- ✅ All 36 tests pass

## UI Preview

The hint appears at the bottom of the overlay panel next to the progress bar:
```
[ Processing... ]
[ content... ]
Press Esc to close     ████████░░░░░░░░
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author