### PR TITLE
fix(ui): prevent verification step from hiding LLM result

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1398,13 +1398,18 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           isThinking: false,
         })
       } else if (!isStreaming) {
-        messages.push({
-          role: "assistant",
-          content: currentThinkingStep.description || "Agent is thinking...",
-          isComplete: false,
-          timestamp: currentThinkingStep.timestamp,
-          isThinking: true,
-        })
+        // Skip adding a fake "thinking" message for verification steps
+        // These steps don't have LLM content and would hide the actual LLM response
+        const isVerificationStep = currentThinkingStep.title?.toLowerCase().includes("verifying")
+        if (!isVerificationStep) {
+          messages.push({
+            role: "assistant",
+            content: currentThinkingStep.description || "Agent is thinking...",
+            isComplete: false,
+            timestamp: currentThinkingStep.timestamp,
+            isThinking: true,
+          })
+        }
       }
     }
   } else {
@@ -1422,13 +1427,17 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           })
         } else if (step.status === "in_progress" && !isComplete) {
           // Only show in-progress thinking when task is not complete
-          messages.push({
-            role: "assistant",
-            content: step.description || "Agent is thinking...",
-            isComplete: false,
-            timestamp: step.timestamp,
-            isThinking: true,
-          })
+          // Skip verification steps as they would hide the actual LLM response
+          const isVerificationStep = step.title?.toLowerCase().includes("verifying")
+          if (!isVerificationStep) {
+            messages.push({
+              role: "assistant",
+              content: step.description || "Agent is thinking...",
+              isComplete: false,
+              timestamp: step.timestamp,
+              isThinking: true,
+            })
+          }
         }
       })
 


### PR DESCRIPTION
## Summary

Fixes #714 - LLM result hidden by UI verification step causing bad UX

## Problem

When the agent runs a verification step after generating an LLM response, the UI was showing the verification step description ('Checking that the user's request has been achieved') instead of the actual LLM response. This caused a confusing user experience where the LLM output was hidden.

## Root Cause

In `agent-progress.tsx`, when there's an in-progress "thinking" step without `llmContent`, the UI adds a fake assistant message with the step's description. For verification steps (which don't have LLM content), this caused the verification message to appear instead of the actual LLM response from `conversationHistory`.

## Solution

Skip adding a fake "thinking" message for verification-related steps (detected by checking if the step title contains 'verifying'). This allows the actual LLM response from `conversationHistory` to remain visible while verification is in progress.

## Changes

- Modified `apps/desktop/src/renderer/src/components/agent-progress.tsx`:
  - Added check to skip verification steps when adding in-progress thinking messages
  - Applied fix to both the primary code path (using conversationHistory) and the fallback path

## Testing

- Build passes with `npm run build`
- All existing tests pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author