### PR TITLE
feat: Improve browser automation performance with typing guidance

### DIFF
--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -1114,7 +1114,12 @@ export class MCPService {
   }
 
   /**
-   * Filter Playwright browser automation responses
+   * Filters Playwright responses to reduce token usage.
+   *
+   * NOTE: Each Playwright action (click, type, etc.) takes ~1 second because
+   * the server captures a full accessibility snapshot after each action.
+   * For text input, prefer browser_type over individual clicks to reduce
+   * the number of round-trips.
    */
   private filterPlaywrightResponse(
     toolName: string,

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -21,6 +21,13 @@ TOOL EXECUTION MODES:
 Example parallel (default): {"toolCalls": [...], "needsMoreWork": true}
 Example serial: {"toolCalls": [...], "toolExecutionMode": "serial", "needsMoreWork": true}
 
+
+BROWSER AUTOMATION BEST PRACTICES:
+- When entering text (like typing in games, forms, or search boxes), prefer browser_type over individual browser_click calls
+- Use browser_type with the submit: true parameter when you need to type and press Enter
+- For Wordle-style games: type the entire word at once using browser_type instead of clicking individual letter buttons
+- Each browser action takes ~1 second due to page snapshots, so minimize the number of separate actions
+
 WHEN TO ASK: Multiple valid approaches exist, sensitive/destructive operations, or ambiguous intent
 WHEN TO ACT: Request is clear and tools can accomplish it directly
 


### PR DESCRIPTION
## Summary

This PR improves browser automation performance by adding guidance to prefer `browser_type` over individual `browser_click` calls when entering text.

## Problem

Each Playwright browser action (click, type, navigate, etc.) takes approximately **~1 second** because the MCP server captures a full accessibility snapshot after each action. This means:

- Typing a 5-letter word by clicking individual letter buttons = **5+ seconds** (5 clicks + overhead)
- Typing the same word with `browser_type` = **~1 second** (single action)

For Wordle-style games or form inputs, this can result in **5-6x performance improvement**.

## Changes

1. **System prompts** (`system-prompts.ts`): Added "Browser Automation Best Practices" section with guidance to:
   - Prefer `browser_type` over individual `browser_click` calls for text input
   - Use `submit: true` parameter when needing to type and press Enter
   - Minimize separate actions due to ~1s snapshot overhead

2. **MCP service** (`mcp-service.ts`): Enhanced comment on `filterPlaywrightResponse` to document the performance characteristics and guide future development.

## Testing

These are prompt-level changes that guide the AI agent's behavior. The agent should now prefer typing over clicking for text input scenarios.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author