### PR TITLE
feat: improve system prompt based on research feedback

### DIFF
--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -64,6 +64,7 @@ export interface LLMToolCallResponse {
   content?: string
   toolCalls?: MCPToolCall[]
   needsMoreWork?: boolean
+  status?: "working" | "complete" | "blocked"
 }
 
 export class MCPService {

--- a/apps/desktop/src/main/structured-output.ts
+++ b/apps/desktop/src/main/structured-output.ts
@@ -14,6 +14,7 @@ const LLMToolCallSchema = z.object({
     .optional(),
   content: z.string().optional(),
   needsMoreWork: z.boolean().optional(),
+  status: z.enum(["working", "complete", "blocked"]).optional(),
 })
 
 export type LLMToolCallResponse = z.infer<typeof LLMToolCallSchema>
@@ -51,7 +52,12 @@ const toolCallResponseSchema: OpenAI.ResponseFormatJSONSchema["json_schema"] = {
       },
       needsMoreWork: {
         type: "boolean",
-        description: "Whether more work is needed after this response",
+        description: "Deprecated: use status instead",
+      },
+      status: {
+        type: "string",
+        enum: ["working", "complete", "blocked"],
+        description: "Task status: working (continue), complete (done), blocked (need user input)",
       },
     },
     additionalProperties: false,
@@ -273,7 +279,7 @@ export async function makeStructuredToolCall(
           // If parsing fails completely, try to extract any meaningful content
           const textContent = content.replace(/<\|[^|]*\|>/g, '').trim()
           if (textContent) {
-            return { content: textContent, needsMoreWork: true }
+            return { content: textContent, status: "working", needsMoreWork: true }
           }
         }
       }


### PR DESCRIPTION
Key improvements:
- Add persistence instruction: keep working until fully complete
- Add anti-hallucination instruction: use tools to verify, don't guess
- Add planning/reflection: reason before calls, verify after
- Use XML tags for structure (research shows ~40% performance variance)
- Move critical rules to end (transformers weight recent tokens more)
- Add explicit circuit breakers: max 3 retries, 10 rounds before blocked
- Add verification pattern: check state changes before reporting success
- Add error recovery guidance with alternative approach fallback
- Show full loop examples with error recovery and blocked state
- Add task decomposition guidance for complex requests
- Replace boolean needsMoreWork with expressive status enum: "working" | "complete" | "blocked"
- Updated all parsing/handling code to support both old and new formats