### PR TITLE
feat: add MCP tools for toggling post-processing, TTS, and tool approval settings

### DIFF
--- a/apps/desktop/src/main/builtin-tool-definitions.ts
+++ b/apps/desktop/src/main/builtin-tool-definitions.ts
@@ -1,0 +1,178 @@
+/**
+ * Builtin Tool Definitions - Dependency-Free Module
+ *
+ * This module contains the static definitions for built-in MCP tools.
+ * It is intentionally kept free of dependencies on other app modules
+ * to avoid circular import issues.
+ *
+ * The tool execution handlers are in builtin-tools.ts, which can safely
+ * import from services that might also need access to these definitions.
+ */
+
+// Define a local type to avoid importing from mcp-service
+export interface BuiltinToolDefinition {
+  name: string
+  description: string
+  inputSchema: {
+    type: string
+    properties: Record<string, unknown>
+    required: string[]
+  }
+}
+
+// The virtual server name for built-in tools
+export const BUILTIN_SERVER_NAME = "speakmcp-settings"
+
+// Tool definitions
+export const builtinToolDefinitions: BuiltinToolDefinition[] = [
+  {
+    name: `${BUILTIN_SERVER_NAME}:list_mcp_servers`,
+    description: "List all configured MCP servers and their status (enabled/disabled, connected/disconnected)",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:toggle_mcp_server`,
+    description: "Enable or disable an MCP server by name. Disabled servers will not be initialized on next startup.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        serverName: {
+          type: "string",
+          description: "The name of the MCP server to toggle",
+        },
+        enabled: {
+          type: "boolean",
+          description: "Whether to enable (true) or disable (false) the server. If not provided, toggles to the opposite of the current state.",
+        },
+      },
+      required: ["serverName"],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:list_profiles`,
+    description: "List all available profiles and show which one is currently active",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:switch_profile`,
+    description: "Switch to a different profile by ID or name. The profile's guidelines will become active.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        profileIdOrName: {
+          type: "string",
+          description: "The ID or name of the profile to switch to",
+        },
+      },
+      required: ["profileIdOrName"],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:get_current_profile`,
+    description: "Get the currently active profile with its full guidelines",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:list_running_agents`,
+    description: "List all currently running agent sessions with their status, iteration count, and activity. Useful for monitoring active agents before terminating them.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:kill_agent`,
+    description: "Terminate a specific agent session by its session ID. This will abort any in-flight LLM requests, kill spawned processes, and stop the agent immediately.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: {
+          type: "string",
+          description: "The session ID of the agent to terminate (get this from list_running_agents)",
+        },
+      },
+      required: ["sessionId"],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:kill_all_agents`,
+    description: "Emergency stop ALL running agent sessions. This will abort all in-flight LLM requests, kill all spawned processes, and stop all agents immediately. Use with caution.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:get_settings`,
+    description: "Get the current status of SpeakMCP feature toggles including post-processing, TTS (text-to-speech), and tool approval settings.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:toggle_post_processing`,
+    description: "Enable or disable transcript post-processing. When enabled, transcripts are cleaned up and improved using AI.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        enabled: {
+          type: "boolean",
+          description: "Whether to enable (true) or disable (false) post-processing. If not provided, toggles to the opposite of the current state.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:toggle_tts`,
+    description: "Enable or disable text-to-speech (TTS). When enabled, assistant responses are read aloud.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        enabled: {
+          type: "boolean",
+          description: "Whether to enable (true) or disable (false) TTS. If not provided, toggles to the opposite of the current state.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: `${BUILTIN_SERVER_NAME}:toggle_tool_approval`,
+    description: "Enable or disable tool approval. When enabled, a confirmation dialog appears before any tool executes. Recommended for safety.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        enabled: {
+          type: "boolean",
+          description: "Whether to enable (true) or disable (false) tool approval. If not provided, toggles to the opposite of the current state.",
+        },
+      },
+      required: [],
+    },
+  },
+]
+
+/**
+ * Get all builtin tool names (for disabling by default)
+ */
+export function getBuiltinToolNames(): string[] {
+  return builtinToolDefinitions.map((tool) => tool.name)
+}
+

--- a/apps/desktop/src/main/builtin-tools.ts
+++ b/apps/desktop/src/main/builtin-tools.ts
@@ -19,154 +19,17 @@ import { agentSessionTracker } from "./agent-session-tracker"
 import { agentSessionStateManager, toolApprovalManager } from "./state"
 import { emergencyStopAll } from "./emergency-stop"
 
-// The virtual server name for built-in tools
-export const BUILTIN_SERVER_NAME = "speakmcp-settings"
+// Re-export from the dependency-free definitions module for backward compatibility
+// This breaks the circular dependency: profile-service -> builtin-tool-definitions (no cycle)
+// while builtin-tools -> profile-service is still valid since profile-service no longer imports from here
+export {
+  BUILTIN_SERVER_NAME,
+  builtinToolDefinitions as builtinTools,
+  getBuiltinToolNames,
+} from "./builtin-tool-definitions"
 
