### PR TITLE
fix: apply dock icon visibility changes immediately on toggle

### DIFF
--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1490,6 +1490,28 @@ export const router = {
         // best-effort only
       }
 
+      // Apply dock icon visibility changes immediately (macOS only)
+      if (process.env.IS_MAC) {
+        try {
+          const prevHideDock = !!(prev as any)?.hideDockIcon
+          const nextHideDock = !!(merged as any)?.hideDockIcon
+
+          if (prevHideDock !== nextHideDock) {
+            if (nextHideDock) {
+              // User wants to hide dock icon - hide it now
+              app.setActivationPolicy("accessory")
+              app.dock.hide()
+            } else {
+              // User wants to show dock icon - show it now
+              app.dock.show()
+              app.setActivationPolicy("regular")
+            }
+          }
+        } catch (_e) {
+          // best-effort only
+        }
+      }
+
       // Manage Remote Server lifecycle on config changes
       try {
         const prevEnabled = !!(prev as any)?.remoteServerEnabled


### PR DESCRIPTION
## Problem

When toggling the "Hide Dock Icon" setting in Settings > General, the dock icon visibility wouldn't change until the app was restarted. This was frustrating for users who expected the change to take effect immediately.

## Root Cause

The `saveConfig` handler in `tipc.ts` saved the `hideDockIcon` preference but had no logic to actually apply the change to the dock icon visibility.

## Solution

Added logic in the `saveConfig` handler to detect when `hideDockIcon` changes and immediately apply the change:

- When `hideDockIcon` changes from `false` → `true`: Hides the dock icon by setting activation policy to "accessory" and calling `app.dock.hide()`
- When `hideDockIcon` changes from `true` → `false`: Shows the dock icon by calling `app.dock.show()` and setting activation policy to "regular"

This matches the behavior of other settings like "Launch at Login" which apply immediately when changed.

## Testing

1. Open Settings > General
2. Toggle "Hide Dock Icon" ON → dock icon should disappear immediately
3. Toggle "Hide Dock Icon" OFF → dock icon should reappear immediately

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author