### PR TITLE
docs: streamline README and extract development guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,137 @@
+# Development Guide
+
+## Prerequisites
+
+- **Node.js 18+** and **pnpm** (required package manager)
+- **Rust toolchain** for the native keyboard/input binary
+- **Xcode** (macOS only) for code signing
+
+> ⚠️ **Important**: This project uses **pnpm**. Using npm or yarn may cause installation issues.
+> ```bash
+> npm install -g pnpm
+> ```
+
+## Quick Start
+
+```bash
+git clone https://github.com/aj47/SpeakMCP.git
+cd SpeakMCP
+pnpm install
+pnpm build-rs  # Build Rust binary
+pnpm dev       # Start development server
+```
+
+## Build Commands
+
+| Command | Description |
+|---------|-------------|
+| `pnpm dev` | Start development server |
+| `pnpm build` | Production build for current platform |
+| `pnpm build:mac` | macOS build (Apple Silicon + Intel) |
+| `pnpm build:win` | Windows build (x64) |
+| `pnpm build:linux` | Linux build (x64) |
+| `pnpm test` | Run test suite |
+| `pnpm test:run` | Run tests once (CI mode) |
+| `pnpm test:coverage` | Run tests with coverage |
+
+For signed release builds, see [BUILDING.md](BUILDING.md).
+
+## Docker Support
+
+Docker is useful for building Linux packages in a consistent environment:
+
+```bash
+docker compose run --rm build-linux       # Build Linux packages
+docker compose run --rm --build build-linux  # Rebuild after code changes
+docker compose run --rm shell             # Interactive development shell
+```
+
+> **Note**: SpeakMCP is an Electron desktop app that requires a display. Docker is primarily for building Linux packages.
+
+## Debug Mode
+
+Enable comprehensive debug logging for development:
+
+```bash
+pnpm dev d               # Enable ALL debug logging
+pnpm dev debug-llm       # LLM calls and responses only
+pnpm dev debug-tools     # MCP tool execution only
+pnpm dev debug-ui        # UI focus and state changes
+```
+
+See [apps/desktop/DEBUGGING.md](apps/desktop/DEBUGGING.md) for detailed debugging instructions.
+
+## Project Structure
+
+```
+SpeakMCP/
+├── apps/
+│   ├── desktop/         # Electron desktop application
+│   │   ├── src/main/    # Main process (MCP, TTS, system integration)
+│   │   ├── src/renderer/# React UI
+│   │   └── speakmcp-rs/ # Rust keyboard/input binary
+│   └── mobile/          # React Native mobile app (Expo)
+├── packages/
+│   └── shared/          # Shared utilities and types
+└── scripts/             # Build and release scripts
+```
+
+## Troubleshooting
+
+### "Electron uninstall" error
+
+Electron binaries weren't installed correctly:
+
+```bash
+rm -rf node_modules
+pnpm install
+```
+
+### Multiple lock files
+
+You've mixed package managers:
+
+```bash
+rm -f package-lock.json bun.lock
+rm -rf node_modules
+pnpm install
+```
+
+### Windows: "not a valid Win32 application"
+
+If `pnpm install` fails with this error:
+
+```powershell
+pnpm install --ignore-scripts
+pnpm.cmd -C apps/desktop exec electron-builder install-app-deps
+```
+
+### Node version mismatch
+
+This project requires Node.js 18-20:
+
+```bash
+node --version  # Should be v18.x, v19.x, or v20.x
+nvm use 20      # If using nvm
+```
+
+## Architecture
+
+| Component | Technology | Purpose |
+|-----------|------------|---------|
+| Desktop App | Electron | System integration, MCP orchestration, TTS |
+| UI | React + TypeScript | Real-time progress tracking, conversation management |
+| Native Binary | Rust | Keyboard monitoring, text injection |
+| MCP Client | TypeScript | Model Context Protocol with OAuth 2.1 |
+| AI Providers | OpenAI, Groq, Gemini | Speech recognition, LLM, TTS |
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run tests: `pnpm test`
+5. Open a Pull Request
+
+**💬 Get help on [Discord](https://discord.gg/cK9WeQ7jPq)** | **🌐 More info at [techfren.net](https://techfren.net)**
+

--- a/README.md
+++ b/README.md
@@ -41,216 +41,53 @@ https://github.com/user-attachments/assets/0c181c70-d1f1-4c5d-a6f5-a73147e75182
 
 - **`Ctrl+T`** (macOS/Linux) or **`Ctrl+Shift+T`** (Windows) for direct typing
 
-
-
 ## ✨ Features
 
-### 🎤 Voice & Speech
-- **Voice-to-Text**: Hold `Ctrl` (macOS/Linux) or `Ctrl+/` (Windows) to record
-- **Toggle Voice Dictation**: Press `Fn` key to start/stop recording (configurable)
-- **Multi-Language Support**: 30+ languages including Spanish, French, German, Chinese, Japanese, Arabic, Hindi
-- **Text-to-Speech (TTS)**: AI-generated speech with 50+ voices across OpenAI, Groq, and Gemini
-- **Auto-Play TTS**: Automatic speech playback for seamless conversations
-
-### 🤖 AI Agent & MCP
-- **MCP Agent Mode**: Hold `Ctrl+Alt` for intelligent tool execution with real-time progress
-- **MCP Integration**: Connect to any MCP-compatible tools and services
-- **OAuth 2.1 Support**: Secure authentication for MCP servers with deep link integration
-- **Tool Management**: Per-server tool toggles and approval prompts
-- **Conversation Continuity**: Context preservation across agent interactions
-
-### 🛠️ Platform & Performance
-- **Cross-Platform**: macOS, Windows, and Linux support with native builds
-- **Rate Limit Handling**: Exponential backoff retry for API rate limits (429 errors)
-- **Model Selection**: Choose specific models for OpenAI, Groq, and Gemini providers
-- **Debug Modes**: Comprehensive logging for LLM calls and tool execution
-- **Universal Integration**: Works with any text-input application
-
-### 🎨 User Experience
-- **Text Input**: `Ctrl+T` (macOS/Linux) or `Ctrl+Shift+T` (Windows) for direct input
-- **Dark/Light Themes**: Toggle between dark and light modes
-- **Resizable Panels**: Drag-to-resize interface components
-- **Kill Switch**: Emergency stop for agent operations (`Ctrl+Shift+Escape`)
-- **Conversation Management**: Full conversation history with tool call visualization
-
-## 🏗️ Architecture
-
-Built with modern technologies for cross-platform performance:
-- **Electron**: Main process for system integration, MCP orchestration, and TTS processing
-- **React + TypeScript**: Modern UI with real-time progress tracking and conversation management
-- **Rust**: High-performance keyboard monitoring and text injection across platforms
-- **MCP Client**: Full Model Context Protocol implementation with OAuth 2.1 support
-- **Multi-Provider AI**: OpenAI, Groq, and Gemini integration for speech, text, and TTS
+| Category | Capabilities |
+|----------|--------------|
+| **🎤 Voice** | Hold-to-record, 30+ languages, Fn toggle mode, auto-insert to any app |
+| **🔊 TTS** | 50+ AI voices via OpenAI, Groq, and Gemini with auto-play |
+| **🤖 MCP Agent** | Tool execution, OAuth 2.1 auth, real-time progress, conversation context |
+| **🛠️ Platform** | macOS/Windows/Linux, rate limit handling, multi-provider AI |
+| **🎨 UX** | Dark/light themes, resizable panels, kill switch, conversation history |
 
 ## 🛠️ Development
 
-**Prerequisites**: Node.js 18+, pnpm, Rust toolchain
-
-> ⚠️ **Important**: This project uses **pnpm** as its package manager. Using npm or yarn may cause installation issues, especially with Electron binaries. If you don't have pnpm installed:
-> ```bash
-> npm install -g pnpm
-> ```
-
 ```bash
-# Setup
-git clone https://github.com/aj47/SpeakMCP.git
-cd SpeakMCP
-pnpm install
-pnpm build-rs  # Build Rust binary for your platform
-pnpm dev       # Start development server
-
-# Platform-specific builds
-pnpm build        # Production build for current platform
-pnpm build:mac    # macOS build (Apple Silicon + Intel)
-pnpm build:win    # Windows build (x64)
-pnpm build:linux  # Linux build (x64)
-
-# Signed release builds (see BUILDING.md for details)
-./scripts/build-release.sh --mac-only
-
-# Testing
-pnpm test         # Run test suite
-pnpm test:run     # Run tests once (CI mode)
-pnpm test:coverage # Run tests with coverage
+git clone https://github.com/aj47/SpeakMCP.git && cd SpeakMCP
+pnpm install && pnpm build-rs && pnpm dev
 ```
 
-### 🐳 Docker Support
-
-Docker can be used for building Linux packages in a consistent environment or for CI/CD pipelines.
-
-```bash
-# Build Linux packages using Docker (outputs to ./dist)
-docker compose run --rm build-linux
-
-# Rebuild after code changes (use --build to rebuild the Docker image)
-docker compose run --rm --build build-linux
-
-# Interactive development shell
-docker compose run --rm shell
-```
-
-> **Note**: SpeakMCP is an Electron desktop application that requires a display. Docker is primarily useful for building Linux packages, not for running the desktop app.
-
-> **Tip**: Since `build-linux` only mounts `./dist` for output, you need to use `--build` after code changes to rebuild the Docker image with your latest source code.
-
-### 🔧 Troubleshooting Development Setup
-
-**"Electron uninstall" error when running `pnpm dev`:**
-
-This usually means Electron binaries weren't installed correctly. Fix it by:
-
-```bash
-# Clean install with pnpm
-rm -rf node_modules
-pnpm install
-```
-
-**Multiple lock files (package-lock.json, pnpm-lock.yaml, bun.lock):**
-
-If you have multiple lock files, you've mixed package managers. Clean up:
-
-```bash
-# Remove all lock files except pnpm's
-rm -f package-lock.json bun.lock
-rm -rf node_modules
-pnpm install
-```
-
-**Windows: "not a valid Win32 application" during postinstall:**
-
-If you see this error when running `pnpm install`:
-```
-%1 is not a valid Win32 application
-```
-
-This is caused by electron-builder attempting to execute `pnpm.cjs` directly. Try the manual workaround:
-
-```powershell
-pnpm install --ignore-scripts
-pnpm.cmd -C apps/desktop exec electron-builder install-app-deps
-```
-
-**Node version mismatch:**
-
-This project works best with Node.js 18-20. Check your version:
-
-```bash
-node --version  # Should be v18.x, v19.x, or v20.x
-```
-
-If using nvm, switch to the recommended version:
-
-```bash
-nvm use 20
-```
+See **[DEVELOPMENT.md](DEVELOPMENT.md)** for full setup, build commands, troubleshooting, and architecture details.
 
 ## ⚙️ Configuration
 
-**AI Providers**: OpenAI, Groq, Google Gemini
-- Configure API keys and custom base URLs in settings
-- Select specific models for each provider
-- Multi-language speech recognition support
-- TTS with 50+ voices across providers
+**AI Providers** — Configure in settings:
+- OpenAI, Groq, or Google Gemini API keys
+- Model selection per provider
+- Custom base URLs (optional)
 
-**MCP Servers**: Configure tools in `mcpServers` JSON format:
+**MCP Servers** — Add tools in `mcpServers` JSON format:
 ```json
 {
   "mcpServers": {
     "filesystem": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
-    },
-    "web-search": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-web-search"],
-      "env": {"BRAVE_API_KEY": "your-key"}
     }
   }
 }
 ```
 
 **Keyboard Shortcuts**:
-- **Hold Ctrl** (macOS/Linux) / **Ctrl+/** (Windows): Voice recording
-- **Fn Key**: Toggle voice dictation (press once to start/stop)
-- **Hold Ctrl+Alt**: MCP agent mode (macOS only)
-- **Ctrl+T** (macOS/Linux) / **Ctrl+Shift+T** (Windows): Text input mode
-- **Ctrl+Shift+Escape**: Kill switch for agent operations
 
-## 🤖 MCP Agent Mode
-
-**MCP (Model Context Protocol)** enables AI assistants to connect to external tools. SpeakMCP implements a full MCP client with advanced capabilities.
-
-**Enhanced Features**:
-- **Intelligent Tool Selection**: Automatically determines which tools to use
-- **Real-time Progress**: Visual feedback with TTS narration during execution
-- **Conversation Continuity**: Context preservation across multi-turn interactions
-- **OAuth 2.1 Integration**: Secure authentication for MCP servers
-- **Rate Limit Handling**: Automatic retry with exponential backoff
-- **Kill Switch**: Emergency stop functionality with `Ctrl+Shift+Escape`
-- **Tool Management**: Per-server tool toggles and approval prompts
-
-**Example commands**:
-- "Create a new project folder and add a README"
-- "Search for latest AI news and summarize the top 3 articles"
-- "Send a message to the team about today's progress"
-- "Analyze this codebase and suggest improvements"
-
-## 🐛 Debug Mode
-
-For development and troubleshooting, SpeakMCP includes comprehensive debug logging:
-
-```bash
-# Enable all debug modes
-pnpm dev d               # Shortest option
-pnpm dev debug-all       # Readable format
-
-# Enable specific modes
-pnpm dev debug-llm       # LLM calls and responses
-pnpm dev debug-tools     # MCP tool execution
-pnpm dev debug-ui        # UI focus, renders, and state changes
-```
-
-See [DEBUGGING.md](DEBUGGING.md) for detailed debugging instructions.
+| Shortcut | Action |
+|----------|--------|
+| Hold `Ctrl` / `Ctrl+/` (Win) | Voice recording |
+| `Fn` | Toggle dictation on/off |
+| Hold `Ctrl+Alt` | MCP agent mode (macOS) |
+| `Ctrl+T` / `Ctrl+Shift+T` (Win) | Text input |
+| `Ctrl+Shift+Escape` | Kill switch |
 
 ## 🤝 Contributing
 
@@ -264,15 +101,7 @@ This project is licensed under the [AGPL-3.0 License](./LICENSE).
 
 ## 🙏 Acknowledgments
 
-- **[Whispo](https://github.com/egoist/whispo)** - This project is a fork of Whispo, the original AI voice assistant
-- [OpenAI](https://openai.com/) for Whisper speech recognition and GPT models
-- [Anthropic](https://anthropic.com/) for Claude and MCP protocol development
-- [Model Context Protocol](https://modelcontextprotocol.io/) for the extensible tool integration standard
-- [Electron](https://electronjs.org/) for cross-platform desktop framework
-- [React](https://reactjs.org/) for the user interface
-- [Rust](https://rust-lang.org/) for system-level integration
-- [Groq](https://groq.com/) for fast inference capabilities
-- [Google](https://ai.google.dev/) for Gemini models
+Built on [Whispo](https://github.com/egoist/whispo) • Powered by [OpenAI](https://openai.com/), [Anthropic](https://anthropic.com/), [Groq](https://groq.com/), [Google](https://ai.google.dev/) • [MCP](https://modelcontextprotocol.io/) • [Electron](https://electronjs.org/) • [React](https://reactjs.org/) • [Rust](https://rust-lang.org/)
 
 ---
 


### PR DESCRIPTION
## Summary

Streamlines the README and extracts development documentation into a dedicated file.

## Changes

### README.md (280 → 109 lines, -60%)
- **Features**: Condensed 20+ bullet points into compact 5-row table
- **Development**: Reduced to 3-line quick start + link to DEVELOPMENT.md
- **Configuration**: Simplified providers, shortened MCP example, converted shortcuts to table
- **Removed duplicates**: MCP Agent Mode section (covered in Features), Debug Mode (moved)
- **Acknowledgments**: Consolidated into single line with links

### New: DEVELOPMENT.md
- Prerequisites and quick start
- Build commands table
- Docker support
- Debug mode instructions
- Project structure overview
- Troubleshooting section (moved from README)
- Architecture table
- Contributing guidelines

## Why

The README was getting long with mixed user/developer content. This separates concerns:
- **README**: User-focused (download, usage, features, config)
- **DEVELOPMENT.md**: Developer-focused (setup, building, debugging, architecture)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author