-// Tool definitions
-export const builtinTools: MCPTool[] = [
-  {
-    name: `${BUILTIN_SERVER_NAME}:list_mcp_servers`,
-    description: "List all configured MCP servers and their status (enabled/disabled, connected/disconnected)",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:toggle_mcp_server`,
-    description: "Enable or disable an MCP server by name. Disabled servers will not be initialized on next startup.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        serverName: {
-          type: "string",
-          description: "The name of the MCP server to toggle",
-        },
-        enabled: {
-          type: "boolean",
-          description: "Whether to enable (true) or disable (false) the server. If not provided, toggles to the opposite of the current state.",
-        },
-      },
-      required: ["serverName"],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:list_profiles`,
-    description: "List all available profiles and show which one is currently active",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:switch_profile`,
-    description: "Switch to a different profile by ID or name. The profile's guidelines will become active.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        profileIdOrName: {
-          type: "string",
-          description: "The ID or name of the profile to switch to",
-        },
-      },
-      required: ["profileIdOrName"],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:get_current_profile`,
-    description: "Get the currently active profile with its full guidelines",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:list_running_agents`,
-    description: "List all currently running agent sessions with their status, iteration count, and activity. Useful for monitoring active agents before terminating them.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:kill_agent`,
-    description: "Terminate a specific agent session by its session ID. This will abort any in-flight LLM requests, kill spawned processes, and stop the agent immediately.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        sessionId: {
-          type: "string",
-          description: "The session ID of the agent to terminate (get this from list_running_agents)",
-        },
-      },
-      required: ["sessionId"],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:kill_all_agents`,
-    description: "Emergency stop ALL running agent sessions. This will abort all in-flight LLM requests, kill all spawned processes, and stop all agents immediately. Use with caution.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:get_settings`,
-    description: "Get the current status of SpeakMCP feature toggles including post-processing, TTS (text-to-speech), and tool approval settings.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:toggle_post_processing`,
-    description: "Enable or disable transcript post-processing. When enabled, transcripts are cleaned up and improved using AI.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        enabled: {
-          type: "boolean",
-          description: "Whether to enable (true) or disable (false) post-processing. If not provided, toggles to the opposite of the current state.",
-        },
-      },
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:toggle_tts`,
-    description: "Enable or disable text-to-speech (TTS). When enabled, assistant responses are read aloud.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        enabled: {
-          type: "boolean",
-          description: "Whether to enable (true) or disable (false) TTS. If not provided, toggles to the opposite of the current state.",
-        },
-      },
-      required: [],
-    },
-  },
-  {
-    name: `${BUILTIN_SERVER_NAME}:toggle_tool_approval`,
-    description: "Enable or disable tool approval. When enabled, a confirmation dialog appears before any tool executes. Recommended for safety.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        enabled: {
-          type: "boolean",
-          description: "Whether to enable (true) or disable (false) tool approval. If not provided, toggles to the opposite of the current state.",
-        },
-      },
-      required: [],
-    },
-  },
-]
+// Import for local use
+import { BUILTIN_SERVER_NAME, builtinToolDefinitions } from "./builtin-tool-definitions"
 
 // Tool execution handlers
 type ToolHandler = (args: Record<string, unknown>) => Promise<MCPToolResult>
@@ -838,11 +701,4 @@ export async function executeBuiltinTool(
  */
 export function isBuiltinTool(toolName: string): boolean {
   return toolName.startsWith(`${BUILTIN_SERVER_NAME}:`)
-}
-
-/**
- * Get all builtin tool names (for disabling by default)
- */
-export function getBuiltinToolNames(): string[] {
-  return builtinTools.map((tool) => tool.name)
 }

--- a/apps/desktop/src/main/profile-service.ts
+++ b/apps/desktop/src/main/profile-service.ts
@@ -5,7 +5,7 @@ import { Profile, ProfilesData, ProfileMcpServerConfig, ProfileModelConfig } fro
 import { randomUUID } from "crypto"
 import { logApp } from "./debug"
 import { configStore } from "./config"
-import { getBuiltinToolNames } from "./builtin-tools"
+import { getBuiltinToolNames } from "./builtin-tool-definitions"
 
 export const profilesPath = path.join(
   app.getPath("appData"),


### PR DESCRIPTION
## Summary

Adds configurable toggles for post-processing, TTS, and tool approval as internal MCP tools in the `speakmcp-settings` server.

Fixes #658

## Changes

Added 4 new built-in MCP tools:

### `speakmcp-settings:get_settings`
Gets the current status of all feature toggles. Returns:
- `postProcessingEnabled` - Whether transcript post-processing is enabled
- `ttsEnabled` - Whether text-to-speech is enabled
- `toolApprovalEnabled` - Whether tool approval dialogs are shown

### `speakmcp-settings:toggle_post_processing`
Enables or disables transcript post-processing.
- Optional `enabled` parameter to explicitly set the value
- If not provided, toggles to the opposite of current state

### `speakmcp-settings:toggle_tts`
Enables or disables text-to-speech.
- Optional `enabled` parameter to explicitly set the value
- If not provided, toggles to the opposite of current state

### `speakmcp-settings:toggle_tool_approval`
Enables or disables tool approval dialogs.
- Optional `enabled` parameter to explicitly set the value
- If not provided, toggles to the opposite of current state

## Usage Examples

The LLM can now control these settings dynamically:

```
User: "Turn off text-to-speech"
LLM: [calls speakmcp-settings:toggle_tts with {enabled: false}]

User: "What are my current settings?"
LLM: [calls speakmcp-settings:get_settings]

User: "Enable tool approval for safety"
LLM: [calls speakmcp-settings:toggle_tool_approval with {enabled: true}]
```

## Testing

- ✅ TypeScript compilation passes
- ✅ All 36 tests pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author