### PR TITLE
feat: show 'Start with Text' and 'Start with Voice' buttons always

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -401,9 +401,19 @@ export function Component() {
           <EmptyState onTextClick={handleTextClick} onVoiceClick={handleVoiceStart} />
         ) : (
           <>
-            {/* Header with clear inactive button */}
-            {inactiveSessionCount > 0 && (
-              <div className="px-4 py-2 flex items-center justify-end bg-muted/20 border-b">
+            {/* Header with start buttons and clear inactive button */}
+            <div className="px-4 py-2 flex items-center justify-between bg-muted/20 border-b">
+              <div className="flex gap-2">
+                <Button size="sm" onClick={handleTextClick} className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  Start with Text
+                </Button>
+                <Button variant="secondary" size="sm" onClick={handleVoiceStart} className="gap-2">
+                  <Mic className="h-4 w-4" />
+                  Start with Voice
+                </Button>
+              </div>
+              {inactiveSessionCount > 0 && (
                 <Button
                   variant="ghost"
                   size="sm"
@@ -414,8 +424,8 @@ export function Component() {
                   <CheckCircle2 className="h-4 w-4" />
                   Clear {inactiveSessionCount} completed
                 </Button>
-              </div>
-            )}
+              )}
+            </div>
             {/* Active sessions grid - includes pending continuation if any */}
             <SessionGrid sessionCount={allProgressEntries.length + (pendingProgress ? 1 : 0)}>
               {/* Pending continuation tile first */}


### PR DESCRIPTION
## Summary

This PR fixes #731 by always displaying the 'Start with Text' and 'Start with Voice' buttons, even when sessions are active.

## Changes

- Modified the sessions page to show start buttons in a header bar when there are active sessions
- The buttons appear alongside the 'Clear completed' button on the left side of the header
- The empty state (when no sessions) still shows the centered welcome message with the buttons

## Before
The start buttons were hidden when sessions were active, requiring users to terminate all sessions before starting new ones.

## After
The start buttons are always visible in the header bar when sessions exist, allowing users to start new sessions at any time.

## Testing
- Build passes successfully
- Type checking passes
- Tests pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author