### PR TITLE
feat(#660): Display total enabled vs disabled MCP tools count

### DIFF
--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
@@ -1351,11 +1351,21 @@ export function MCPConfigManager({
     }
   }
 
+  // Calculate total tools count
+  const totalToolsCount = tools.length
+  const enabledToolsCount = tools.filter((t) => t.enabled).length
+  const disabledToolsCount = totalToolsCount - enabledToolsCount
+
   return (
     <div className="min-w-0 space-y-6">
       <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
+        <div className="flex items-center gap-3">
           <h3 className="text-lg font-medium">MCP Server Configuration</h3>
+          {totalToolsCount > 0 && (
+            <Badge variant="secondary" className="text-sm">
+              {enabledToolsCount} enabled / {disabledToolsCount} disabled
+            </Badge>
+          )}
         </div>
         <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
           <Button variant="outline" size="sm" onClick={handleExportConfig}>


### PR DESCRIPTION
## Summary

Fixes #660 - Adds a summary badge prominently displaying the total number of enabled tools versus disabled tools in the MCP server configuration settings UI.

## Changes

- Added a summary badge next to the "MCP Server Configuration" header
- Badge shows total enabled vs disabled tools count (e.g., '12 enabled / 5 disabled')
- Badge only appears when there are tools available (totalToolsCount > 0)
- Uses the existing `Badge` component with `secondary` variant for consistent styling

## Screenshots

The badge appears at the top of the MCP Server Configuration section:
```
MCP Server Configuration [12 enabled / 5 disabled]
```

## Testing

- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ No new errors introduced - pre-existing errors in `settings-tools.tsx` are unrelated
- ✅ The feature uses existing UI components and follows the established patterns

## Files Changed

- `apps/desktop/src/renderer/src/components/mcp-config-manager.tsx` - Added tool count calculation and summary badge display

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author