### PR TITLE
fix: restore Command+Tab visibility when main window is shown

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -106,6 +106,8 @@ export function createMainWindow({ url }: { url?: string } = {}) {
     win.on("show", () => {
       if (configStore.get().hideDockIcon && !app.dock.isVisible()) {
         app.dock.show()
+        // Reset activation policy to "regular" so app appears in Command+Tab
+        app.setActivationPolicy("regular")
       }
     })
   }


### PR DESCRIPTION
## Summary

Fixes #648 - Cannot Alt+Tab/Command+Tab to SpeakMCP app

## Problem

When the "Hide Dock Icon" setting is enabled on macOS:
1. When the main window closes, the app sets `app.setActivationPolicy("accessory")` which removes the app from Command+Tab
2. When the main window is shown again and the dock icon is made visible, the activation policy was **not** being reset to "regular"
3. This caused the app to remain invisible in Command+Tab even though the dock icon was visible

## Solution

Reset the activation policy to "regular" when showing the dock icon, ensuring the app appears in Command+Tab window switcher again.

## Changes

- `apps/desktop/src/main/window.ts`: Added `app.setActivationPolicy("regular")` call when showing the dock icon in the main window's `show` event handler

## Testing

1. Enable "Hide Dock Icon" in Settings > General
2. Close the main window (dock icon should hide)
3. Open the main window again (via tray icon or shortcut)
4. Verify the app now appears in Command+Tab window switcher

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author