### PR TITLE
feat: change default tiled session width to half container width

### DIFF
--- a/apps/desktop/src/renderer/src/components/session-grid.tsx
+++ b/apps/desktop/src/renderer/src/components/session-grid.tsx
@@ -31,13 +31,19 @@ export function SessionGrid({ children, sessionCount, className }: SessionGridPr
       if (containerRef.current) {
         // Dynamically compute padding from computed styles to handle className overrides
         const computedStyle = getComputedStyle(containerRef.current)
-        const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0
-        const paddingRight = parseFloat(computedStyle.paddingRight) || 0
+        // Use proper NaN check to allow 0 as a valid padding value
+        const parsedPaddingLeft = parseFloat(computedStyle.paddingLeft)
+        const parsedPaddingRight = parseFloat(computedStyle.paddingRight)
+        const paddingLeft = !Number.isNaN(parsedPaddingLeft) ? parsedPaddingLeft : 0
+        const paddingRight = !Number.isNaN(parsedPaddingRight) ? parsedPaddingRight : 0
         const totalPadding = paddingLeft + paddingRight
         setContainerWidth(containerRef.current.clientWidth - totalPadding)
 
         // Also compute gap from styles to handle className overrides (columnGap or gap)
-        const columnGap = parseFloat(computedStyle.columnGap) || parseFloat(computedStyle.gap) || 16
+        // Use a proper check that doesn't treat 0 as falsy (0 is a valid gap value)
+        const parsedColumnGap = parseFloat(computedStyle.columnGap)
+        const parsedGap = parseFloat(computedStyle.gap)
+        const columnGap = !Number.isNaN(parsedColumnGap) ? parsedColumnGap : (!Number.isNaN(parsedGap) ? parsedGap : 16)
         setGap(columnGap)
       }
     }


### PR DESCRIPTION
## Summary

Changes the default width of tiled sessions in the native session view to half the container/window width, allowing two sessions to tile side-by-side by default.

## Changes

- Add `SessionGridContext` to share container width with tile wrappers
- Track container width using `ResizeObserver` in `SessionGrid`
- Calculate initial tile width as half the container width (minus gap for spacing)
- Clamp width to min/max bounds from `TILE_DIMENSIONS` (200-1200px)
- Respect user-persisted sizes from localStorage (existing users keep their preferences)
- Update width dynamically once container is measured on first render

## Testing

- TypeScript compilation passes
- App builds and starts successfully
- New sessions should spawn at half the container width
- Existing users with persisted tile sizes will keep their preferences

Fixes #665

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author