### PR TITLE
fix(mobile): make LLM result text expandable/collapsible and selectable

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -1744,25 +1744,42 @@ export default function ChatScreen({ route, navigation }: any) {
                   <>
                     {m.content ? (
                       isExpanded || !shouldCollapse ? (
-                        <MarkdownRenderer content={m.content} />
+                        <MarkdownRenderer content={m.content} selectable={true} />
                       ) : (
-                        <Text
-                          style={{ color: theme.colors.foreground }}
-                          numberOfLines={COLLAPSED_LINES}
+                        <Pressable
+                          onPress={() => toggleMessageExpansion(i)}
+                          accessibilityRole="button"
+                          accessibilityHint="Tap to expand message"
+                          style={({ pressed }) => [
+                            styles.collapsedContentPressable,
+                            pressed && styles.collapsedContentPressed,
+                          ]}
                         >
-                          {m.content}
-                        </Text>
+                          <Text
+                            style={{ color: theme.colors.foreground }}
+                            numberOfLines={COLLAPSED_LINES}
+                          >
+                            {m.content}
+                          </Text>
+                        </Pressable>
                       )
                     ) : null}
 
                     {/* Unified Tool Execution Display - show when there are toolCalls OR toolResults */}
                     {((m.toolCalls?.length ?? 0) > 0 || (m.toolResults?.length ?? 0) > 0) && (
-                      <View style={[
-                        styles.toolExecutionCard,
-                        isPending && styles.toolExecutionPending,
-                        allSuccess && styles.toolExecutionSuccess,
-                        hasErrors && styles.toolExecutionError,
-                      ]}>
+                      <Pressable
+                        onPress={!isExpanded && shouldCollapse ? () => toggleMessageExpansion(i) : undefined}
+                        disabled={isExpanded || !shouldCollapse}
+                        accessibilityRole={!isExpanded && shouldCollapse ? 'button' : undefined}
+                        accessibilityHint={!isExpanded && shouldCollapse ? 'Tap to expand tool details' : undefined}
+                        style={({ pressed }) => [
+                          styles.toolExecutionCard,
+                          isPending && styles.toolExecutionPending,
+                          allSuccess && styles.toolExecutionSuccess,
+                          hasErrors && styles.toolExecutionError,
+                          !isExpanded && shouldCollapse && pressed && styles.toolExecutionPressed,
+                        ]}
+                      >
                         {/* Collapsed view - show preview */}
                         {!isExpanded && (
                           <View style={styles.toolExecutionCollapsed}>
@@ -1795,7 +1812,7 @@ export default function ChatScreen({ route, navigation }: any) {
                                     <Text style={styles.toolName}>{toolCall.name}</Text>
                                     {toolCall.arguments && (
                                       <ScrollView style={styles.toolParamsScroll} nestedScrollEnabled>
-                                        <Text style={styles.toolParamsCode}>
+                                        <Text style={styles.toolParamsCode} selectable={true}>
                                           {formatToolArguments(toolCall.arguments)}
                                         </Text>
                                       </ScrollView>
@@ -1828,14 +1845,14 @@ export default function ChatScreen({ route, navigation }: any) {
                                     </Text>
                                   </View>
                                   <ScrollView style={styles.toolResultScroll} nestedScrollEnabled>
-                                    <Text style={styles.toolResultCode}>
+                                    <Text style={styles.toolResultCode} selectable={true}>
                                       {result.content || 'No content returned'}
                                     </Text>
                                   </ScrollView>
                                   {result.error && (
                                     <View style={styles.toolResultErrorSection}>
                                       <Text style={styles.toolResultErrorLabel}>Error:</Text>
-                                      <Text style={styles.toolResultErrorText}>{result.error}</Text>
+                                      <Text style={styles.toolResultErrorText} selectable={true}>{result.error}</Text>
                                     </View>
                                   )}
                                 </View>
@@ -1853,7 +1870,7 @@ export default function ChatScreen({ route, navigation }: any) {
                             </View>
                           </>
                         )}
-                      </View>
+                      </Pressable>
                     )}
                   </>
                 )}
@@ -2151,6 +2168,16 @@ function createStyles(theme: Theme) {
     },
     collapsedToolTextError: {
       color: 'rgb(239, 68, 68)',
+    },
+    collapsedContentPressable: {
+      // Make the collapsed text area tappable
+    },
+    collapsedContentPressed: {
+      backgroundColor: theme.colors.muted,
+      borderRadius: radius.sm,
+    },
+    toolExecutionPressed: {
+      opacity: 0.7,
     },
     inputRow: {
       flexDirection: 'row',

--- a/apps/mobile/src/ui/MarkdownRenderer.tsx
+++ b/apps/mobile/src/ui/MarkdownRenderer.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
-import { Platform, StyleSheet } from 'react-native';
-import Markdown from 'react-native-markdown-display';
+import React, { useMemo } from 'react';
+import { Platform, StyleSheet, Text } from 'react-native';
+import Markdown, { RenderRules } from 'react-native-markdown-display';
 import { useTheme } from './ThemeProvider';
 import { spacing, radius } from './theme';
 
 interface MarkdownRendererProps {
   content: string;
+  selectable?: boolean;
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
+  selectable = true,
 }) => {
   const { theme, isDark } = useTheme();
 
@@ -141,8 +143,22 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     },
   });
 
+  // Custom render rules to enable text selection
+  const rules: RenderRules = useMemo(() => {
+    if (!selectable) return {};
+
+    return {
+      // Make text content selectable
+      textgroup: (node, children, parent, styles) => (
+        <Text key={node.key} style={styles.textgroup} selectable={true}>
+          {children}
+        </Text>
+      ),
+    };
+  }, [selectable]);
+
   return (
-    <Markdown style={markdownStyles}>
+    <Markdown style={markdownStyles} rules={rules}>
       {content}
     </Markdown>
   );


### PR DESCRIPTION
## Summary

Fixes #716 - Text not expandable/collapsible and not selectable in mobile app.

## Problem

In the mobile app, clicking on the middle area where the LLM response text renders did not expand or collapse the content as expected. Additionally, the text was not selectable, preventing users from highlighting and copying it. There were also difficulties expanding failed tool calls because the clickable section was too small.

## Changes

### ChatScreen.tsx
- **Wrapped collapsed text content in `Pressable`** - Tapping the collapsed text area now expands the message
- **Wrapped tool execution cards in `Pressable`** - Tapping collapsed tool cards now expands to show details
- **Added `selectable={true}`** to tool parameters, response text, and error text for copying
- **Added visual feedback styles** for pressed states (`collapsedContentPressed`, `toolExecutionPressed`)

### MarkdownRenderer.tsx
- **Added `selectable` prop** (default: `true`) to enable text selection
- **Custom render rules** - Uses `textgroup` render rule to make markdown text selectable

## Behavior Changes

**Before:**
- Only the header (role icon, tool badge, expand button) was clickable
- Text could not be selected/copied
- Small tap target for expanding tool results

**After:**
- ✅ Tapping anywhere on collapsed text expands the message
- ✅ Tapping on collapsed tool cards expands to show full details
- ✅ Expanded text is selectable for copying
- ✅ Tool parameters and response text are selectable
- ✅ Visual feedback when pressing collapsed content

## Testing

```bash
pnpm dev:mobile  # Press 'w' for web → localhost:8081
```

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Manual testing on mobile web

## Related Issue

Closes #716

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author