### PR TITLE
docs: add comprehensive build instructions for signed Mac releases

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,153 @@
+# Building SpeakMCP
+
+This guide covers building signed release versions of SpeakMCP for distribution.
+
+## Prerequisites
+
+- **Node.js 18+** and **pnpm**
+- **Rust toolchain** (for the keyboard/input binary)
+- **Xcode** (for macOS builds)
+- **Apple Developer Account** (for code signing)
+
+## macOS Signed Release Build
+
+### Step 1: Find Your Signing Identity
+
+First, list your available code signing certificates:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+You'll see output like:
+```
+1) XXXXXXXX "Apple Development: your@email.com (XXXXXXXX)"
+2) XXXXXXXX "Developer ID Application: Your Name (TEAMID)"
+3) XXXXXXXX "3rd Party Mac Developer Application: Your Name (TEAMID)"
+```
+
+For distribution outside the App Store, you need **"Developer ID Application"**.
+
+### Step 2: Set Environment Variables
+
+**Important:** Use only the name portion WITHOUT the "Developer ID Application:" prefix.
+
+```bash
+# ✅ CORRECT - Just the name and team ID
+export CSC_NAME="Your Name (TEAMID)"
+
+# ❌ WRONG - Don't include the prefix
+# export CSC_NAME="Developer ID Application: Your Name (TEAMID)"
+```
+
+**Required variables for signed builds:**
+```bash
+export CSC_NAME="Your Name (TEAMID)"              # For app signing
+export APPLE_DEVELOPER_ID="Your Name (TEAMID)"    # For Rust binary signing  
+export ENABLE_HARDENED_RUNTIME=true               # Required for notarization
+```
+
+**Additional variables for notarization (recommended for public distribution):**
+```bash
+export APPLE_TEAM_ID="TEAMID"                     # Your 10-character Team ID
+export APPLE_ID="your@email.com"                  # Your Apple ID email
+export APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"  # From appleid.apple.com
+```
+
+> **Generating App-Specific Password:** Go to https://appleid.apple.com → Sign In → 
+> App-Specific Passwords → Generate a password for "SpeakMCP Notarization"
+
+### Step 3: Build the Rust Binary
+
+```bash
+cd apps/desktop
+pnpm run build-rs
+```
+
+This builds and signs the native keyboard/input binary.
+
+### Step 4: Build the Electron App
+
+```bash
+# Build the app (skips type checking for faster builds)
+npx electron-vite build
+
+# Build signed DMG, ZIP, and PKG for both Intel and Apple Silicon
+npx electron-builder --mac --config electron-builder.config.cjs --publish=never
+```
+
+### Step 5: Verify Output
+
+Built artifacts will be in `apps/desktop/dist/`:
+- `SpeakMCP-X.X.X-arm64.dmg` - Apple Silicon DMG
+- `SpeakMCP-X.X.X-x64.dmg` - Intel DMG
+- `SpeakMCP-X.X.X-arm64.zip` - Apple Silicon ZIP (for auto-updates)
+- `SpeakMCP-X.X.X-x64.zip` - Intel ZIP
+- `SpeakMCP-X.X.X-arm64.pkg` - Apple Silicon installer
+- `SpeakMCP-X.X.X-x64.pkg` - Intel installer
+
+## Quick One-Liner
+
+For a complete signed build (replace with your actual name and team ID):
+
+```bash
+cd apps/desktop && \
+export CSC_NAME="Your Name (TEAMID)" && \
+export APPLE_DEVELOPER_ID="Your Name (TEAMID)" && \
+export ENABLE_HARDENED_RUNTIME=true && \
+pnpm run build-rs && \
+npx electron-vite build && \
+npx electron-builder --mac --config electron-builder.config.cjs --publish=never
+```
+
+## Troubleshooting
+
+### "Please remove prefix 'Developer ID Application:'"
+
+You included the certificate type prefix. Use just the name:
+```bash
+# Wrong
+export CSC_NAME="Developer ID Application: John Doe (ABC123XYZ)"
+
+# Correct  
+export CSC_NAME="John Doe (ABC123XYZ)"
+```
+
+### "No identity found for signing"
+
+Your certificate isn't installed or doesn't match. Run:
+```bash
+security find-identity -v -p codesigning
+```
+
+### "Notarization skipped"
+
+This happens when `APPLE_TEAM_ID`, `APPLE_ID`, or `APPLE_APP_SPECIFIC_PASSWORD` aren't set. 
+The app will still be signed but users may see Gatekeeper warnings on first launch.
+
+### TypeScript errors during build
+
+The `pnpm build:mac:signed` command runs type checking which may fail due to dependency 
+version mismatches. Use the direct commands above which skip type checking:
+```bash
+npx electron-vite build  # Builds without type checking
+npx electron-builder --mac --config electron-builder.config.cjs --publish=never
+```
+
+## Using the Build Script
+
+For convenience, there's a build script that handles all platforms:
+
+```bash
+# Build all platforms
+./scripts/build-release.sh
+
+# macOS only
+./scripts/build-release.sh --mac-only
+
+# Skip specific platforms
+./scripts/build-release.sh --skip-ios --skip-android
+```
+
+See the script header for all required environment variables.
+

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ pnpm build:mac    # macOS build (Apple Silicon + Intel)
 pnpm build:win    # Windows build (x64)
 pnpm build:linux  # Linux build (x64)
 
