### PR TITLE
fix: add click handler to collapsed preview text for expand/collapse

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -544,7 +544,11 @@ const ToolExecutionBubble: React.FC<{
 
       {/* Collapsed preview - show result summary when available, otherwise show input parameters */}
       {!isExpanded && (collapsedResultSummary || collapsedInputPreview) && (
-        <div className="px-1 pb-1 text-[10px] opacity-80 truncate" title={collapsedResultSummary || collapsedInputPreview || ''}>
+        <div
+          className="px-1 pb-1 text-[10px] opacity-80 truncate cursor-pointer hover:bg-muted/20 rounded"
+          title={collapsedResultSummary || collapsedInputPreview || ''}
+          onClick={handleToggleExpand}
+        >
           {collapsedResultSummary ? (
             <span className="font-medium">{collapsedResultSummary}</span>
           ) : (
@@ -762,7 +766,10 @@ const AssistantWithToolsBubble: React.FC<{
 
             {/* Collapsed preview - show result summary */}
             {!showToolDetails && collapsedResultSummary && (
-              <div className="mt-1 text-[10px] opacity-80 truncate">
+              <div
+                className="mt-1 text-[10px] opacity-80 truncate cursor-pointer hover:bg-muted/20 rounded px-1"
+                onClick={handleToggleToolDetails}
+              >
                 <span className="font-medium">{collapsedResultSummary}</span>
               </div>
             )}


### PR DESCRIPTION
## Summary
Fixes #715 - Clicking on collapsed preview text in ToolExecutionBubble and AssistantWithToolsBubble components now properly triggers expand/collapse.

## Problem
When rendering text in the middle of the UI (specifically the collapsed preview/result summary text), clicking on the text did not expand or collapse the content as expected. This prevented users from viewing full details or hiding them.

## Solution
Added click handlers to the collapsed preview divs in both components:
- `ToolExecutionBubble`: Added `onClick={handleToggleExpand}` to the collapsed preview div
- `AssistantWithToolsBubble`: Added `onClick={handleToggleToolDetails}` to the collapsed result summary div

Also added visual feedback with `cursor-pointer` and `hover:bg-muted/20` classes.

## Testing
- Verified that clicking on collapsed preview text now expands the content
- Verified that clicking again collapses the content
- Tested in the Electron desktop app with remote debugging

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author