### PR TITLE
Fix: Combine two close buttons in session tile view

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1603,11 +1603,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                 <Maximize2 className="h-3 w-3" />
               </Button>
             )}
-            {!isComplete && (
-              <Button variant="ghost" size="icon" className="h-6 w-6 hover:bg-destructive/20 hover:text-destructive" onClick={(e) => { e.stopPropagation(); handleKillConfirmation(); }} title="Stop">
-                <X className="h-3 w-3" />
-              </Button>
-            )}
             {/* Show in panel button for completed sessions (not for synthetic pending tiles) */}
             {isComplete && isRealSession && (
               <Button variant="ghost" size="icon" className="h-6 w-6" onClick={async (e) => {
@@ -1624,11 +1619,16 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                 <ExternalLink className="h-3 w-3" />
               </Button>
             )}
-            {onDismiss && (
+            {/* Combined close button: stops agent if running, dismisses if complete */}
+            {!isComplete ? (
+              <Button variant="ghost" size="icon" className="h-6 w-6 hover:bg-destructive/20 hover:text-destructive" onClick={(e) => { e.stopPropagation(); handleKillConfirmation(); }} title="Stop agent">
+                <X className="h-3 w-3" />
+              </Button>
+            ) : onDismiss ? (
               <Button variant="ghost" size="icon" className="h-6 w-6" onClick={(e) => { e.stopPropagation(); onDismiss(); }} title="Dismiss">
                 <X className="h-3 w-3" />
               </Button>
-            )}
+            ) : null}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
This PR fixes issue #652 by combining the two close buttons that were previously displayed on the main session tile view.

## Changes
- Combined the stop and dismiss buttons into a single close button in the AgentProgress component (tile variant)
- When agent is running: button stops the agent execution
- When agent is complete: button dismisses the session (moves to history)
- Improved UX by removing confusing duplicate X buttons

## Implementation Details
The fix modifies the button rendering logic in apps/desktop/src/renderer/src/components/agent-progress.tsx:
- Uses conditional rendering to show the appropriate button based on session state
- Maintains the same functionality but with a clearer, single-button interface
- Preserves the Show in floating panel button for completed sessions

## Testing
- Built and ran the app locally with pnpm dev
- Verified the app starts without errors
- The change is in the UI layer and maintains existing functionality

Fixes #652