### PR TITLE
fix: improve tool call UI contrast and unify thought+tool display

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -53,6 +53,13 @@ type DisplayItem =
       calls: Array<{ name: string; arguments: any }>
       results: Array<{ success: boolean; content: string; error?: string }>
     } }
+  | { kind: "assistant_with_tools"; id: string; data: {
+      thought: string
+      timestamp: number
+      isComplete: boolean
+      calls: Array<{ name: string; arguments: any }>
+      results: Array<{ success: boolean; content: string; error?: string }>
+    } }
   | { kind: "tool_approval"; id: string; data: {
       approvalId: string
       toolName: string
@@ -292,8 +299,8 @@ const CompactMessage: React.FC<{
                       className={cn(
                         "rounded-lg border p-2 text-xs",
                         result.success
-                          ? "border-green-200/50 bg-green-50/30 text-green-700 dark:border-green-800/50 dark:bg-green-900/20 dark:text-green-300"
-                          : "border-red-200/50 bg-red-50/30 text-red-700 dark:border-red-800/50 dark:bg-red-900/20 dark:text-red-300",
+                          ? "border-green-200/50 bg-green-50/30 text-green-800 dark:border-green-700/50 dark:bg-green-950/40 dark:text-green-200"
+                          : "border-red-200/50 bg-red-50/30 text-red-800 dark:border-red-700/50 dark:bg-red-950/40 dark:text-red-200",
                       )}
                     >
                       <div className="flex items-center justify-between mb-1">
@@ -497,10 +504,10 @@ const ToolExecutionBubble: React.FC<{
       className={cn(
         "rounded-lg border p-2 text-xs",
         isPending
-          ? "border-blue-200/50 bg-blue-50/30 text-blue-700 dark:border-blue-800/50 dark:bg-blue-900/20 dark:text-blue-300"
+          ? "border-blue-200/50 bg-blue-50/30 text-blue-800 dark:border-blue-700/50 dark:bg-blue-950/40 dark:text-blue-200"
           : allSuccess
-            ? "border-green-200/50 bg-green-50/30 text-green-700 dark:border-green-800/50 dark:bg-green-900/20 dark:text-green-300"
-            : "border-red-200/50 bg-red-50/30 text-red-700 dark:border-red-800/50 dark:bg-red-900/20 dark:text-red-300",
+            ? "border-green-200/50 bg-green-50/30 text-green-800 dark:border-green-700/50 dark:bg-green-950/40 dark:text-green-200"
+            : "border-red-200/50 bg-red-50/30 text-red-800 dark:border-red-700/50 dark:bg-red-950/40 dark:text-red-200",
       )}
     >
       <div
@@ -605,7 +612,9 @@ const ToolExecutionBubble: React.FC<{
                     key={idx}
                     className={cn(
                       "rounded border p-2 text-xs",
-                      r.success ? "border-green-200/50 bg-green-50/30" : "border-red-200/50 bg-red-50/30",
+                      r.success
+                        ? "border-green-200/50 bg-green-50/30 dark:border-green-700/50 dark:bg-green-950/30"
+                        : "border-red-200/50 bg-red-50/30 dark:border-red-700/50 dark:bg-red-950/30",
                     )}
                   >
                     <div className="mb-1 flex items-center justify-between">
@@ -642,6 +651,180 @@ const ToolExecutionBubble: React.FC<{
       )}
 
 
+    </div>
+  )
+}
+
+// Unified Assistant + Tool Execution component - combines thought and tool call as one message
+const AssistantWithToolsBubble: React.FC<{
+  data: {
+    thought: string
+    timestamp: number
+    isComplete: boolean
+    calls: Array<{ name: string; arguments: any }>
+    results: Array<{ success: boolean; content: string; error?: string }>
+  }
+  isExpanded: boolean
+  onToggleExpand: () => void
+}> = ({ data, isExpanded, onToggleExpand }) => {
+  const [showToolDetails, setShowToolDetails] = useState(false)
+
+  const isPending = data.results.length === 0
+  const allSuccess = data.results.length > 0 && data.results.every(r => r.success)
+  const hasThought = data.thought && data.thought.trim().length > 0
+  const shouldCollapse = (data.thought?.length ?? 0) > 100 || data.calls.length > 0
+
+  // Generate result summary for collapsed state
+  const collapsedResultSummary = (() => {
+    if (isExpanded || isPending) return null
+    if (data.results.length === 0) return null
+    const toolResults = data.results.map(r => ({
+      success: r.success,
+      content: r.content,
+      error: r.error,
+    }))
+    return getToolResultsSummary(toolResults)
+  })()
+
+  const handleToggleExpand = () => {
+    if (shouldCollapse) {
+      onToggleExpand()
+    }
+  }
+
+  const handleChevronClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onToggleExpand()
+  }
+
+  const handleToggleToolDetails = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setShowToolDetails(!showToolDetails)
+  }
+
+  // Tool names for display
+  const toolNames = data.calls.map(c => c.name).join(', ')
+  const toolCount = data.calls.length
+
+  return (
+    <div className={cn(
+      "rounded text-xs transition-all duration-200",
+      "border-l-2 border-gray-400 bg-gray-400/5",
+      !isExpanded && shouldCollapse && "hover:bg-muted/20",
+      shouldCollapse && "cursor-pointer"
+    )}>
+      {/* Thought content section */}
+      <div
+        className="flex items-start gap-2 px-2 py-1 text-left"
+        onClick={handleToggleExpand}
+      >
+        <span className="opacity-60 mt-0.5 flex-shrink-0">🤖</span>
+        <div className="flex-1 min-w-0">
+          {hasThought && (
+            <div className={cn(
+              "leading-relaxed text-left",
+              !isExpanded && shouldCollapse && "line-clamp-2"
+            )}>
+              <MarkdownRenderer content={data.thought.trim()} />
+            </div>
+          )}
+
+          {/* Tool execution section - always visible but collapsible */}
+          <div className={cn(
+            "mt-2 rounded-lg border p-2",
+            isPending
+              ? "border-blue-200/50 bg-blue-50/30 text-blue-800 dark:border-blue-700/50 dark:bg-blue-950/40 dark:text-blue-200"
+              : allSuccess
+                ? "border-green-200/50 bg-green-50/30 text-green-800 dark:border-green-700/50 dark:bg-green-950/40 dark:text-green-200"
+                : "border-red-200/50 bg-red-50/30 text-red-800 dark:border-red-700/50 dark:bg-red-950/40 dark:text-red-200",
+          )}>
+            <div
+              className="flex items-center justify-between cursor-pointer"
+              onClick={handleToggleToolDetails}
+            >
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                <span className="opacity-60">🔧</span>
+                <span className="font-mono font-semibold truncate">
+                  {toolCount === 1 ? data.calls[0].name : `${toolCount} tool calls`}
+                </span>
+                <Badge variant="outline" className="text-[10px] flex-shrink-0">
+                  {isPending ? "Running..." : allSuccess ? "✓" : "✗"}
+                </Badge>
+              </div>
+              <button
+                onClick={handleChevronClick}
+                className="p-1 rounded hover:bg-muted/30 transition-colors flex-shrink-0"
+                aria-label={showToolDetails ? "Collapse" : "Expand"}
+              >
+                {showToolDetails ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+              </button>
+            </div>
+
+            {/* Collapsed preview - show result summary */}
+            {!showToolDetails && collapsedResultSummary && (
+              <div className="mt-1 text-[10px] opacity-80 truncate">
+                <span className="font-medium">{collapsedResultSummary}</span>
+              </div>
+            )}
+
+            {/* Expanded tool details */}
+            {showToolDetails && (
+              <div className="mt-2 space-y-2">
+                {/* Tool calls */}
+                {data.calls.map((call, idx) => (
+                  <div key={idx} className="rounded bg-muted/30 p-2">
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="font-mono font-semibold text-primary">{call.name}</span>
+                      <Badge variant="outline" className="text-[10px]">Call {idx + 1}</Badge>
+                    </div>
+                    {call.arguments && (
+                      <pre className="rounded bg-muted/50 p-2 overflow-auto text-xs whitespace-pre-wrap max-h-40 scrollbar-thin">
+                        {JSON.stringify(call.arguments, null, 2)}
+                      </pre>
+                    )}
+                  </div>
+                ))}
+
+                {/* Tool results */}
+                {data.results.length > 0 && (
+                  <div className="space-y-2">
+                    <div className="text-[11px] font-semibold opacity-70">Results:</div>
+                    {data.results.map((result, idx) => (
+                      <div
+                        key={idx}
+                        className={cn(
+                          "rounded border p-2",
+                          result.success
+                            ? "border-green-200/50 bg-green-50/20 dark:border-green-700/50 dark:bg-green-950/20"
+                            : "border-red-200/50 bg-red-50/20 dark:border-red-700/50 dark:bg-red-950/20",
+                        )}
+                      >
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="font-semibold">{result.success ? "✅ Success" : "❌ Error"}</span>
+                          <span className="text-[10px] opacity-60 font-mono">
+                            {(result.content?.length || 0).toLocaleString()} chars
+                          </span>
+                        </div>
+                        <pre className="rounded bg-muted/30 p-2 overflow-auto whitespace-pre-wrap break-all max-h-40 scrollbar-thin">
+                          {result.content || "No content returned"}
+                        </pre>
+                        {result.error && (
+                          <div className="mt-2">
+                            <div className="text-[11px] font-medium text-destructive mb-1">Error:</div>
+                            <pre className="rounded bg-destructive/10 p-2 overflow-auto whitespace-pre-wrap break-all max-h-40 scrollbar-thin">
+                              {result.error}
+                            </pre>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }
@@ -1305,17 +1488,17 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     if (m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0) {
       const next = messages[i + 1]
       const results = next && next.role === "tool" && next.toolResults ? next.toolResults : []
-      // Show assistant message without extras (stable key by role ordinal)
+      // Create unified assistant + tools item (combines thought and tool execution)
       const aIndex = ++roleCounters.assistant
-      displayItems.push({ kind: "message", id: `msg-assistant-${aIndex}`, data: { ...m, toolCalls: undefined, toolResults: undefined } })
-      // Unified execution bubble with stable ID (include timestamp for uniqueness)
       const execTimestamp = next?.timestamp ?? m.timestamp
       const toolExecId = generateToolExecutionId(m.toolCalls, execTimestamp)
       displayItems.push({
-        kind: "tool_execution",
-        id: `exec-${toolExecId}`,
+        kind: "assistant_with_tools",
+        id: `assistant-tools-${aIndex}-${toolExecId}`,
         data: {
-          timestamp: execTimestamp,
+          thought: m.content || "",
+          timestamp: m.timestamp,
+          isComplete: m.isComplete,
           calls: m.toolCalls,
           results,
         },
@@ -1692,6 +1875,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                             variant="tile"
                           />
                         )
+                      } else if (item.kind === "assistant_with_tools") {
+                        return (
+                          <AssistantWithToolsBubble
+                            key={itemKey}
+                            data={item.data}
+                            isExpanded={isExpanded}
+                            onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
+                          />
+                        )
                       } else if (item.kind === "tool_approval") {
                         return (
                           <ToolApprovalBubble
@@ -1891,6 +2083,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                       isExpanded={isExpanded}
                       onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
                       variant={variant}
+                    />
+                  )
+                } else if (item.kind === "assistant_with_tools") {
+                  return (
+                    <AssistantWithToolsBubble
+                      key={itemKey}
+                      data={item.data}
+                      isExpanded={isExpanded}
+                      onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
                     />
                   )
                 } else if (item.kind === "tool_approval") {


### PR DESCRIPTION
## Summary

This PR addresses issue #703 by improving the tool call UI component readability and structure.

## Changes

### 1. Fixed dark mode contrast for tool call results
- Changed `dark:text-green-300` to `dark:text-green-200` for better readability
- Changed `dark:bg-green-900/20` to `dark:bg-green-950/40` for better contrast
- Changed `dark:border-green-800/50` to `dark:border-green-700/50`
- Applied same pattern to blue (pending) and red (error) states

### 2. Unified thought and tool call display
- Created new `AssistantWithToolsBubble` component that combines:
  - The thought content (assistant's reasoning text)
  - The tool execution details (calls and results)
- Added new `assistant_with_tools` DisplayItem type
- Updated display items building logic to create unified items instead of separate message + tool_execution items
- Updated both tile and overlay render sections to handle the new type

## Testing
- TypeScript type checks pass
- Build completes successfully
- App starts and runs without errors

Fixes #703

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author