+# Signed release builds (see BUILDING.md for details)
+./scripts/build-release.sh --mac-only
+
 # Testing
 pnpm test         # Run test suite
 pnpm test:run     # Run tests once (CI mode)

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# SpeakMCP Release Build Script
+# Builds signed DMG (macOS), IPA (iOS), and APK (Android) for distribution
+#
+# For detailed instructions, see BUILDING.md
+#
+# Environment Variables Required:
+#
+# macOS DMG signing:
+#   CSC_NAME             - Developer ID name WITHOUT prefix (e.g., "Your Name (TEAMID)")
+#                          Run: security find-identity -v -p codesigning
+#                          ❌ WRONG: "Developer ID Application: Your Name (TEAMID)"
+#                          ✅ RIGHT: "Your Name (TEAMID)"
+#   APPLE_DEVELOPER_ID   - Same as CSC_NAME, used for Rust binary signing
+#   ENABLE_HARDENED_RUNTIME=true - Enable hardened runtime for notarization
+#
+# macOS Notarization (optional but recommended):
+#   APPLE_TEAM_ID        - Your 10-character Apple Team ID
+#   APPLE_ID             - Your Apple ID email
+#   APPLE_APP_SPECIFIC_PASSWORD - App-specific password from appleid.apple.com
+#
+# iOS IPA signing:
+#   APPLE_TEAM_ID        - Apple Developer Team ID
+#   IOS_PROVISIONING_PROFILE - Provisioning profile name or UUID
+#
+# Android APK signing:
+#   ANDROID_KEYSTORE_FILE     - Path to release keystore file
+#   ANDROID_KEYSTORE_PASSWORD - Keystore password
+#   ANDROID_KEY_ALIAS         - Key alias (default: speakmcp)
+#   ANDROID_KEY_PASSWORD      - Key password
+#
+# Optional:
+#   SKIP_MAC    - Set to 1 to skip macOS build
+#   SKIP_IOS    - Set to 1 to skip iOS build
+#   SKIP_ANDROID - Set to 1 to skip Android build
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RELEASE_DIR="$ROOT_DIR/release"
+
+echo "🚀 SpeakMCP Release Build Script"
+echo "================================"
+echo "Root directory: $ROOT_DIR"
+echo ""
+
+# Create release directory
+mkdir -p "$RELEASE_DIR"
+
+# Build shared package first
+echo "📦 Building shared package..."
+cd "$ROOT_DIR"
+pnpm run build:shared
+
+#######################################
+# macOS DMG Build
+#######################################
+build_macos() {
+    echo ""
+    echo "🍎 Building macOS DMG..."
+    echo "------------------------"
+    
+    cd "$ROOT_DIR/apps/desktop"
+    
+    # Build the Rust binary first
+    echo "🦀 Building Rust binary..."
+    pnpm run build-rs
+    
+    # Set hardened runtime for production
+    export ENABLE_HARDENED_RUNTIME=true
+    
+    # Build DMG for both architectures (skip type checking for now)
+    echo "📦 Building DMG packages..."
+    # Use electron-vite build directly to skip type checking
+    npx electron-vite build
+    npx electron-builder --mac --config electron-builder.config.cjs --publish=never
+    
+    # Copy artifacts to release folder
+    cp "$ROOT_DIR/dist/"*.dmg "$RELEASE_DIR/" 2>/dev/null || true
+    
+    echo "✅ macOS build complete!"
+    ls -la "$RELEASE_DIR/"*.dmg 2>/dev/null || echo "⚠️ No DMG files found"
+}
+
+#######################################
+# iOS IPA Build
+#######################################
+build_ios() {
+    echo ""
+    echo "📱 Building iOS IPA..."
+    echo "----------------------"
+    
+    if [[ "$(uname)" != "Darwin" ]]; then
+        echo "⚠️ iOS builds require macOS. Skipping..."
+        return 0
+    fi
+    
+    cd "$ROOT_DIR/apps/mobile"
+    
+    # Install dependencies
+    echo "📦 Installing dependencies..."
+    pnpm install
+    
+    # Install CocoaPods dependencies
+    echo "🍫 Installing CocoaPods..."
+    cd ios
+    pod install --repo-update
+    cd ..
+    
+    # Generate native code with Expo
+    echo "🔧 Running Expo prebuild..."
+    npx expo prebuild --platform ios --clean
+    
+    # Create export options with environment variables
+    EXPORT_OPTIONS="$ROOT_DIR/apps/mobile/ios/ExportOptions.plist"
+    EXPORT_OPTIONS_TEMP="$ROOT_DIR/apps/mobile/ios/ExportOptions.temp.plist"
+    
+    if [ -n "$APPLE_TEAM_ID" ] && [ -n "$IOS_PROVISIONING_PROFILE" ]; then
+        sed -e "s/\${APPLE_TEAM_ID}/$APPLE_TEAM_ID/g" \
+            -e "s/\${IOS_PROVISIONING_PROFILE}/$IOS_PROVISIONING_PROFILE/g" \
+            "$EXPORT_OPTIONS" > "$EXPORT_OPTIONS_TEMP"
+        EXPORT_OPTIONS="$EXPORT_OPTIONS_TEMP"
+    fi
+    
+    # Build archive
+    echo "🔨 Building iOS archive..."
+    xcodebuild -workspace ios/SpeakMCP.xcworkspace \
+        -scheme SpeakMCP \
+        -configuration Release \
+        -archivePath "$RELEASE_DIR/SpeakMCP.xcarchive" \
+        archive \
+        CODE_SIGN_IDENTITY="${IOS_CODE_SIGN_IDENTITY:-iPhone Distribution}" \
+        DEVELOPMENT_TEAM="${APPLE_TEAM_ID:-}" \
+        -allowProvisioningUpdates
+    
+    # Export IPA
+    echo "📤 Exporting IPA..."
+    xcodebuild -exportArchive \
+        -archivePath "$RELEASE_DIR/SpeakMCP.xcarchive" \
+        -exportPath "$RELEASE_DIR" \
+        -exportOptionsPlist "$EXPORT_OPTIONS" \
+        -allowProvisioningUpdates
+    
+    # Cleanup temp file
+    rm -f "$EXPORT_OPTIONS_TEMP"
+    
+    # Rename IPA with version
+    VERSION=$(grep '"version"' "$ROOT_DIR/apps/mobile/app.json" | sed 's/.*"version": "\(.*\)".*/\1/')
+    if [ -f "$RELEASE_DIR/SpeakMCP.ipa" ]; then
+        mv "$RELEASE_DIR/SpeakMCP.ipa" "$RELEASE_DIR/SpeakMCP-${VERSION:-1.0.0}.ipa"
+    fi
+    
+    echo "✅ iOS build complete!"
+    ls -la "$RELEASE_DIR/"*.ipa 2>/dev/null || echo "⚠️ No IPA files found"
+}
+
+#######################################
+# Android APK Build  
+#######################################
+build_android() {
+    echo ""
+    echo "🤖 Building Android APK..."
+    echo "--------------------------"
+    
+    cd "$ROOT_DIR/apps/mobile"
+    
+    # Install dependencies
+    echo "📦 Installing dependencies..."
+    pnpm install
+    
+    # Generate native code with Expo
+    echo "🔧 Running Expo prebuild..."
+    npx expo prebuild --platform android --clean
+    
+    # Build release APK
+    echo "🔨 Building release APK..."
+    cd android
+    
+    if [[ "$(uname)" == "Darwin" ]] || [[ "$(uname)" == "Linux" ]]; then
+        ./gradlew assembleRelease
+    else
+        ./gradlew.bat assembleRelease
+    fi
+    
+    # Copy APK to release folder
+    VERSION=$(grep '"version"' "$ROOT_DIR/apps/mobile/app.json" | sed 's/.*"version": "\(.*\)".*/\1/')
+    APK_PATH="app/build/outputs/apk/release/app-release.apk"
+    
+    if [ -f "$APK_PATH" ]; then
+        cp "$APK_PATH" "$RELEASE_DIR/SpeakMCP-${VERSION:-1.0.0}.apk"
+        echo "✅ Android build complete!"
+    else
+        echo "⚠️ APK not found at expected path: $APK_PATH"
+        # Try to find APK
+        find . -name "*.apk" -type f 2>/dev/null
+    fi
+    
+    ls -la "$RELEASE_DIR/"*.apk 2>/dev/null || echo "⚠️ No APK files found"
+}
+
+#######################################
+# Main Build Process
+#######################################
+
+# Parse arguments
+BUILD_MAC=true
+BUILD_IOS=true
+BUILD_ANDROID=true
+
+for arg in "$@"; do
+    case $arg in
+        --mac-only)
+            BUILD_IOS=false
+            BUILD_ANDROID=false
+            ;;
+        --ios-only)
+            BUILD_MAC=false
+            BUILD_ANDROID=false
+            ;;
+        --android-only)
+            BUILD_MAC=false
+            BUILD_IOS=false
+            ;;
+        --skip-mac)
+            BUILD_MAC=false
+            ;;
+        --skip-ios)
+            BUILD_IOS=false
+            ;;
+        --skip-android)
+            BUILD_ANDROID=false
+            ;;
+    esac
+done
+
+# Environment variable overrides
+[ "$SKIP_MAC" = "1" ] && BUILD_MAC=false
+[ "$SKIP_IOS" = "1" ] && BUILD_IOS=false
+[ "$SKIP_ANDROID" = "1" ] && BUILD_ANDROID=false
+
+# Run builds
+if [ "$BUILD_MAC" = true ]; then
+    build_macos
+fi
+
+if [ "$BUILD_IOS" = true ]; then
+    build_ios
+fi
+
+if [ "$BUILD_ANDROID" = true ]; then
+    build_android
+fi
+
+#######################################
+# Summary
+#######################################
+echo ""
+echo "🎉 Build Complete!"
+echo "=================="
+echo "Release artifacts in: $RELEASE_DIR"
+echo ""
+ls -la "$RELEASE_DIR/"
+


