### PR TITLE
fix: enable voice input button in always-on-top panel window

### DIFF
--- a/apps/desktop/src/renderer/src/components/overlay-follow-up-input.tsx
+++ b/apps/desktop/src/renderer/src/components/overlay-follow-up-input.tsx
@@ -89,6 +89,13 @@ export function OverlayFollowUpInput({
 
   const handleVoiceClick = async (e: React.MouseEvent) => {
     e.stopPropagation()
+    // Make panel focusable and focused first to ensure click events are received
+    // This is required on macOS for windows shown with showInactive()
+    try {
+      await tipcClient.setPanelFocusable({ focusable: true, andFocus: true })
+    } catch {
+      // Ignore errors - recording might still work
+    }
     // Pass conversationId and sessionId directly through IPC to continue in the same session
     // This is more reliable than using Zustand store which has timing issues
     // Don't pass fake "pending-*" sessionIds - let the backend find the real session by conversationId
@@ -146,6 +153,7 @@ export function OverlayFollowUpInput({
         variant="ghost"
         className="h-7 w-7 flex-shrink-0"
         disabled={!text.trim() || isDisabled}
+        onMouseDown={handleInputInteraction}
         title={isSessionActive && isQueueEnabled ? "Queue message" : "Send message"}
       >
         <Send className={cn(
@@ -163,6 +171,7 @@ export function OverlayFollowUpInput({
           "hover:text-red-600 dark:hover:text-red-400"
         )}
         disabled={isVoiceDisabled}
+        onMouseDown={handleInputInteraction}
         onClick={handleVoiceClick}
         title={isSessionActive ? "Voice unavailable while agent is processing" : "Continue with voice"}
       >


### PR DESCRIPTION
## Summary

Fixes #647 - The microphone icon in the cue message input field cannot be clicked when using the always-on-top window mode.

## Problem

The microphone button in the overlay follow-up input was not clickable in the always-on-top panel window because:

1. The panel window is created with `focusable: false` to avoid stealing focus from other applications
2. On macOS, windows shown with `showInactive()` need to be explicitly focused to receive input events properly
3. The text input had `onClick`/`onFocus` handlers that called `handleInputInteraction` to make the panel focusable, but the buttons did not have this handling

## Solution

This fix adds:
- `onMouseDown` handler to the Mic button that calls `handleInputInteraction` to make the panel focusable and focused before the click event fires
- `setPanelFocusable` call in `handleVoiceClick` as a backup to ensure the panel is focused when triggering voice recording
- Same `onMouseDown` handler to the Send button for consistency

## Testing

1. Open SpeakMCP and trigger a voice command to start an agent session
2. Wait for the agent to complete (or stop it)
3. In the always-on-top panel, try clicking the microphone icon in the follow-up input
4. The voice recording should now start properly

## Files Changed

- `apps/desktop/src/renderer/src/components/overlay-follow-up-input.tsx` - Added `onMouseDown` handlers and `setPanelFocusable` call

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author