### PR TITLE
fix(mobile): sort sessions by updatedAt descending in session list

### DIFF
--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -242,7 +242,10 @@ export function useSessions(): SessionStore {
   }, [sessions, currentSessionId]);
 
   const getSessionList = useCallback((): SessionListItem[] => {
-    return sessions.map(sessionToListItem);
+    // Sort sessions by updatedAt descending (most recent first) - fixes #649
+    return [...sessions]
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .map(sessionToListItem);
   }, [sessions]);
 
   const addMessage = useCallback(async (


### PR DESCRIPTION
## Summary

Fixes #649 - Latest session should always be on top in sessions view

## Problem

The mobile app's `getSessionList` function was returning sessions in their stored order without sorting. When sessions were loaded from AsyncStorage, they appeared in whatever order they were saved, rather than showing the most recently updated session at the top.

## Solution

Modified `getSessionList` in `apps/mobile/src/store/sessions.ts` to sort sessions by `updatedAt` descending before mapping to list items. This ensures the most recently updated session always appears at the top of the session list.

## Changes

- `apps/mobile/src/store/sessions.ts`: Added sorting by `updatedAt` descending in `getSessionList` function

## Testing

- Verified TypeScript compiles (pre-existing unrelated errors exist on main)
- Verified mobile app bundles successfully in web mode
- The desktop app already had correct sorting logic in place

## Notes

- Could not add `slot-2` label due to permission restrictions
- No existing tests for the sessions store in the mobile app

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author