### PR TITLE
fix(desktop): persist dock icon visibility and cmd+tab on app restart

### DIFF
--- a/apps/desktop/src/main/config.ts
+++ b/apps/desktop/src/main/config.ts
@@ -71,6 +71,7 @@ const getConfig = () => {
 
 	    // App behavior
 	    launchAtLogin: false,
+	    hideDockIcon: false,
 
     // TTS defaults
     ttsEnabled: true,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -54,6 +54,26 @@ app.whenReady().then(() => {
 	    }
 	  } catch (_) {}
 
+	  // Apply hideDockIcon setting on startup (macOS only)
+	  if (process.platform === "darwin") {
+	    try {
+	      const cfg = configStore.get()
+	      if (cfg.hideDockIcon) {
+	        app.setActivationPolicy("accessory")
+	        app.dock.hide()
+	        logApp("Dock icon hidden on startup per user preference")
+	      } else {
+	        // Ensure dock is visible when hideDockIcon is false
+	        // This handles the case where dock state persisted from a previous session
+	        app.dock.show()
+	        app.setActivationPolicy("regular")
+	        logApp("Dock icon shown on startup per user preference")
+	      }
+	    } catch (e) {
+	      logApp("Failed to apply hideDockIcon on startup:", e)
+	    }
+	  }
+
 
   logApp("Serve protocol registered")
 


### PR DESCRIPTION
## Summary

Fixes the issue where the dock icon visibility and Cmd+Tab functionality would not persist after closing and reopening the app on macOS.

## Changes

### `apps/desktop/src/main/config.ts`
- Added `hideDockIcon: false` as the default value in the config

### `apps/desktop/src/main/index.ts`
- Added startup initialization to apply the `hideDockIcon` setting when the app launches
- Explicitly sets both dock visibility and activation policy based on the saved config:
  - When `hideDockIcon: true`: Hides dock and sets policy to "accessory" (no Cmd+Tab)
  - When `hideDockIcon: false`: Shows dock and sets policy to "regular" (appears in Cmd+Tab)

## Problem

The dock icon visibility setting was being applied when toggled in settings and when windows opened/closed, but it was not being applied on app startup. This meant that:
1. The dock state could persist incorrectly from a previous session
2. Users would lose their dock icon and Cmd+Tab functionality after restarting the app

## Testing

1. Set "Hide Dock Icon" to OFF in settings
2. Close and reopen the app
3. Verify the dock icon appears and app shows in Cmd+Tab
4. Set "Hide Dock Icon" to ON in settings
5. Close and reopen the app
6. Verify the dock icon is hidden and app doesn't appear in Cmd+Tab

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author