### PR TITLE
feat: replace mem0 with GitHub and EXA as example MCP servers

### DIFF
--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
@@ -693,6 +693,8 @@ function ServerDialog({ server, onSave, onCancel, onImportFromFile, onImportFrom
                                   .join("\n")
                               : ""
                           )
+                          // Reset OAuth config when switching examples to prevent stale fields
+                          setOAuthConfig({})
                           setActiveTab('manual')
                         }}
                       >
@@ -793,7 +795,7 @@ const MCP_EXAMPLES: Record<string, { name: string; config: MCPServerConfig; note
       transport: "streamableHttp" as MCPTransportType,
       url: "https://mcp.exa.ai/mcp",
     },
-    note: "Requires API key. After adding, set the x-api-key header in Custom HTTP Headers.",
+    note: "Requires API key. After adding, set x-api-key=YOUR_KEY in Custom HTTP Headers.",
   },
   memory: {
     name: "memory",


### PR DESCRIPTION
## Summary

Closes #669 - Replaces mem0 with GitHub and EXA as the example MCP servers and makes the examples tab the default when users click "Add Server".

## Changes

### Example MCP Servers Updated
- **Added GitHub MCP server** (`@modelcontextprotocol/server-github`) - Official GitHub API integration for repository operations, issues, PRs, etc.
- **Added EXA MCP server** (`exa-mcp-server`) - Web search capabilities powered by Exa AI Search API
- **Removed mem0** from the example servers list

### UX Improvement
- **Examples tab is now the default** when opening "Add Server" dialog (previously was "Manual")
- When editing an existing server, "Manual" tab remains the default for direct editing

## Why These Examples?

**GitHub MCP Server:**
- Official MCP server from Model Context Protocol organization
- Provides access to GitHub API operations
- Requires `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable

**EXA MCP Server:**
- Popular web search integration for AI assistants
- Provides real-time web search through Exa AI Search API
- Requires `EXA_API_KEY` environment variable

## Testing

- ✅ TypeScript compilation passes
- ✅ All 36 unit tests pass
- ✅ Changes are focused and minimal

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author