### PR TITLE
refactor: improve agent system prompt based on research feedback

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1611,8 +1611,8 @@ Always use actual resource IDs from the conversation history or create new ones 
         }
 
         const nudgeMessage = isActionableRequest
-          ? "You have relevant tools available for this request. Please respond with a valid JSON object: either call tools using the toolCalls array, or set needsMoreWork=false with a complete answer in the content field."
-          : "Please respond with a valid JSON object containing your answer in the content field and needsMoreWork=false if the task is complete."
+          ? "You have relevant tools available. Respond with valid JSON: either call tools with status: \"working\", or provide answer with status: \"complete\"."
+          : "Respond with valid JSON: {\"content\": \"your answer\", \"status\": \"complete\"}"
 
         addMessage("user", nudgeMessage)
 

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -64,6 +64,7 @@ export interface LLMToolCallResponse {
   content?: string
   toolCalls?: MCPToolCall[]
   needsMoreWork?: boolean
+  status?: "working" | "complete" | "blocked"
 }
 
 export class MCPService {


### PR DESCRIPTION
- Add XML structure (<role>, <response_format>, <tool_usage>, <examples>, <critical_rules>)
- Change from needsMoreWork boolean to status enum ("working"|"complete"|"blocked")
- Add persistence instruction: keep working until task fully complete
- Add anti-hallucination instruction: verify with tools instead of guessing
- Add planning/reflection guidance: reason before tools, verify after
- Add circuit breakers: max 15 rounds, max 3 retries for same operation
- Add error recovery examples showing full tool loops
- Add verification pattern: confirm state changes before reporting complete
- Move critical rules to end (transformers weight recent tokens more heavily)
- Maintain backward compatibility by normalizing status→needsMoreWork internally