### PR TITLE
Fix JSX nesting in MCP Config Manager tools dialog

### DIFF
--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
@@ -2063,6 +2063,7 @@ export function MCPConfigManager({
                                     })}
                                   </div>
                                 </TooltipProvider>
+	                              </div>
                             </div>
                             <div className="ml-4 flex items-center gap-2">
                               <Dialog>
@@ -2122,7 +2123,6 @@ export function MCPConfigManager({
                                       })}
                                     </div>
                                   </div>
-                                </div>
                               </DialogContent>
                             </Dialog>
                             <Switch
@@ -2132,6 +2132,7 @@ export function MCPConfigManager({
                               }
                             />
                           </div>
+	                        </div>
                         ))}
                       </div>
                     )}


### PR DESCRIPTION
## What
Fixes mismatched JSX tags in `apps/desktop/src/renderer/src/components/mcp-config-manager.tsx` inside the Tools section (per-tool dialog / tooltip area).

This resolves the Vite/Babel parse error (`Expected corresponding JSX closing tag for <DialogContent>`) and subsequent TS JSX structure errors.

## Why
The Tools UI had unbalanced `<div>` wrappers around the tooltip indicators / dialog content.

## Testing
- `pnpm -C apps/desktop run typecheck`
- `pnpm -C apps/desktop run test:run`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author