### PR DESCRIPTION
## Problem

The build instructions for creating signed Mac release builds were not documented well enough to succeed on the first try. Specifically:

1. **Wrong `CSC_NAME` format** - The existing docs showed including the "Developer ID Application:" prefix, but electron-builder requires just the name without the prefix
2. **No instructions on finding your certificate** - Users had to know to run `security find-identity`
3. **Missing notarization docs** - Environment variables for notarization weren't documented
4. **TypeScript errors** - The standard build commands run type checking which can fail due to dependency version mismatches

## Solution

### New `BUILDING.md`
Comprehensive guide covering:
- How to find your signing identity
- Correct environment variable format (with examples of wrong vs right)
- Step-by-step build process
- Quick one-liner for experienced users
- Troubleshooting section for common errors

### Updated `scripts/build-release.sh`
- Fixed documentation for `CSC_NAME` format
- Added notarization environment variables
- Added reference to BUILDING.md

### Updated `README.md`
- Added reference to BUILDING.md for signed release builds

## Testing

Successfully built signed release using the documented process:
```
dist/SpeakMCP-1.0.0-arm64.dmg
dist/SpeakMCP-1.0.0-x64.dmg
dist/SpeakMCP-1.0.0-arm64.zip
dist/SpeakMCP-1.0.0-x64.zip
dist/SpeakMCP-1.0.0-arm64.pkg
dist/SpeakMCP-1.0.0-x64.pkg
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author