### PR TITLE
fix: sort sessions by updatedAt to ensure newest sessions appear at top

### DIFF
--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -36,7 +36,10 @@ async function loadSessions(): Promise<Session[]> {
   try {
     const raw = await AsyncStorage.getItem(SESSIONS_KEY);
     if (!raw) return [];
-    return JSON.parse(raw);
+    const sessions: Session[] = JSON.parse(raw);
+    // Sort by updatedAt descending (most recent first) to ensure
+    // the latest/newest session is always at the top
+    return sessions.sort((a, b) => b.updatedAt - a.updatedAt);
   } catch {}
   return [];
 }
@@ -242,7 +245,9 @@ export function useSessions(): SessionStore {
   }, [sessions, currentSessionId]);
 
   const getSessionList = useCallback((): SessionListItem[] => {
-    return sessions.map(sessionToListItem);
+    // Sort by updatedAt descending to ensure the latest/newest session is always at the top
+    const sortedSessions = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+    return sortedSessions.map(sessionToListItem);
   }, [sessions]);
 
   const addMessage = useCallback(async (


### PR DESCRIPTION
## Summary

Fixes #649 - Latest session should always be on top in sessions view

## Changes

- Sort sessions by `updatedAt` (descending) when loading from storage in `loadSessions()`
- Sort session list by `updatedAt` when returning from `getSessionList()`
- This ensures sessions with the most recent activity always appear first in the mobile app

## Testing

- Desktop app tests pass (`pnpm vitest run`)
- Mobile app compiles and starts successfully
- The sorting logic ensures that:
  1. When sessions are loaded from storage, they are sorted by most recently updated first
  2. When the session list is displayed, it maintains the same ordering

## Notes

The desktop app already had correct ordering logic in place. This fix addresses the mobile app where sessions were not being sorted by `updatedAt` when loaded or displayed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author