### PR TITLE
fix(ui): improve tool call UI contrast and combine thought with tool execution

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1323,11 +1323,13 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       // Unified execution bubble combining thought + tool calls + results
       // The assistant's content (thought) is included in the tool_execution item
       const execTimestamp = next?.timestamp ?? m.timestamp
+      // Use only the content-based hash for stable ID - avoid using roleCounters
+      // which can shift if message ordering changes (e.g., equal timestamps)
       const toolExecId = generateToolExecutionId(m.toolCalls, execTimestamp)
-      const aIndex = ++roleCounters.assistant
+      ++roleCounters.assistant // Still increment counter for consistency with other branches
       displayItems.push({
         kind: "tool_execution",
-        id: `exec-${toolExecId}-${aIndex}`,
+        id: `exec-${toolExecId}`,
         data: {
           timestamp: execTimestamp,
           calls: m.toolCalls,


### PR DESCRIPTION
## Summary

This PR addresses issue #703 by improving the tool call UI component readability and structure.

## Changes

### 1. Fix dark mode contrast for tool call results
- Changed `dark:text-green-300` to `dark:text-green-100` for better readability on green backgrounds
- Changed `dark:text-red-300` to `dark:text-red-100` for error states
- Changed `dark:text-blue-300` to `dark:text-blue-100` for pending states

### 2. Combine assistant thought and tool call into single unified component
- Added optional `thought` field to `tool_execution` DisplayItem type
- Modified `ToolExecutionBubble` to display the assistant's thought/reasoning above tool calls
- Updated `displayItems` building logic to include thought content in the tool_execution item
- Removed separate message item for assistant thoughts when tool calls are present

## Testing
- TypeScript compiles without errors
- Tested in dev mode with dark mode enabled

Closes #703

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author