### PR TITLE
Allow OAuth redirect override for providers without custom scheme

### DIFF
--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -61,6 +61,8 @@ export interface OAuthConfig {
   scope?: string
   useDiscovery?: boolean // Whether to use .well-known/oauth-authorization-server
   useDynamicRegistration?: boolean // Whether to use RFC7591 dynamic client registration
+  // Optional override for redirect URI (e.g., when the provider disallows custom schemes)
+  redirectUri?: string
 
   // Pending authorization state (used during OAuth flow)
   pendingAuth?: {


### PR DESCRIPTION
## Summary
- allow overriding OAuth redirect URI via `oauth.redirectUri`
- apply override to registration, auth URL, and token exchange for providers that disallow custom schemes

## Testing
- Not run (manual testing planned)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author