### PR TITLE
feat: add persistent storage for Cloudflare tunnel URL

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
@@ -397,6 +397,49 @@ export function Component() {
                     </div>
                   </div>
                 )}
+
+                {/* Show last known URL when tunnel is not running */}
+                {!tunnelStatus?.running && !tunnelStatus?.starting && tunnelStatus?.lastKnownUrl && (
+                  <Control label={<ControlLabel label="Last Known URL" tooltip="The last Cloudflare tunnel URL that was active. This URL may no longer be valid." />} className="px-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        type="text"
+                        value={`${tunnelStatus.lastKnownUrl}/v1`}
+                        readOnly
+                        className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs opacity-75"
+                      />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => navigator.clipboard.writeText(`${tunnelStatus.lastKnownUrl}/v1`)}
+                      >
+                        Copy
+                      </Button>
+                    </div>
+                    <div className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                      ⚠️ This URL was last active {tunnelStatus.lastKnownTimestamp
+                        ? new Date(tunnelStatus.lastKnownTimestamp).toLocaleString()
+                        : "previously"}. Start the tunnel to get a new URL.
+                    </div>
+                    {cfg?.remoteServerApiKey && (
+                      <div className="mt-3">
+                        <div className="text-sm font-medium mb-2">Last Known QR Code</div>
+                        <div className="flex flex-col items-start gap-3">
+                          <div className="p-3 bg-white rounded-lg opacity-75">
+                            <QRCodeSVG
+                              value={`speakmcp://config?baseUrl=${encodeURIComponent(`${tunnelStatus.lastKnownUrl}/v1`)}&apiKey=${encodeURIComponent(cfg.remoteServerApiKey)}`}
+                              size={120}
+                              level="M"
+                            />
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            This QR code uses the last known URL and may not work until the tunnel is restarted.
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </Control>
+                )}
               </>
             )}
           </ControlGroup>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -478,6 +478,10 @@ export type Config = {
 	  remoteServerCorsOrigins?: string[]
 	  remoteServerAutoShowPanel?: boolean // Auto-show floating panel when receiving remote messages
 
+	  // Cloudflare Tunnel Persistence
+	  lastCloudflareTunnelUrl?: string // Last known Cloudflare tunnel URL for easy reconnection
+	  lastCloudflareTunnelTimestamp?: number // Timestamp when the URL was last active
+
   // Stream Status Watcher Configuration
   streamStatusWatcherEnabled?: boolean
   streamStatusFilePath?: string


### PR DESCRIPTION
## Summary

This PR adds persistent storage for the Cloudflare tunnel URL to enable easy reconnection from mobile devices.

## Changes

### Config Type (`apps/desktop/src/shared/types.ts`)
- Added `lastCloudflareTunnelUrl` field to store the last known tunnel URL
- Added `lastCloudflareTunnelTimestamp` field to track when the URL was last active

### Cloudflare Tunnel (`apps/desktop/src/main/cloudflare-tunnel.ts`)
- Added `saveTunnelUrlToConfig()` function to persist URL when tunnel starts
- Added `getLastKnownTunnelUrl()` function to retrieve persisted URL
- Updated `getCloudflareTunnelStatus()` to include `lastKnownUrl` and `lastKnownTimestamp`
- URL is automatically saved to config when a new tunnel is created

### Settings UI (`apps/desktop/src/renderer/src/pages/settings-remote-server.tsx`)
- Added "Last Known URL" section that displays when tunnel is not running
- Shows the last known URL with copy button
- Displays timestamp of when the URL was last active
- Shows QR code with last known URL for mobile reconnection
- Visual indicators (opacity, warning icon) to show URL may no longer be valid

## How It Works

1. When a Cloudflare tunnel is started and a URL is obtained, it's automatically saved to the config file
2. When the tunnel is stopped or the app is restarted, the last known URL is still available
3. Users can see the last known URL in settings with a warning that it may no longer be active
4. The QR code with the last known URL allows mobile users to quickly try reconnecting

## Testing

- [x] TypeScript type checking passes
- [x] All existing tests pass
- [ ] Manual testing with Cloudflare tunnel

Closes #482

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author