### PR TITLE
Refactor: Consolidate LLM abstraction layer

### DIFF
--- a/apps/desktop/src/main/llm/agent/context-extraction.ts
+++ b/apps/desktop/src/main/llm/agent/context-extraction.ts
@@ -1,0 +1,228 @@
+/**
+ * Context Extraction Module
+ * Extracts useful context from conversation history for agent mode
+ */
+
+import { makeStructuredContextExtraction } from "../structured-output"
+import type { MCPToolCall, MCPToolResult } from "../../mcp-service"
+
+/**
+ * Conversation entry for context extraction
+ */
+export interface ConversationEntry {
+  role: "user" | "assistant" | "tool"
+  content: string
+  toolCalls?: MCPToolCall[]
+  toolResults?: MCPToolResult[]
+}
+
+/**
+ * Extracted context information
+ */
+export interface ExtractedContext {
+  resources: Array<{ type: string; id: string }>
+}
+
+/**
+ * Use LLM to extract useful context from conversation history
+ */
+export async function extractContextFromHistory(
+  conversationHistory: ConversationEntry[],
+  providerId?: string,
+): Promise<ExtractedContext> {
+  if (conversationHistory.length === 0) {
+    return { resources: [] }
+  }
+
+  // Create a condensed version of the conversation for analysis
+  const conversationText = conversationHistory
+    .map((entry) => {
+      let text = `${entry.role.toUpperCase()}: ${entry.content}`
+
+      if (entry.toolCalls) {
+        text += `\nTOOL_CALLS: ${entry.toolCalls.map((tc) => `${tc.name}(${JSON.stringify(tc.arguments)})`).join(", ")}`
+      }
+
+      if (entry.toolResults) {
+        text += `\nTOOL_RESULTS: ${entry.toolResults.map((tr) => (tr.isError ? "ERROR" : "SUCCESS")).join(", ")}`
+      }
+
+      return text
+    })
+    .join("\n\n")
+
+  const contextExtractionPrompt = `Extract active resource IDs from this conversation:
+
+${conversationText}
+
+Return JSON: {"resources": [{"type": "session|connection|handle|other", "id": "actual_id_value"}]}
+Only include currently active/usable resources.`
+
+  try {
+    const result = await makeStructuredContextExtraction(
+      contextExtractionPrompt,
+      providerId,
+    )
+    return result as ExtractedContext
+  } catch (error) {
+    return { resources: [] }
+  }
+}
+
+/**
+ * Extract recent context from history (simple approach without LLM)
+ * Returns the last N messages for context
+ */
+export function extractRecentContext(
+  history: ConversationEntry[],
+  maxMessages: number = 8,
+): ConversationEntry[] {
+  return history.slice(-maxMessages)
+}
+
+/**
+ * Analyze tool errors and provide recovery strategies
+ */
+export function analyzeToolErrors(toolResults: MCPToolResult[]): {
+  recoveryStrategy: string
+  errorTypes: string[]
+} {
+  const errorTypes: string[] = []
+  const errorMessages = toolResults
+    .filter((r) => r.isError)
+    .map((r) => r.content.map((c) => c.text).join(" "))
+    .join(" ")
+
+  // Categorize error types generically
+  if (
+    errorMessages.includes("timeout") ||
+    errorMessages.includes("connection")
+  ) {
+    errorTypes.push("connectivity")
+  }
+  if (
+    errorMessages.includes("permission") ||
+    errorMessages.includes("access") ||
+    errorMessages.includes("denied")
+  ) {
+    errorTypes.push("permissions")
+  }
+  if (
+    errorMessages.includes("not found") ||
+    errorMessages.includes("does not exist") ||
+    errorMessages.includes("missing")
+  ) {
+    errorTypes.push("resource_missing")
+  }
+
+  // Generate generic recovery strategy
+  let recoveryStrategy = "RECOVERY STRATEGIES:\n"
+
+  if (errorTypes.includes("connectivity")) {
+    recoveryStrategy +=
+      "- For connectivity issues: Wait a moment and retry, or check if the service is available\n"
+  }
+  if (errorTypes.includes("permissions")) {
+    recoveryStrategy +=
+      "- For permission errors: Try alternative approaches or check access rights\n"
+  }
+  if (errorTypes.includes("resource_missing")) {
+    recoveryStrategy +=
+      "- For missing resources: Verify the resource exists or try creating it first\n"
+  }
+
+  // Always provide generic fallback advice
+  recoveryStrategy +=
+    "- General: Try breaking down the task into smaller steps, use alternative tools, or try a different approach\n"
+
+  return { recoveryStrategy, errorTypes }
+}
+
+/**
+ * Format conversation history for progress updates
+ */
+export function formatConversationForProgress(
+  history: ConversationEntry[],
+): Array<{
+  role: string
+  content: string
+  toolCalls?: Array<{ name: string; arguments: Record<string, unknown> }>
+  toolResults?: Array<{ success: boolean; content: string; error?: string }>
+  timestamp?: number
+}> {
+  const isNudge = (content: string) =>
+    content.includes("Please either take action using available tools") ||
+    content.includes("You have relevant tools available for this request")
+
+  return history
+    .filter((entry) => !(entry.role === "user" && isNudge(entry.content)))
+    .map((entry) => ({
+      role: entry.role,
+      content: entry.content,
+      toolCalls: entry.toolCalls?.map((tc) => ({
+        name: tc.name,
+        arguments: tc.arguments,
+      })),
+      toolResults: entry.toolResults?.map((tr) => {
+        const contentText = Array.isArray(tr.content)
+          ? tr.content.map((c) => c.text).join("\n")
+          : String(tr.content || "")
+
+        return {
+          success: !tr.isError,
+          content: contentText,
+          error: tr.isError ? contentText : undefined,
+        }
+      }),
+      timestamp: (entry as { timestamp?: number }).timestamp || Date.now(),
+    }))
+}
+
+/**
+ * Check if content is just a tool call placeholder
+ */
+export function isToolCallPlaceholder(content: string): boolean {
+  const trimmed = content.trim()
+  return /^\[(?:Calling tools?|Tool|Tools?):[^\]]+\]$/i.test(trimmed)
+}
+
+/**
+ * Detect if agent is repeating the same response (infinite loop)
+ */
+export function detectRepeatedResponse(
+  currentResponse: string,
+  conversationHistory: ConversationEntry[],
+): boolean {
+  const assistantResponses = conversationHistory
+    .filter((entry) => entry.role === "assistant")
+    .map((entry) => entry.content.trim().toLowerCase())
+    .slice(-3)
+
+  if (assistantResponses.length < 2) return false
+
+  const currentTrimmed = currentResponse.trim().toLowerCase()
+
+  for (const prevResponse of assistantResponses.slice(-2)) {
+    if (prevResponse.length === 0 || currentTrimmed.length === 0) continue
+
+    const similarity = calculateSimilarity(currentTrimmed, prevResponse)
+    if (similarity > 0.8) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Simple similarity calculation (Jaccard similarity on words)
+ */
+function calculateSimilarity(str1: string, str2: string): number {
+  const words1 = new Set(str1.split(/\s+/))
+  const words2 = new Set(str2.split(/\s+/))
+
+  const intersection = new Set([...words1].filter((x) => words2.has(x)))
+  const union = new Set([...words1, ...words2])
+
+  return union.size === 0 ? 0 : intersection.size / union.size
+}

--- a/apps/desktop/src/main/llm/agent/index.ts
+++ b/apps/desktop/src/main/llm/agent/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Agent Module Exports
+ * Unified exports for agent-related functionality
+ */
+
+// Context extraction
+export {
+  extractContextFromHistory,
+  extractRecentContext,
+  analyzeToolErrors,
+  formatConversationForProgress,
+  isToolCallPlaceholder,
+  detectRepeatedResponse,
+  type ConversationEntry,
+  type ExtractedContext,
+} from "./context-extraction"
+
+// Tool execution
+export {
+  executeToolWithRetries,
+  executeToolsInParallel,
+  executeToolsSequentially,
+  toolRequiresSequentialExecution,
+  batchRequiresSequentialExecution,
+  buildToolErrorSummary,
+  SEQUENTIAL_EXECUTION_TOOL_PATTERNS,
+  type ToolExecutionResult,
+} from "./tool-execution"

--- a/apps/desktop/src/main/llm/agent/tool-execution.ts
+++ b/apps/desktop/src/main/llm/agent/tool-execution.ts
@@ -1,0 +1,297 @@
+/**
+ * Tool Execution Module
+ * Handles tool call execution with retry logic and kill switch support
+ */
+
+import type { MCPToolCall, MCPToolResult } from "../../mcp-service"
+import { agentSessionStateManager } from "../../state"
+import { isDebugTools, logTools } from "../../debug"
+
+/**
+ * Result from a single tool execution including metadata
+ */
+export interface ToolExecutionResult {
+  toolCall: MCPToolCall
+  result: MCPToolResult
+  retryCount: number
+  cancelledByKill: boolean
+}
+
+/**
+ * Tool name patterns that require sequential execution to avoid race conditions.
+ * These are typically browser automation tools that modify shared state.
+ */
+export const SEQUENTIAL_EXECUTION_TOOL_PATTERNS: string[] = [
+  // Playwright browser tools that modify DOM or browser state
+  "browser_click",
+  "browser_drag",
+  "browser_type",
+  "browser_fill_form",
+  "browser_hover",
+  "browser_press_key",
+  "browser_select_option",
+  "browser_file_upload",
+  "browser_handle_dialog",
+  "browser_navigate",
+  "browser_navigate_back",
+  "browser_close",
+  "browser_resize",
+  "browser_tabs",
+  "browser_wait_for",
+  "browser_evaluate",
+  "browser_run_code",
+  // Vision-based coordinate tools
+  "browser_mouse_click_xy",
+  "browser_mouse_drag_xy",
+  "browser_mouse_move_xy",
+]
+
+/**
+ * Check if a tool call requires sequential execution based on its name
+ */
+export function toolRequiresSequentialExecution(toolName: string): boolean {
+  const baseName = toolName.includes(":") ? toolName.split(":")[1] : toolName
+  return SEQUENTIAL_EXECUTION_TOOL_PATTERNS.some((pattern) => baseName === pattern)
+}
+
+/**
+ * Check if any tools in the batch require sequential execution
+ */
+export function batchRequiresSequentialExecution(toolCalls: MCPToolCall[]): boolean {
+  return toolCalls.some((tc) => toolRequiresSequentialExecution(tc.name))
+}
+
+/**
+ * Execute a single tool call with retry logic and kill switch support
+ */
+export async function executeToolWithRetries(
+  toolCall: MCPToolCall,
+  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void) => Promise<MCPToolResult>,
+  currentSessionId: string,
+  onToolProgress: (message: string) => void,
+  maxRetries: number = 2,
+): Promise<ToolExecutionResult> {
+  // Check for stop signal before starting
+  if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
+    return {
+      toolCall,
+      result: {
+        content: [{ type: "text", text: "Tool execution cancelled by emergency kill switch" }],
+        isError: true,
+      },
+      retryCount: 0,
+      cancelledByKill: true,
+    }
+  }
+
+  // Execute tool with cancel-aware race so kill switch can stop mid-tool
+  let cancelledByKill = false
+  let cancelInterval: ReturnType<typeof setInterval> | null = null
+
+  const stopPromise: Promise<MCPToolResult> = new Promise((resolve) => {
+    cancelInterval = setInterval(() => {
+      if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
+        cancelledByKill = true
+        if (cancelInterval) clearInterval(cancelInterval)
+        resolve({
+          content: [{ type: "text", text: "Tool execution cancelled by emergency kill switch" }],
+          isError: true,
+        })
+      }
+    }, 100)
+  })
+
+  const execPromise = executeToolCall(toolCall, onToolProgress)
+  let result = (await Promise.race([execPromise, stopPromise])) as MCPToolResult
+
+  // Avoid unhandled rejection if the tool promise rejects after we already stopped
+  if (cancelledByKill) {
+    execPromise.catch(() => {
+      /* swallow after kill switch */
+    })
+  }
+  if (cancelInterval) clearInterval(cancelInterval)
+
+  if (cancelledByKill) {
+    return {
+      toolCall,
+      result,
+      retryCount: 0,
+      cancelledByKill: true,
+    }
+  }
+
+  // Enhanced retry logic for specific error types
+  let retryCount = 0
+  while (result.isError && retryCount < maxRetries) {
+    // Check kill switch before retrying
+    if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
+      return {
+        toolCall,
+        result: {
+          content: [{ type: "text", text: "Tool execution cancelled by emergency kill switch" }],
+          isError: true,
+        },
+        retryCount,
+        cancelledByKill: true,
+      }
+    }
+
+    const errorText = result.content.map((c) => c.text).join(" ").toLowerCase()
+
+    // Check if this is a retryable error
+    const isRetryableError =
+      errorText.includes("timeout") ||
+      errorText.includes("connection") ||
+      errorText.includes("network") ||
+      errorText.includes("temporary") ||
+      errorText.includes("busy")
+
+    if (isRetryableError) {
+      retryCount++
+
+      // Wait before retry (exponential backoff)
+      await new Promise((resolve) => setTimeout(resolve, Math.pow(2, retryCount) * 1000))
+
+      result = await executeToolCall(toolCall, onToolProgress)
+    } else {
+      break // Don't retry non-transient errors
+    }
+  }
+
+  return {
+    toolCall,
+    result,
+    retryCount,
+    cancelledByKill: false,
+  }
+}
+
+/**
+ * Execute tool calls in parallel
+ */
+export async function executeToolsInParallel(
+  toolCalls: MCPToolCall[],
+  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void) => Promise<MCPToolResult>,
+  currentSessionId: string,
+  onToolProgress: (toolIndex: number, message: string) => void,
+  maxRetries: number = 2,
+): Promise<ToolExecutionResult[]> {
+  if (isDebugTools()) {
+    logTools(
+      `Executing ${toolCalls.length} tool calls in parallel`,
+      toolCalls.map((t) => t.name),
+    )
+  }
+
+  const executionPromises = toolCalls.map(async (toolCall, index) => {
+    return executeToolWithRetries(
+      toolCall,
+      executeToolCall,
+      currentSessionId,
+      (message) => onToolProgress(index, message),
+      maxRetries,
+    )
+  })
+
+  return Promise.all(executionPromises)
+}
+
+/**
+ * Execute tool calls sequentially
+ */
+export async function executeToolsSequentially(
+  toolCalls: MCPToolCall[],
+  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void) => Promise<MCPToolResult>,
+  currentSessionId: string,
+  onToolProgress: (toolIndex: number, message: string) => void,
+  maxRetries: number = 2,
+): Promise<ToolExecutionResult[]> {
+  if (isDebugTools()) {
+    logTools(
+      `Executing ${toolCalls.length} tool calls sequentially`,
+      toolCalls.map((t) => t.name),
+    )
+  }
+
+  const results: ToolExecutionResult[] = []
+
+  for (let i = 0; i < toolCalls.length; i++) {
+    const toolCall = toolCalls[i]
+
+    // Check for stop signal before executing each tool
+    if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
+      break
+    }
+
+    if (isDebugTools()) {
+      logTools("Executing planned tool call", toolCall)
+    }
+
+    const result = await executeToolWithRetries(
+      toolCall,
+      executeToolCall,
+      currentSessionId,
+      (message) => onToolProgress(i, message),
+      maxRetries,
+    )
+
+    results.push(result)
+
+    if (result.cancelledByKill) {
+      break
+    }
+  }
+
+  return results
+}
+
+/**
+ * Build error summary for failed tools
+ */
+export function buildToolErrorSummary(
+  failedTools: string[],
+  toolResults: MCPToolResult[],
+  recoveryStrategy: string,
+): string {
+  return `Tool execution errors occurred:
+${failedTools
+  .map((toolName) => {
+    const failedResult = toolResults.find((r) => r.isError)
+    const errorText = failedResult?.content.map((c) => c.text).join(" ") || "Unknown error"
+
+    let suggestion = ""
+    if (
+      errorText.includes("timeout") ||
+      errorText.includes("connection") ||
+      errorText.includes("network")
+    ) {
+      suggestion = " (Suggestion: Try again or check connectivity)"
+    } else if (
+      errorText.includes("permission") ||
+      errorText.includes("access") ||
+      errorText.includes("denied")
+    ) {
+      suggestion = " (Suggestion: Try a different approach)"
+    } else if (
+      errorText.includes("not found") ||
+      errorText.includes("missing") ||
+      errorText.includes("does not exist")
+    ) {
+      suggestion = " (Suggestion: Verify the resource exists or try alternatives)"
+    } else if (errorText.includes("Expected string, received array")) {
+      suggestion = " (Fix: Parameter type mismatch - check tool schema)"
+    } else if (errorText.includes("Expected array, received string")) {
+      suggestion = " (Fix: Parameter should be an array, not a string)"
+    } else if (errorText.includes("invalid_type")) {
+      suggestion = " (Fix: Check parameter types match tool schema)"
+    }
+
+    return `- ${toolName}: ${errorText}${suggestion}`
+  })
+  .join("\n")}
+
+${recoveryStrategy}
+
+Please try alternative approaches, break down the task into smaller steps, or provide manual instructions to the user.`
+}

--- a/apps/desktop/src/main/llm/index.ts
+++ b/apps/desktop/src/main/llm/index.ts
@@ -1,0 +1,192 @@
+/**
+ * LLM Module - Unified Public API
+ *
+ * This module provides a clean abstraction layer for LLM interactions:
+ * - Provider abstraction (OpenAI, Groq, Gemini)
+ * - Retry logic with exponential backoff
+ * - Structured output handling
+ * - Agent utilities (context extraction, tool execution)
+ *
+ * Usage:
+ * ```ts
+ * import { createProviderFromConfig, makeLLMCallWithFetch } from "./llm"
+ *
+ * // Using provider directly
+ * const provider = createProviderFromConfig("mcp")
+ * const response = await provider.makeCall(messages)
+ *
+ * // Using legacy API (backwards compatible)
+ * const result = await makeLLMCallWithFetch(messages)
+ * ```
+ */
+
+// Re-export types
+export type {
+  LLMMessage,
+  LLMCallOptions,
+  LLMToolCallResponse,
+  MCPToolCall,
+  CompletionVerification,
+  ModelCapabilities,
+  RetryProgressCallback,
+  StreamingCallback,
+  ResponseFormat,
+  RawLLMResponse,
+} from "./types"
+
+// Re-export retry utilities
+export {
+  withRetry,
+  apiCallWithRetry,
+  HttpError,
+  isRetryableError,
+  calculateBackoffDelay,
+  type RetryOptions,
+} from "./retry"
+
+// Re-export provider factory and types
+export {
+  createProvider,
+  createProviderFromConfig,
+  getAvailableProviders,
+  isValidProviderId,
+  type ProviderId,
+  type LLMProvider,
+  type LLMProviderConstructorConfig,
+  // Provider implementations
+  OpenAIProvider,
+  GroqProvider,
+  GeminiProvider,
+  // Utilities
+  extractJsonObject,
+  recordStructuredOutputFailure,
+  recordStructuredOutputSuccess,
+  TOOL_CALL_RESPONSE_SCHEMA,
+  VERIFICATION_RESPONSE_SCHEMA,
+} from "./providers"
+
+// Re-export structured output utilities
+export {
+  makeStructuredToolCall,
+  makeStructuredContextExtraction,
+  makeTextCompletion,
+  parseToolCallResponse,
+  parseContextExtractionResponse,
+  LLMToolCallSchema,
+  ContextExtractionSchema,
+  CONTEXT_EXTRACTION_SCHEMA,
+  type ContextExtractionResponse,
+} from "./structured-output"
+
+// Re-export agent utilities
+export {
+  // Context extraction
+  extractContextFromHistory,
+  extractRecentContext,
+  analyzeToolErrors,
+  formatConversationForProgress,
+  isToolCallPlaceholder,
+  detectRepeatedResponse,
+  type ConversationEntry,
+  type ExtractedContext,
+  // Tool execution
+  executeToolWithRetries,
+  executeToolsInParallel,
+  executeToolsSequentially,
+  toolRequiresSequentialExecution,
+  batchRequiresSequentialExecution,
+  buildToolErrorSummary,
+  SEQUENTIAL_EXECUTION_TOOL_PATTERNS,
+  type ToolExecutionResult,
+} from "./agent"
+
+// ============================================================================
+// Legacy API - Backwards compatible exports from llm-fetch.ts
+// ============================================================================
+
+import { configStore } from "../config"
+import { createProviderFromConfig } from "./providers"
+import type { LLMMessage, LLMCallOptions, LLMToolCallResponse, RetryProgressCallback, StreamingCallback, CompletionVerification } from "./types"
+
+/**
+ * Main function to make LLM calls using fetch with automatic retry on empty responses
+ * @deprecated Use createProviderFromConfig().makeCall() instead
+ */
+export async function makeLLMCallWithFetch(
+  messages: Array<{ role: string; content: string }>,
+  providerId?: string,
+  onRetryProgress?: RetryProgressCallback,
+  sessionId?: string,
+): Promise<LLMToolCallResponse> {
+  const config = configStore.get()
+  const effectiveProviderId = providerId || config.mcpToolsProviderId || "openai"
+
+  // Create provider with the specified ID
+  const provider = createProviderFromConfig("mcp")
+
+  // Convert messages to LLMMessage format
+  const llmMessages: LLMMessage[] = messages.map((m) => ({
+    role: m.role as "system" | "user" | "assistant",
+    content: m.content,
+  }))
+
+  const options: LLMCallOptions = {
+    useStructuredOutput: true,
+    sessionId,
+    onRetryProgress,
+  }
+
+  return provider.makeCall(llmMessages, options)
+}
+
+/**
+ * Make a streaming LLM call
+ * @deprecated Use createProviderFromConfig().makeStreamingCall() instead
+ */
+export async function makeLLMCallWithStreaming(
+  messages: Array<{ role: string; content: string }>,
+  onChunk: StreamingCallback,
+  providerId?: string,
+  sessionId?: string,
+  externalAbortController?: AbortController,
+): Promise<LLMToolCallResponse> {
+  const provider = createProviderFromConfig("mcp")
+
+  const llmMessages: LLMMessage[] = messages.map((m) => ({
+    role: m.role as "system" | "user" | "assistant",
+    content: m.content,
+  }))
+
+  return provider.makeStreamingCall(llmMessages, onChunk, { sessionId })
+}
+
+/**
+ * Make a simple text completion call
+ * @deprecated Use createProviderFromConfig().makeTextCompletion() instead
+ */
+export async function makeTextCompletionWithFetch(
+  prompt: string,
+  providerId?: string,
+  sessionId?: string,
+): Promise<string> {
+  const provider = createProviderFromConfig("transcript")
+  return provider.makeTextCompletion(prompt, { sessionId })
+}
+
+/**
+ * Verify completion using LLM
+ * @deprecated Use createProviderFromConfig().verifyCompletion() instead
+ */
+export async function verifyCompletionWithFetch(
+  messages: Array<{ role: string; content: string }>,
+  providerId?: string,
+): Promise<CompletionVerification> {
+  const provider = createProviderFromConfig("mcp")
+
+  const llmMessages: LLMMessage[] = messages.map((m) => ({
+    role: m.role as "system" | "user" | "assistant",
+    content: m.content,
+  }))
+
+  return provider.verifyCompletion(llmMessages)
+}

--- a/apps/desktop/src/main/llm/providers/base.ts
+++ b/apps/desktop/src/main/llm/providers/base.ts
@@ -1,0 +1,309 @@
+/**
+ * Abstract LLM Provider interface
+ * All provider implementations must implement this interface
+ */
+
+import type {
+  LLMMessage,
+  LLMCallOptions,
+  LLMToolCallResponse,
+  CompletionVerification,
+  ModelCapabilities,
+  ResponseFormat,
+  RawLLMResponse,
+} from "../types"
+
+/**
+ * Base interface for all LLM providers
+ */
+export interface LLMProvider {
+  /** Unique identifier for this provider (e.g., "openai", "groq", "gemini") */
+  readonly id: string
+
+  /** Display name for UI (e.g., "OpenAI", "Groq", "Google Gemini") */
+  readonly displayName: string
+
+  /**
+   * Make a completion call to the LLM
+   * @param messages - Array of messages in the conversation
+   * @param options - Optional call configuration
+   * @returns Parsed LLM response with tool calls and content
+   */
+  makeCall(
+    messages: LLMMessage[],
+    options?: LLMCallOptions
+  ): Promise<LLMToolCallResponse>
+
+  /**
+   * Make a streaming completion call
+   * @param messages - Array of messages in the conversation
+   * @param onChunk - Callback for each streamed chunk
+   * @param options - Optional call configuration
+   * @returns Final parsed response
+   */
+  makeStreamingCall(
+    messages: LLMMessage[],
+    onChunk: (chunk: string, accumulated: string) => void,
+    options?: LLMCallOptions
+  ): Promise<LLMToolCallResponse>
+
+  /**
+   * Make a simple text completion (no structured output)
+   * @param prompt - The prompt to complete
+   * @param options - Optional call configuration
+   * @returns Plain text response
+   */
+  makeTextCompletion(
+    prompt: string,
+    options?: LLMCallOptions
+  ): Promise<string>
+
+  /**
+   * Verify if a task is complete using the LLM
+   * @param messages - Conversation history for verification
+   * @param options - Optional call configuration
+   * @returns Verification result
+   */
+  verifyCompletion(
+    messages: LLMMessage[],
+    options?: LLMCallOptions
+  ): Promise<CompletionVerification>
+
+  /**
+   * Check if the provider supports structured output (JSON schema)
+   * @param model - Optional model name (uses default if not specified)
+   * @returns Whether JSON schema mode is supported
+   */
+  supportsStructuredOutput(model?: string): boolean
+
+  /**
+   * Check if the provider supports JSON object mode
+   * @param model - Optional model name (uses default if not specified)
+   * @returns Whether JSON object mode is supported
+   */
+  supportsJsonMode(model?: string): boolean
+
+  /**
+   * Get runtime-learned capabilities for a model
+   * @param model - Model name
+   * @returns Cached capabilities or undefined if not tested
+   */
+  getModelCapabilities(model?: string): ModelCapabilities | undefined
+
+  /**
+   * Get the current model being used
+   * @param type - The type of model to get (e.g., "mcp" or "transcript")
+   * @returns Model identifier string
+   */
+  getModel(type: "mcp" | "transcript"): string
+}
+
+/**
+ * Configuration for creating an LLM provider
+ */
+export interface LLMProviderConstructorConfig {
+  /** API key for authentication */
+  apiKey: string
+  /** Base URL for the API (provider-specific default if not provided) */
+  baseUrl?: string
+  /** Model name for MCP tool calls */
+  mcpModel?: string
+  /** Model name for transcript post-processing */
+  transcriptModel?: string
+  /** Retry count for failed requests */
+  retryCount?: number
+  /** Base delay for retry backoff in ms */
+  retryBaseDelay?: number
+  /** Maximum delay for retry backoff in ms */
+  retryMaxDelay?: number
+}
+
+/**
+ * JSON schema for tool call response format (structured output)
+ */
+export const TOOL_CALL_RESPONSE_SCHEMA = {
+  name: "LLMToolCallResponse",
+  description:
+    "Response format for LLM tool calls with optional tool execution and content",
+  schema: {
+    type: "object",
+    properties: {
+      toolCalls: {
+        type: "array",
+        description: "Array of tool calls to execute",
+        items: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "Name of the tool to call",
+            },
+            arguments: {
+              type: "object",
+              description: "Arguments to pass to the tool",
+              properties: {},
+              additionalProperties: true,
+            },
+          },
+          required: ["name", "arguments"],
+          additionalProperties: false,
+        },
+      },
+      content: {
+        type: "string",
+        description: "Text content of the response",
+      },
+      needsMoreWork: {
+        type: "boolean",
+        description: "Whether more work is needed after this response",
+      },
+    },
+    additionalProperties: false,
+  },
+  strict: true,
+}
+
+/**
+ * JSON schema for completion verification
+ */
+export const VERIFICATION_RESPONSE_SCHEMA = {
+  name: "CompletionVerification",
+  description: "Strict verifier to determine if the user's request has been fully satisfied.",
+  schema: {
+    type: "object",
+    properties: {
+      isComplete: {
+        type: "boolean",
+        description: "True only if the user's original request has been fully satisfied.",
+      },
+      confidence: {
+        type: "number",
+        description: "Confidence in the judgment, must be between 0 and 1 inclusive.",
+      },
+      missingItems: {
+        type: "array",
+        items: { type: "string" },
+        description: "List of missing steps, outputs, or requirements, if any.",
+      },
+      reason: {
+        type: "string",
+        description: "Brief explanation of the judgment.",
+      },
+    },
+    required: ["isComplete"],
+    additionalProperties: false,
+  },
+  strict: true,
+}
+
+/**
+ * Cache of model capabilities learned at runtime
+ * Shared across all providers for models that may be accessed through different endpoints
+ */
+export const modelCapabilityCache = new Map<string, ModelCapabilities>()
+
+/**
+ * How long to cache model capability information (24 hours)
+ */
+export const CAPABILITY_CACHE_TTL = 24 * 60 * 60 * 1000
+
+/**
+ * Record that a model failed with a specific structured output mode
+ */
+export function recordStructuredOutputFailure(
+  model: string,
+  mode: "json_schema" | "json_object"
+): void {
+  const cached = modelCapabilityCache.get(model) || {
+    supportsJsonSchema: true,
+    supportsJsonObject: true,
+    lastTested: Date.now(),
+  }
+
+  if (mode === "json_schema") {
+    cached.supportsJsonSchema = false
+  } else if (mode === "json_object") {
+    cached.supportsJsonObject = false
+  }
+
+  cached.lastTested = Date.now()
+  modelCapabilityCache.set(model, cached)
+}
+
+/**
+ * Record that a model succeeded with a specific structured output mode
+ */
+export function recordStructuredOutputSuccess(
+  model: string,
+  mode: "json_schema" | "json_object"
+): void {
+  const cached = modelCapabilityCache.get(model) || {
+    supportsJsonSchema: true,
+    supportsJsonObject: true,
+    lastTested: Date.now(),
+  }
+
+  if (mode === "json_schema") {
+    cached.supportsJsonSchema = true
+  } else if (mode === "json_object") {
+    cached.supportsJsonObject = true
+  }
+
+  cached.lastTested = Date.now()
+  modelCapabilityCache.set(model, cached)
+}
+
+/**
+ * Check if cached model capabilities are still valid
+ */
+export function isCacheValid(model: string): boolean {
+  const cached = modelCapabilityCache.get(model)
+  if (!cached) return false
+  return Date.now() - cached.lastTested < CAPABILITY_CACHE_TTL
+}
+
+/**
+ * Extracts the first JSON object from a given string.
+ * @param str - The string to search for a JSON object.
+ * @returns The parsed JSON object, or null if no valid JSON object is found.
+ */
+export function extractJsonObject(str: string): unknown | null {
+  let braceCount = 0
+  let startIndex = -1
+
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i]
+
+    if (char === "{") {
+      if (braceCount === 0) {
+        startIndex = i
+      }
+      braceCount++
+    } else if (char === "}") {
+      braceCount--
+
+      if (braceCount === 0 && startIndex !== -1) {
+        const jsonStr = str.substring(startIndex, i + 1)
+        try {
+          return JSON.parse(jsonStr)
+        } catch {
+          startIndex = -1
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Helper: detect empty assistant content in an OpenAI-compatible response
+ */
+export function isEmptyContentResponse(resp: RawLLMResponse): boolean {
+  try {
+    const content = resp?.choices?.[0]?.message?.content
+    return typeof content !== "string" || content.trim() === ""
+  } catch {
+    return true
+  }
+}

--- a/apps/desktop/src/main/llm/providers/gemini.ts
+++ b/apps/desktop/src/main/llm/providers/gemini.ts
@@ -1,0 +1,282 @@
+/**
+ * Google Gemini LLM Provider
+ * Handles Google's Gemini API with its native format
+ */
+
+import type {
+  LLMMessage,
+  LLMCallOptions,
+  LLMToolCallResponse,
+  CompletionVerification,
+  ModelCapabilities,
+} from "../types"
+import type {
+  LLMProvider,
+  LLMProviderConstructorConfig,
+} from "./base"
+import { extractJsonObject } from "./base"
+import { withRetry, HttpError } from "../retry"
+import { diagnosticsService } from "../../diagnostics"
+import { isDebugLLM, logLLM } from "../../debug"
+import { llmRequestAbortManager, agentSessionStateManager } from "../../state"
+
+/**
+ * Gemini provider implementation
+ */
+export class GeminiProvider implements LLMProvider {
+  readonly id = "gemini"
+  readonly displayName = "Google Gemini"
+
+  private apiKey: string
+  private baseUrl: string
+  private mcpModel: string
+  private transcriptModel: string
+  private retryCount: number
+  private retryBaseDelay: number
+  private retryMaxDelay: number
+
+  constructor(config: LLMProviderConstructorConfig) {
+    if (!config.apiKey) {
+      throw new Error("API key is required for Gemini provider")
+    }
+    this.apiKey = config.apiKey
+    this.baseUrl = config.baseUrl || "https://generativelanguage.googleapis.com"
+    this.mcpModel = config.mcpModel || "gemini-1.5-flash-002"
+    this.transcriptModel = config.transcriptModel || "gemini-1.5-flash-002"
+    this.retryCount = config.retryCount ?? 3
+    this.retryBaseDelay = config.retryBaseDelay ?? 1000
+    this.retryMaxDelay = config.retryMaxDelay ?? 30000
+  }
+
+  getModel(type: "mcp" | "transcript"): string {
+    return type === "mcp" ? this.mcpModel : this.transcriptModel
+  }
+
+  getModelCapabilities(_model?: string): ModelCapabilities | undefined {
+    // Gemini doesn't support JSON schema mode like OpenAI
+    return {
+      supportsJsonSchema: false,
+      supportsJsonObject: false,
+      lastTested: Date.now(),
+    }
+  }
+
+  supportsStructuredOutput(_model?: string): boolean {
+    return false
+  }
+
+  supportsJsonMode(_model?: string): boolean {
+    return false
+  }
+
+  async makeCall(
+    messages: LLMMessage[],
+    options: LLMCallOptions = {}
+  ): Promise<LLMToolCallResponse> {
+    const { sessionId, onRetryProgress } = options
+
+    return withRetry(
+      () => this.makeGeminiCall(messages, sessionId),
+      {
+        retryCount: this.retryCount,
+        baseDelay: this.retryBaseDelay,
+        maxDelay: this.retryMaxDelay,
+        onRetryProgress,
+        logCategory: "llm-gemini",
+      }
+    )
+  }
+
+  async makeStreamingCall(
+    messages: LLMMessage[],
+    onChunk: (chunk: string, accumulated: string) => void,
+    options: LLMCallOptions = {}
+  ): Promise<LLMToolCallResponse> {
+    // Gemini doesn't support streaming in the same way as OpenAI
+    // Fall back to non-streaming and emit the full result
+    const result = await this.makeCall(messages, options)
+    if (result.content) {
+      onChunk(result.content, result.content)
+    }
+    return result
+  }
+
+  async makeTextCompletion(
+    prompt: string,
+    options: LLMCallOptions = {}
+  ): Promise<string> {
+    const messages: LLMMessage[] = [{ role: "user", content: prompt }]
+    const result = await this.makeCall(messages, options)
+    return result.content || ""
+  }
+
+  async verifyCompletion(
+    messages: LLMMessage[],
+    options: LLMCallOptions = {}
+  ): Promise<CompletionVerification> {
+    const parseVerification = (content: string): CompletionVerification => {
+      const json = extractJsonObject(content) || (() => {
+        try {
+          return JSON.parse(content)
+        } catch {
+          return null
+        }
+      })()
+
+      if (json && typeof (json as { isComplete?: unknown }).isComplete === "boolean") {
+        return json as CompletionVerification
+      }
+
+      diagnosticsService.logError(
+        "llm-gemini",
+        "Failed to parse verifier output",
+        {
+          contentLength: content?.length || 0,
+          contentPreview: content?.substring(0, 200) || "(empty)",
+        }
+      )
+
+      return { isComplete: false, reason: "Unparseable verifier output" }
+    }
+
+    try {
+      const result = await this.makeCall(messages, options)
+      const content = result.content || ""
+      return parseVerification(content)
+    } catch (error) {
+      diagnosticsService.logError("llm-gemini", "Verification call failed", error)
+      return { isComplete: false, reason: (error as { message?: string })?.message || "Verification failed" }
+    }
+  }
+
+  /**
+   * Make a call to the Gemini API
+   */
+  private async makeGeminiCall(
+    messages: LLMMessage[],
+    sessionId?: string
+  ): Promise<LLMToolCallResponse> {
+    // Convert messages to Gemini format
+    const prompt = messages.map((m) => `${m.role}: ${m.content}`).join("\n\n")
+
+    if (isDebugLLM()) {
+      logLLM("Gemini HTTP Request", {
+        url: `${this.baseUrl}/v1beta/models/${this.mcpModel}:generateContent`,
+        model: this.mcpModel,
+      })
+      logLLM("Gemini Request Body", { prompt })
+    }
+
+    const controller = new AbortController()
+    if (sessionId) {
+      agentSessionStateManager.registerAbortController(sessionId, controller)
+    } else {
+      llmRequestAbortManager.register(controller)
+    }
+
+    try {
+      // Check stop flags
+      if (sessionId && agentSessionStateManager.shouldStopSession(sessionId)) {
+        controller.abort()
+      }
+
+      const response = await fetch(
+        `${this.baseUrl}/v1beta/models/${this.mcpModel}:generateContent?key=${this.apiKey}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            contents: [
+              {
+                parts: [{ text: prompt }],
+              },
+            ],
+            generationConfig: {
+              temperature: 0,
+            },
+          }),
+          signal: controller.signal,
+        }
+      )
+
+      if (!response.ok) {
+        const errorText = await response.text()
+
+        // Extract Retry-After header for rate limiting
+        let retryAfter: number | undefined
+        const retryAfterHeader = response.headers.get("retry-after")
+        if (retryAfterHeader) {
+          const parsed = parseInt(retryAfterHeader, 10)
+          if (!isNaN(parsed)) {
+            retryAfter = parsed
+          }
+        }
+
+        if (isDebugLLM()) {
+          logLLM("Gemini HTTP Error", {
+            status: response.status,
+            statusText: response.statusText,
+            errorText,
+            retryAfter,
+          })
+        }
+
+        throw new HttpError(response.status, response.statusText, errorText, retryAfter)
+      }
+
+      const data = await response.json()
+
+      if (data.error) {
+        if (isDebugLLM()) {
+          logLLM("Gemini API Error", data.error)
+        }
+        throw new Error(data.error.message)
+      }
+
+      // Extract text from Gemini response format
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text
+      if (!text) {
+        throw new Error("No text content in Gemini response")
+      }
+
+      if (isDebugLLM()) {
+        logLLM("Gemini HTTP Response", data)
+      }
+
+      // Parse the response content
+      return this.parseResponse(text.trim())
+    } finally {
+      if (sessionId) {
+        agentSessionStateManager.unregisterAbortController(sessionId, controller)
+      } else {
+        llmRequestAbortManager.unregister(controller)
+      }
+    }
+  }
+
+  /**
+   * Parse Gemini response into LLMToolCallResponse
+   */
+  private parseResponse(content: string): LLMToolCallResponse {
+    // Try to extract JSON object from response
+    const jsonObject = extractJsonObject(content) as LLMToolCallResponse | null
+    if (jsonObject && (jsonObject.toolCalls || jsonObject.content)) {
+      if (jsonObject.needsMoreWork === undefined && !jsonObject.toolCalls) {
+        jsonObject.needsMoreWork = true
+      }
+      return jsonObject
+    }
+
+    // Check for tool markers
+    const hasToolMarkers = /<\|tool_calls_section_begin\|>|<\|tool_call_begin\|>/i.test(content)
+    const cleaned = content.replace(/<\|[^|]*\|>/g, "").trim()
+
+    if (hasToolMarkers) {
+      return { content: cleaned, needsMoreWork: true }
+    }
+
+    return { content: cleaned || content, needsMoreWork: undefined }
+  }
+}

--- a/apps/desktop/src/main/llm/providers/groq.ts
+++ b/apps/desktop/src/main/llm/providers/groq.ts
@@ -1,0 +1,36 @@
+/**
+ * Groq LLM Provider
+ * Extends OpenAI-compatible provider with Groq-specific defaults
+ */
+
+import { OpenAIProvider } from "./openai"
+import type { LLMProviderConstructorConfig } from "./base"
+
+/**
+ * Groq provider implementation
+ * Uses OpenAI-compatible API with Groq-specific configuration
+ */
+export class GroqProvider extends OpenAIProvider {
+  override readonly id = "groq"
+  override readonly displayName = "Groq"
+
+  constructor(config: LLMProviderConstructorConfig) {
+    super({
+      ...config,
+      baseUrl: config.baseUrl || "https://api.groq.com/openai/v1",
+      mcpModel: config.mcpModel || "llama-3.3-70b-versatile",
+      transcriptModel: config.transcriptModel || "llama-3.1-70b-versatile",
+    })
+  }
+
+  override supportsJsonMode(model?: string): boolean {
+    const modelName = model || this.getModel("mcp")
+    return (
+      modelName.includes("llama") ||
+      modelName.includes("mixtral") ||
+      modelName.includes("gemma") ||
+      modelName.includes("moonshotai/kimi-k2-instruct") ||
+      modelName.includes("openai/gpt-oss")
+    )
+  }
+}

--- a/apps/desktop/src/main/llm/providers/index.ts
+++ b/apps/desktop/src/main/llm/providers/index.ts
@@ -1,0 +1,164 @@
+/**
+ * LLM Provider Factory
+ * Unified interface for creating and managing LLM providers
+ */
+
+import type { LLMProvider, LLMProviderConstructorConfig } from "./base"
+import { OpenAIProvider } from "./openai"
+import { GroqProvider } from "./groq"
+import { GeminiProvider } from "./gemini"
+import { configStore } from "../../config"
+
+// Re-export types and utilities
+export type { LLMProvider, LLMProviderConstructorConfig } from "./base"
+export {
+  TOOL_CALL_RESPONSE_SCHEMA,
+  VERIFICATION_RESPONSE_SCHEMA,
+  modelCapabilityCache,
+  CAPABILITY_CACHE_TTL,
+  recordStructuredOutputFailure,
+  recordStructuredOutputSuccess,
+  isCacheValid,
+  extractJsonObject,
+  isEmptyContentResponse,
+} from "./base"
+
+export { OpenAIProvider } from "./openai"
+export { GroqProvider } from "./groq"
+export { GeminiProvider } from "./gemini"
+
+/**
+ * Supported provider IDs
+ */
+export type ProviderId = "openai" | "groq" | "gemini"
+
+/**
+ * Provider configuration from config store
+ */
+interface ProviderConfigFromStore {
+  providerId: string
+  openaiApiKey?: string
+  openaiBaseUrl?: string
+  mcpToolsOpenaiModel?: string
+  transcriptPostProcessingOpenaiModel?: string
+  groqApiKey?: string
+  groqBaseUrl?: string
+  mcpToolsGroqModel?: string
+  transcriptPostProcessingGroqModel?: string
+  geminiApiKey?: string
+  geminiBaseUrl?: string
+  mcpToolsGeminiModel?: string
+  apiRetryCount?: number
+  apiRetryBaseDelay?: number
+  apiRetryMaxDelay?: number
+}
+
+/**
+ * Create an LLM provider from the config store settings
+ * @param type - The type of provider to use ("mcp" for tool calls, "transcript" for post-processing)
+ * @returns Configured LLM provider instance
+ */
+export function createProviderFromConfig(
+  type: "mcp" | "transcript" = "mcp"
+): LLMProvider {
+  const config = configStore.get()
+
+  const providerId = type === "mcp"
+    ? config.mcpToolsProviderId || "openai"
+    : config.transcriptPostProcessingProviderId || "openai"
+
+  return createProvider(providerId as ProviderId, {
+    // OpenAI config
+    openaiApiKey: config.openaiApiKey,
+    openaiBaseUrl: config.openaiBaseUrl,
+    mcpToolsOpenaiModel: config.mcpToolsOpenaiModel,
+    transcriptPostProcessingOpenaiModel: config.transcriptPostProcessingOpenaiModel,
+    // Groq config
+    groqApiKey: config.groqApiKey,
+    groqBaseUrl: config.groqBaseUrl,
+    mcpToolsGroqModel: config.mcpToolsGroqModel,
+    transcriptPostProcessingGroqModel: config.transcriptPostProcessingGroqModel,
+    // Gemini config
+    geminiApiKey: config.geminiApiKey,
+    geminiBaseUrl: config.geminiBaseUrl,
+    mcpToolsGeminiModel: config.mcpToolsGeminiModel,
+    // Retry config
+    apiRetryCount: config.apiRetryCount,
+    apiRetryBaseDelay: config.apiRetryBaseDelay,
+    apiRetryMaxDelay: config.apiRetryMaxDelay,
+    // Provider selection
+    providerId,
+  })
+}
+
+/**
+ * Create an LLM provider instance
+ * @param providerId - The provider ID ("openai", "groq", or "gemini")
+ * @param config - Provider configuration
+ * @returns Configured LLM provider instance
+ */
+export function createProvider(
+  providerId: ProviderId,
+  config: ProviderConfigFromStore
+): LLMProvider {
+  switch (providerId) {
+    case "openai":
+      if (!config.openaiApiKey) {
+        throw new Error("OpenAI API key is required")
+      }
+      return new OpenAIProvider({
+        apiKey: config.openaiApiKey,
+        baseUrl: config.openaiBaseUrl,
+        mcpModel: config.mcpToolsOpenaiModel,
+        transcriptModel: config.transcriptPostProcessingOpenaiModel,
+        retryCount: config.apiRetryCount,
+        retryBaseDelay: config.apiRetryBaseDelay,
+        retryMaxDelay: config.apiRetryMaxDelay,
+      })
+
+    case "groq":
+      if (!config.groqApiKey) {
+        throw new Error("Groq API key is required")
+      }
+      return new GroqProvider({
+        apiKey: config.groqApiKey,
+        baseUrl: config.groqBaseUrl,
+        mcpModel: config.mcpToolsGroqModel,
+        transcriptModel: config.transcriptPostProcessingGroqModel,
+        retryCount: config.apiRetryCount,
+        retryBaseDelay: config.apiRetryBaseDelay,
+        retryMaxDelay: config.apiRetryMaxDelay,
+      })
+
+    case "gemini":
+      if (!config.geminiApiKey) {
+        throw new Error("Gemini API key is required")
+      }
+      return new GeminiProvider({
+        apiKey: config.geminiApiKey,
+        baseUrl: config.geminiBaseUrl,
+        mcpModel: config.mcpToolsGeminiModel,
+        transcriptModel: config.mcpToolsGeminiModel, // Gemini uses same model for both
+        retryCount: config.apiRetryCount,
+        retryBaseDelay: config.apiRetryBaseDelay,
+        retryMaxDelay: config.apiRetryMaxDelay,
+      })
+
+    default:
+      throw new Error(`Unknown provider ID: ${providerId}`)
+  }
+}
+
+/**
+ * Get a list of all available provider IDs
+ */
+export function getAvailableProviders(): ProviderId[] {
+  return ["openai", "groq", "gemini"]
+}
+
+/**
+ * Check if a provider ID is valid
+ */
+export function isValidProviderId(id: string): id is ProviderId {
+  return ["openai", "groq", "gemini"].includes(id)
+}

--- a/apps/desktop/src/main/llm/providers/openai.ts
+++ b/apps/desktop/src/main/llm/providers/openai.ts
@@ -1,0 +1,750 @@
+/**
+ * OpenAI-compatible LLM Provider
+ * Handles OpenAI, OpenRouter, and other OpenAI-compatible APIs
+ */
+
+import type {
+  LLMMessage,
+  LLMCallOptions,
+  LLMToolCallResponse,
+  CompletionVerification,
+  ModelCapabilities,
+  RawLLMResponse,
+} from "../types"
+import type {
+  LLMProvider,
+  LLMProviderConstructorConfig,
+} from "./base"
+import {
+  TOOL_CALL_RESPONSE_SCHEMA,
+  VERIFICATION_RESPONSE_SCHEMA,
+  modelCapabilityCache,
+  CAPABILITY_CACHE_TTL,
+  recordStructuredOutputFailure,
+  recordStructuredOutputSuccess,
+  extractJsonObject,
+  isEmptyContentResponse,
+} from "./base"
+import { withRetry, HttpError } from "../retry"
+import { diagnosticsService } from "../../diagnostics"
+import { isDebugLLM, logLLM } from "../../debug"
+import { llmRequestAbortManager, agentSessionStateManager } from "../../state"
+
+/**
+ * OpenAI-compatible provider implementation
+ */
+export class OpenAIProvider implements LLMProvider {
+  readonly id = "openai"
+  readonly displayName = "OpenAI"
+
+  private apiKey: string
+  private baseUrl: string
+  private mcpModel: string
+  private transcriptModel: string
+  private retryCount: number
+  private retryBaseDelay: number
+  private retryMaxDelay: number
+
+  constructor(config: LLMProviderConstructorConfig) {
+    if (!config.apiKey) {
+      throw new Error("API key is required for OpenAI provider")
+    }
+    this.apiKey = config.apiKey
+    this.baseUrl = config.baseUrl || "https://api.openai.com/v1"
+    this.mcpModel = config.mcpModel || "gpt-4o-mini"
+    this.transcriptModel = config.transcriptModel || "gpt-4o-mini"
+    this.retryCount = config.retryCount ?? 3
+    this.retryBaseDelay = config.retryBaseDelay ?? 1000
+    this.retryMaxDelay = config.retryMaxDelay ?? 30000
+  }
+
+  getModel(type: "mcp" | "transcript"): string {
+    return type === "mcp" ? this.mcpModel : this.transcriptModel
+  }
+
+  getModelCapabilities(model?: string): ModelCapabilities | undefined {
+    const modelName = model || this.mcpModel
+    const cached = modelCapabilityCache.get(modelName)
+    if (cached && Date.now() - cached.lastTested < CAPABILITY_CACHE_TTL) {
+      return cached
+    }
+    return undefined
+  }
+
+  supportsStructuredOutput(model?: string): boolean {
+    const modelName = model || this.mcpModel
+    const cached = this.getModelCapabilities(modelName)
+    if (cached) {
+      return cached.supportsJsonSchema
+    }
+
+    // Hardcoded list of models known to be incompatible
+    const incompatibleModels = ["google/gemini"]
+    return !incompatibleModels.some(
+      (incompatible) => modelName.toLowerCase().includes(incompatible.toLowerCase())
+    )
+  }
+
+  supportsJsonMode(model?: string): boolean {
+    const modelName = model || this.mcpModel
+    const cached = this.getModelCapabilities(modelName)
+    if (cached) {
+      return cached.supportsJsonObject
+    }
+
+    // Most OpenAI models support JSON mode
+    return (
+      modelName.includes("gpt-4") ||
+      modelName.includes("gpt-3.5-turbo")
+    )
+  }
+
+  async makeCall(
+    messages: LLMMessage[],
+    options: LLMCallOptions = {}
+  ): Promise<LLMToolCallResponse> {
+    const { useStructuredOutput = true, sessionId, onRetryProgress } = options
+
+    return withRetry(
+      () => this.makeLLMCallAttempt(messages, useStructuredOutput, sessionId, onRetryProgress),
+      {
+        retryCount: this.retryCount,
+        baseDelay: this.retryBaseDelay,
+        maxDelay: this.retryMaxDelay,
+        onRetryProgress,
+        logCategory: "llm-openai",
+      }
+    )
+  }
+
+  async makeStreamingCall(
+    messages: LLMMessage[],
+    onChunk: (chunk: string, accumulated: string) => void,
+    options: LLMCallOptions = {}
+  ): Promise<LLMToolCallResponse> {
+    const { sessionId } = options
+
+    const controller = new AbortController()
+    if (sessionId) {
+      agentSessionStateManager.registerAbortController(sessionId, controller)
+    } else {
+      llmRequestAbortManager.register(controller)
+    }
+
+    try {
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(this.enrichRequestBody({
+          model: this.mcpModel,
+          messages,
+          temperature: 0,
+          stream: true,
+        })),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`API request failed: ${response.status} ${errorText}`)
+      }
+
+      if (!response.body) {
+        throw new Error("Response body is null")
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let accumulated = ""
+      let buffer = ""
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split("\n")
+        buffer = lines.pop() || ""
+
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (!trimmed || trimmed === "data: [DONE]") continue
+          if (!trimmed.startsWith("data: ")) continue
+
+          try {
+            const json = JSON.parse(trimmed.slice(6))
+            const delta = json.choices?.[0]?.delta?.content
+            if (delta) {
+              accumulated += delta
+              onChunk(delta, accumulated)
+            }
+          } catch {
+            // Skip malformed JSON chunks
+          }
+        }
+      }
+
+      // Flush the decoder
+      buffer += decoder.decode(new Uint8Array(), { stream: false })
+      if (buffer.trim() && buffer.trim() !== "data: [DONE]" && buffer.trim().startsWith("data: ")) {
+        try {
+          const json = JSON.parse(buffer.trim().slice(6))
+          const delta = json.choices?.[0]?.delta?.content
+          if (delta) {
+            accumulated += delta
+            onChunk(delta, accumulated)
+          }
+        } catch {
+          // Skip malformed JSON chunks
+        }
+      }
+
+      return {
+        content: accumulated,
+        needsMoreWork: undefined,
+        toolCalls: undefined,
+      }
+    } catch (error: unknown) {
+      if ((error as { name?: string })?.name === "AbortError") {
+        throw error
+      }
+      diagnosticsService.logError("llm-openai", "Streaming call failed", error)
+      throw error
+    } finally {
+      if (sessionId) {
+        agentSessionStateManager.unregisterAbortController(sessionId, controller)
+      } else {
+        llmRequestAbortManager.unregister(controller)
+      }
+    }
+  }
+
+  async makeTextCompletion(
+    prompt: string,
+    options: LLMCallOptions = {}
+  ): Promise<string> {
+    const { sessionId } = options
+
+    const messages: LLMMessage[] = [{ role: "user", content: prompt }]
+
+    const response = await this.makeAPICallAttempt(
+      { model: this.transcriptModel, messages, temperature: 0, seed: 1 },
+      0,
+      sessionId
+    )
+
+    return response.choices[0]?.message.content?.trim() || ""
+  }
+
+  async verifyCompletion(
+    messages: LLMMessage[],
+    options: LLMCallOptions = {}
+  ): Promise<CompletionVerification> {
+    const { sessionId, onRetryProgress } = options
+
+    const parseVerification = (content: string): CompletionVerification => {
+      const json = extractJsonObject(content) || (() => {
+        try {
+          return JSON.parse(content)
+        } catch {
+          return null
+        }
+      })()
+
+      if (json && typeof (json as { isComplete?: unknown }).isComplete === "boolean") {
+        return json as CompletionVerification
+      }
+
+      diagnosticsService.logError(
+        "llm-openai",
+        "Failed to parse verifier output",
+        {
+          contentLength: content?.length || 0,
+          contentPreview: content?.substring(0, 200) || "(empty)",
+          extractedJson: json,
+        }
+      )
+
+      return { isComplete: false, reason: "Unparseable verifier output" }
+    }
+
+    const estimatedTokens = Math.ceil(
+      messages.reduce((sum, msg) => sum + msg.content.length, 0) / 4
+    )
+    const baseRequestBody = { model: this.mcpModel, messages, temperature: 0, seed: 1 }
+
+    try {
+      const response = await withRetry(
+        async () => {
+          // Try JSON Schema first
+          if (this.supportsStructuredOutput()) {
+            try {
+              const body = {
+                ...baseRequestBody,
+                response_format: { type: "json_schema", json_schema: VERIFICATION_RESPONSE_SCHEMA },
+              }
+              return await this.makeAPICallAttempt(body, estimatedTokens, options.sessionId)
+            } catch (error: unknown) {
+              if (!(error as { isStructuredOutputError?: boolean })?.isStructuredOutputError) throw error
+            }
+          }
+
+          // Try JSON Object
+          if (this.supportsJsonMode()) {
+            try {
+              const body = { ...baseRequestBody, response_format: { type: "json_object" } }
+              return await this.makeAPICallAttempt(body, estimatedTokens, options.sessionId)
+            } catch (error: unknown) {
+              if (!(error as { isStructuredOutputError?: boolean })?.isStructuredOutputError) throw error
+            }
+          }
+
+          // Fallback plain text
+          return await this.makeAPICallAttempt(baseRequestBody, estimatedTokens, options.sessionId)
+        },
+        {
+          retryCount: this.retryCount,
+          baseDelay: this.retryBaseDelay,
+          maxDelay: this.retryMaxDelay,
+          onRetryProgress,
+          logCategory: "llm-openai",
+        }
+      )
+
+      const content = response.choices?.[0]?.message?.content?.trim() || ""
+      return parseVerification(content)
+    } catch (error) {
+      diagnosticsService.logError("llm-openai", "Verification call failed", error)
+      return { isComplete: false, reason: (error as { message?: string })?.message || "Verification failed" }
+    }
+  }
+
+  /**
+   * Make a single API call attempt with structured output fallback
+   */
+  private async makeLLMCallAttempt(
+    messages: LLMMessage[],
+    useStructuredOutput: boolean,
+    sessionId?: string,
+    onRetryProgress?: (info: { isRetrying: boolean; attempt: number; delaySeconds: number; reason: string; startedAt: number }) => void,
+  ): Promise<LLMToolCallResponse> {
+    if (isDebugLLM()) {
+      logLLM("Starting OpenAI LLM call", {
+        messagesCount: messages.length,
+        useStructuredOutput,
+      })
+    }
+
+    const estimatedTokens = Math.ceil(
+      messages.reduce((sum, msg) => sum + msg.content.length, 0) / 4
+    )
+
+    const baseRequestBody = {
+      model: this.mcpModel,
+      messages,
+      temperature: 0,
+      seed: 1,
+    }
+
+    let response: RawLLMResponse
+
+    if (!useStructuredOutput) {
+      response = await this.makeAPICallAttempt(baseRequestBody, estimatedTokens, sessionId)
+    } else {
+      response = await this.makeStructuredCall(baseRequestBody, estimatedTokens, sessionId)
+    }
+
+    return this.parseResponse(response)
+  }
+
+  /**
+   * Make a structured call with fallback through response formats
+   */
+  private async makeStructuredCall(
+    baseRequestBody: { model: string; messages: LLMMessage[]; temperature: number; seed: number },
+    estimatedTokens: number,
+    sessionId?: string
+  ): Promise<RawLLMResponse> {
+    // First attempt: JSON Schema mode
+    if (this.supportsStructuredOutput(baseRequestBody.model)) {
+      try {
+        const requestBodyWithSchema = {
+          ...baseRequestBody,
+          response_format: {
+            type: "json_schema",
+            json_schema: TOOL_CALL_RESPONSE_SCHEMA,
+          },
+        }
+
+        if (isDebugLLM()) {
+          logLLM("Attempting JSON Schema mode for model:", baseRequestBody.model)
+        }
+
+        const data = await this.makeAPICallAttempt(requestBodyWithSchema, estimatedTokens, sessionId)
+        if (isEmptyContentResponse(data)) {
+          if (isDebugLLM()) {
+            logLLM("Empty content from JSON Schema response; falling back")
+          }
+          const err = new Error("Empty content in structured (json_schema) response") as { isStructuredOutputError?: boolean }
+          err.isStructuredOutputError = true
+          recordStructuredOutputFailure(baseRequestBody.model, "json_schema")
+          throw err
+        }
+        recordStructuredOutputSuccess(baseRequestBody.model, "json_schema")
+        return data
+      } catch (error: unknown) {
+        if ((error as { isStructuredOutputError?: boolean })?.isStructuredOutputError) {
+          // Try recovery with failed_generation
+          const failedGeneration = (error as { failedGeneration?: string })?.failedGeneration
+          if (failedGeneration) {
+            try {
+              const retryMessages: LLMMessage[] = [
+                ...baseRequestBody.messages,
+                { role: "assistant", content: failedGeneration },
+                { role: "user", content: `Return your previous response as valid JSON: {"content": "...", "needsMoreWork": false}. Escape quotes properly.` },
+              ]
+
+              const retryData = await this.makeAPICallAttempt(
+                {
+                  ...baseRequestBody,
+                  messages: retryMessages,
+                  response_format: { type: "json_schema", json_schema: TOOL_CALL_RESPONSE_SCHEMA },
+                },
+                estimatedTokens,
+                sessionId
+              )
+
+              if (!isEmptyContentResponse(retryData)) {
+                recordStructuredOutputSuccess(baseRequestBody.model, "json_schema")
+                return retryData
+              }
+            } catch {
+              // Continue to fallback modes
+            }
+          }
+
+          if (isDebugLLM()) {
+            logLLM("JSON Schema failed for", baseRequestBody.model, "- falling back")
+          }
+          recordStructuredOutputFailure(baseRequestBody.model, "json_schema")
+        } else {
+          throw error
+        }
+      }
+    }
+
+    // Second attempt: JSON Object mode
+    if (this.supportsJsonMode(baseRequestBody.model)) {
+      try {
+        const requestBodyWithJson = {
+          ...baseRequestBody,
+          response_format: { type: "json_object" },
+        }
+
+        if (isDebugLLM()) {
+          logLLM("Attempting JSON Object mode for model:", baseRequestBody.model)
+        }
+
+        const data = await this.makeAPICallAttempt(requestBodyWithJson, estimatedTokens, sessionId)
+        if (isEmptyContentResponse(data)) {
+          if (isDebugLLM()) {
+            logLLM("Empty content from JSON Object response; falling back")
+          }
+          const err = new Error("Empty content in structured (json_object) response") as { isStructuredOutputError?: boolean }
+          err.isStructuredOutputError = true
+          recordStructuredOutputFailure(baseRequestBody.model, "json_object")
+          throw err
+        }
+        recordStructuredOutputSuccess(baseRequestBody.model, "json_object")
+        return data
+      } catch (error: unknown) {
+        if ((error as { isStructuredOutputError?: boolean })?.isStructuredOutputError) {
+          if (isDebugLLM()) {
+            logLLM("JSON Object mode FAILED for model", baseRequestBody.model, "- falling back")
+          }
+          recordStructuredOutputFailure(baseRequestBody.model, "json_object")
+        } else {
+          throw error
+        }
+      }
+    }
+
+    // Final attempt: Plain text mode
+    if (isDebugLLM()) {
+      logLLM("Using plain text mode for model:", baseRequestBody.model)
+    }
+
+    return await this.makeAPICallAttempt(baseRequestBody, estimatedTokens, sessionId)
+  }
+
+  /**
+   * Make a single raw API call attempt
+   */
+  private async makeAPICallAttempt(
+    requestBody: Record<string, unknown>,
+    estimatedTokens: number,
+    sessionId?: string
+  ): Promise<RawLLMResponse> {
+    if (isDebugLLM()) {
+      logLLM("=== OPENAI API REQUEST ===")
+      logLLM("HTTP Request", {
+        url: `${this.baseUrl}/chat/completions`,
+        model: requestBody.model,
+        messagesCount: (requestBody.messages as LLMMessage[]).length,
+        responseFormat: requestBody.response_format,
+        estimatedTokens,
+      })
+    }
+
+    const controller = new AbortController()
+    if (sessionId) {
+      agentSessionStateManager.registerAbortController(sessionId, controller)
+    } else {
+      llmRequestAbortManager.register(controller)
+    }
+
+    try {
+      // Check stop flags
+      if (agentSessionStateManager.shouldStopSession(sessionId || "")) {
+        controller.abort()
+      }
+
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(this.enrichRequestBody(requestBody)),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+
+        if (isDebugLLM()) {
+          logLLM("HTTP Error Response", {
+            status: response.status,
+            statusText: response.statusText,
+            errorText: errorText.substring(0, 1000),
+          })
+        }
+
+        // Check if this is a structured output related error
+        const errorTextLower = errorText.toLowerCase()
+        const isStructuredOutputError =
+          response.status >= 400 &&
+          response.status < 500 &&
+          (errorTextLower.includes("json_schema") ||
+            errorTextLower.includes("response_format") ||
+            errorTextLower.includes("json_validate_failed") ||
+            errorTextLower.includes("failed to generate json") ||
+            (errorTextLower.includes("schema") && errorTextLower.includes("not supported")) ||
+            (errorTextLower.includes("model inference") && errorTextLower.includes("error")) ||
+            errorTextLower.includes("unknown error in the model") ||
+            (errorTextLower.includes("object fields require") && errorTextLower.includes("properties")))
+
+        if (isStructuredOutputError) {
+          if (isDebugLLM()) {
+            logLLM("Detected as structured output error")
+          }
+          const error = new Error(errorText) as { isStructuredOutputError?: boolean; failedGeneration?: string }
+          error.isStructuredOutputError = true
+
+          // Extract failed_generation if available
+          try {
+            const errorJson = JSON.parse(errorText)
+            if (errorJson?.error?.failed_generation) {
+              error.failedGeneration = errorJson.error.failed_generation
+            }
+          } catch {
+            // Not JSON
+          }
+
+          throw error
+        }
+
+        throw new HttpError(response.status, response.statusText, errorText)
+      }
+
+      const data = await response.json() as RawLLMResponse
+
+      // Log empty content cases
+      const messageContent = data.choices?.[0]?.message?.content
+      const hasToolCalls = !!data.choices?.[0]?.message?.tool_calls?.length
+      const isEmptyContent =
+        !hasToolCalls &&
+        (!messageContent ||
+          (typeof messageContent === "string" && messageContent.trim() === "") ||
+          (Array.isArray(messageContent) && messageContent.length === 0))
+
+      if (isEmptyContent) {
+        diagnosticsService.logError("llm-openai", "Empty content from LLM API", {
+          model: requestBody.model,
+          provider: this.baseUrl,
+          finishReason: data.choices?.[0]?.finish_reason,
+          usage: data.usage,
+        })
+      }
+
+      if (data.error) {
+        if (isDebugLLM()) {
+          logLLM("API Error", data.error)
+        }
+        const errorMessage = data.error.message || String(data.error)
+        const errorMessageLower = errorMessage.toLowerCase()
+        const error = new Error(errorMessage) as { isStructuredOutputError?: boolean; failedGeneration?: string }
+        error.isStructuredOutputError =
+          errorMessageLower.includes("json_schema") ||
+          errorMessageLower.includes("response_format") ||
+          errorMessageLower.includes("json_validate_failed") ||
+          errorMessageLower.includes("model inference") ||
+          errorMessageLower.includes("unknown error in the model")
+
+        if (data.error.failed_generation) {
+          error.failedGeneration = data.error.failed_generation
+        }
+
+        throw error
+      }
+
+      if (isDebugLLM()) {
+        logLLM("Response received", {
+          hasContent: !!data.choices?.[0]?.message?.content,
+          contentLength: data.choices?.[0]?.message?.content?.length || 0,
+          hasToolCalls: !!data.choices?.[0]?.message?.tool_calls?.length,
+          finishReason: data.choices?.[0]?.finish_reason,
+        })
+      }
+
+      return data
+    } finally {
+      if (sessionId) {
+        agentSessionStateManager.unregisterAbortController(sessionId, controller)
+      } else {
+        llmRequestAbortManager.unregister(controller)
+      }
+    }
+  }
+
+  /**
+   * Parse raw API response into LLMToolCallResponse
+   */
+  private parseResponse(response: RawLLMResponse): LLMToolCallResponse {
+    const messageObj = response.choices?.[0]?.message || {}
+    let content: string | undefined = (messageObj.content ?? "").trim()
+
+    if (isDebugLLM()) {
+      logLLM("Message content extracted:", {
+        contentLength: content?.length || 0,
+        contentPreview: content?.substring(0, 200) || "(empty)",
+      })
+    }
+
+    if (!content) {
+      // Check reasoning fallback
+      const rawReasoning = (messageObj as { reasoning?: string | { text: string } })?.reasoning
+      const reasoningText =
+        typeof rawReasoning === "string"
+          ? rawReasoning
+          : rawReasoning && typeof rawReasoning === "object" && typeof rawReasoning.text === "string"
+            ? rawReasoning.text
+            : ""
+
+      if (reasoningText) {
+        const jsonFromReasoning = extractJsonObject(reasoningText) as LLMToolCallResponse | null
+        if (jsonFromReasoning && (jsonFromReasoning.toolCalls || jsonFromReasoning.content)) {
+          if (isDebugLLM()) {
+            logLLM("Parsed structured output from reasoning fallback")
+          }
+          if (jsonFromReasoning.needsMoreWork === undefined && !jsonFromReasoning.toolCalls) {
+            jsonFromReasoning.needsMoreWork = true
+          }
+          return jsonFromReasoning
+        }
+
+        if (reasoningText.trim()) {
+          if (isDebugLLM()) logLLM("Using reasoning text as content fallback")
+          content = reasoningText.trim()
+        }
+      }
+
+      if (!content) {
+        diagnosticsService.logError("llm-openai", "LLM returned empty response", {
+          hasResponse: !!response,
+          hasChoices: !!response?.choices,
+          choicesLength: response?.choices?.length,
+        })
+        throw new Error("LLM returned empty response - this indicates a model or API issue that should be retried")
+      }
+    }
+
+    // Try to extract JSON object from response
+    const jsonObject = extractJsonObject(content) as LLMToolCallResponse | null
+    if (jsonObject && (jsonObject.toolCalls || jsonObject.content)) {
+      if (jsonObject.needsMoreWork === undefined && !jsonObject.toolCalls) {
+        jsonObject.needsMoreWork = true
+      }
+
+      // Safety check for tool markers in content
+      const toolMarkers = /<\|tool_calls_section_begin\|>|<\|tool_call_begin\|>/i
+      const text = (jsonObject.content || "").replace(/<\|[^|]*\|>/g, "").trim()
+      if (
+        jsonObject.needsMoreWork === false &&
+        (!jsonObject.toolCalls || jsonObject.toolCalls.length === 0) &&
+        toolMarkers.test(text)
+      ) {
+        jsonObject.needsMoreWork = true
+      }
+
+      if (isDebugLLM()) {
+        logLLM("Returning structured JSON response", {
+          hasContent: !!jsonObject.content,
+          hasToolCalls: !!jsonObject.toolCalls,
+          toolCallsCount: jsonObject.toolCalls?.length || 0,
+          needsMoreWork: jsonObject.needsMoreWork,
+        })
+      }
+
+      return jsonObject
+    }
+
+    // No valid JSON found
+    const hasToolMarkers = /<\|tool_calls_section_begin\|>|<\|tool_call_begin\|>/i.test(content || "")
+    const cleaned = (content || "").replace(/<\|[^|]*\|>/g, "").trim()
+
+    if (hasToolMarkers) {
+      if (isDebugLLM()) {
+        logLLM("Returning plain text with tool markers (needsMoreWork=true)")
+      }
+      return { content: cleaned, needsMoreWork: true }
+    }
+
+    if (isDebugLLM()) {
+      logLLM("Returning plain text response (needsMoreWork=undefined)")
+    }
+    return { content: cleaned || content, needsMoreWork: undefined }
+  }
+
+  /**
+   * Enrich request body with OpenRouter-specific fields when using OpenRouter API
+   */
+  private enrichRequestBody(requestBody: Record<string, unknown>): Record<string, unknown> {
+    if (!this.baseUrl.toLowerCase().includes("openrouter.ai")) {
+      return requestBody
+    }
+
+    const existingPlugins = Array.isArray(requestBody.plugins) ? requestBody.plugins : []
+    if (existingPlugins.some((p: { id?: string } | null | undefined) => p?.id === "response-healing")) {
+      return requestBody
+    }
+
+    return {
+      ...requestBody,
+      plugins: [...existingPlugins, { id: "response-healing" }],
+    }
+  }
+}

--- a/apps/desktop/src/main/llm/retry.ts
+++ b/apps/desktop/src/main/llm/retry.ts
@@ -1,0 +1,365 @@
+/**
+ * Generic retry utility with exponential backoff
+ * Reusable by LLM providers, MCP, remote servers, etc.
+ */
+
+import { diagnosticsService } from "../diagnostics"
+import { state } from "../state"
+import type { RetryProgressCallback } from "./types"
+
+/**
+ * Options for retry behavior
+ */
+export interface RetryOptions {
+  /** Number of retry attempts (default: 3) */
+  retryCount?: number
+  /** Base delay in milliseconds for exponential backoff (default: 1000) */
+  baseDelay?: number
+  /** Maximum delay in milliseconds between retries (default: 30000) */
+  maxDelay?: number
+  /** Callback for retry progress reporting */
+  onRetryProgress?: RetryProgressCallback
+  /** Custom function to determine if an error is retryable */
+  isRetryable?: (error: unknown) => boolean
+  /** Custom function to extract retry-after header value */
+  getRetryAfter?: (error: unknown) => number | undefined
+  /** Log category for diagnostics (default: "retry") */
+  logCategory?: string
+  /** Whether to check global stop flag (default: true) */
+  checkStopFlag?: boolean
+}
+
+/**
+ * Enhanced error class for HTTP errors with status code and retry information
+ */
+export class HttpError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    public responseText: string,
+    public retryAfter?: number,
+  ) {
+    super(HttpError.createUserFriendlyMessage(status, statusText, responseText, retryAfter))
+    this.name = "HttpError"
+  }
+
+  /**
+   * Create user-friendly error messages for different HTTP status codes
+   */
+  private static createUserFriendlyMessage(
+    status: number,
+    statusText: string,
+    responseText: string,
+    retryAfter?: number
+  ): string {
+    switch (status) {
+      case 400: {
+        let errorDetail = ""
+        try {
+          const errorJson = JSON.parse(responseText)
+          if (errorJson.error?.message) {
+            errorDetail = errorJson.error.message
+          }
+        } catch {
+          errorDetail = responseText
+        }
+
+        const lowerDetail = errorDetail.toLowerCase()
+        if (lowerDetail.includes("model") || lowerDetail.includes("does not exist") || lowerDetail.includes("not found")) {
+          return `Invalid model name. The specified model does not exist or is not available. Please check your model settings and ensure the model name is correct. Error details: ${errorDetail}`
+        }
+
+        if (lowerDetail.includes("tool choice is none") || lowerDetail.includes("tool_choice")) {
+          return `The model attempted to use tools but tool calling is not enabled for this request. This can happen with certain prompts. Try rephrasing your request.`
+        }
+
+        return `Bad request. The API rejected the request. ${errorDetail ? `Error details: ${errorDetail}` : "Please check your configuration."}`
+      }
+
+      case 429: {
+        const waitTime = retryAfter ? `${retryAfter} seconds` : "a moment"
+        return `Rate limit exceeded. The API is temporarily unavailable due to too many requests. We'll automatically retry after waiting ${waitTime}. You don't need to do anything - just wait for the request to complete.`
+      }
+
+      case 401:
+        return "Authentication failed. Please check your API key configuration."
+
+      case 403:
+        return "Access forbidden. Your API key may not have permission to access this resource."
+
+      case 404:
+        return "API endpoint not found. Please check your base URL configuration."
+
+      case 408:
+        return "Request timeout. The API took too long to respond."
+
+      case 500:
+        return "Internal server error. The API service is experiencing issues."
+
+      case 502:
+        return "Bad gateway. There may be a temporary issue with the API service."
+
+      case 503:
+        return "Service unavailable. The API service is temporarily down for maintenance."
+
+      case 504:
+        return "Gateway timeout. The API service is not responding."
+
+      default: {
+        try {
+          const errorJson = JSON.parse(responseText)
+          if (errorJson.error?.message) {
+            return `API Error: ${errorJson.error.message}`
+          }
+        } catch {
+          // If response is not JSON, use the raw response
+        }
+
+        return `HTTP ${status}: ${responseText || statusText}`
+      }
+    }
+  }
+}
+
+/**
+ * Check if an error is retryable based on status code and error type
+ */
+export function isRetryableError(error: unknown): boolean {
+  // Abort should never be retried
+  if (error instanceof Error) {
+    if ((error as { name?: string }).name === "AbortError" || error.message.toLowerCase().includes("abort")) {
+      return false
+    }
+  }
+
+  if (error instanceof HttpError) {
+    return error.status === 429 ||
+           (error.status >= 500 && error.status < 600) ||
+           error.status === 408 ||
+           error.status === 502 ||
+           error.status === 503 ||
+           error.status === 504
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+
+    return message.includes("network") ||
+           message.includes("timeout") ||
+           message.includes("connection") ||
+           message.includes("fetch") ||
+           message.includes("empty response") ||
+           message.includes("empty content") ||
+           message.includes("cloudflare") ||
+           message.includes("gateway")
+  }
+
+  return false
+}
+
+/**
+ * Calculate delay for exponential backoff with jitter
+ */
+export function calculateBackoffDelay(
+  attempt: number,
+  baseDelay: number = 1000,
+  maxDelay: number = 30000
+): number {
+  // Exponential backoff: baseDelay * 2^attempt
+  const exponentialDelay = baseDelay * Math.pow(2, attempt)
+
+  // Cap at maxDelay
+  const cappedDelay = Math.min(exponentialDelay, maxDelay)
+
+  // Add jitter (±25% randomization) to avoid thundering herd
+  const jitter = cappedDelay * 0.25 * (Math.random() * 2 - 1)
+
+  return Math.max(0, cappedDelay + jitter)
+}
+
+/**
+ * Generic retry utility with exponential backoff
+ *
+ * Rate limit errors (429) will retry indefinitely until successful.
+ * Other errors respect the retry count limit.
+ *
+ * @example
+ * ```ts
+ * const result = await withRetry(
+ *   () => fetchData(),
+ *   { retryCount: 3, baseDelay: 1000 }
+ * )
+ * ```
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const {
+    retryCount = 3,
+    baseDelay = 1000,
+    maxDelay = 30000,
+    onRetryProgress,
+    isRetryable = isRetryableError,
+    getRetryAfter,
+    logCategory = "retry",
+    checkStopFlag = true,
+  } = options
+
+  let lastError: unknown
+  let attempt = 0
+
+  const clearRetryStatus = () => {
+    if (onRetryProgress) {
+      onRetryProgress({
+        isRetrying: false,
+        attempt: 0,
+        delaySeconds: 0,
+        reason: "",
+        startedAt: 0,
+      })
+    }
+  }
+
+  while (true) {
+    // If an emergency stop has been requested, abort immediately
+    if (checkStopFlag && state.shouldStopAgent) {
+      clearRetryStatus()
+      throw lastError instanceof Error ? lastError : new Error("Aborted by emergency stop")
+    }
+
+    try {
+      const response = await fn()
+      clearRetryStatus()
+      return response
+    } catch (error) {
+      lastError = error
+
+      // Do not retry on abort or if we've been asked to stop
+      if ((error as { name?: string })?.name === "AbortError" || (checkStopFlag && state.shouldStopAgent)) {
+        clearRetryStatus()
+        throw error
+      }
+
+      // Check if error is retryable
+      if (!isRetryable(error)) {
+        diagnosticsService.logError(
+          logCategory,
+          "Non-retryable error",
+          {
+            error: error instanceof Error ? error.message : String(error),
+            errorType: error instanceof HttpError ? "HttpError" : error instanceof Error ? "Error" : typeof error,
+            status: error instanceof HttpError ? error.status : undefined,
+            stack: error instanceof Error ? error.stack : undefined,
+          },
+        )
+        clearRetryStatus()
+        throw error
+      }
+
+      // Handle rate limit errors (429) - no retry limit, keep trying indefinitely
+      if (error instanceof HttpError && error.status === 429) {
+        let delay = calculateBackoffDelay(attempt, baseDelay, maxDelay)
+
+        // Use Retry-After header if provided
+        const retryAfterValue = getRetryAfter?.(error) ?? error.retryAfter
+        if (retryAfterValue) {
+          delay = retryAfterValue * 1000
+          delay = Math.min(delay, maxDelay)
+        }
+
+        const waitTimeSeconds = Math.round(delay / 1000)
+
+        diagnosticsService.logError(
+          logCategory,
+          `Rate limit encountered (429). Waiting ${waitTimeSeconds}s before retry (attempt ${attempt + 1})`,
+          {
+            status: error.status,
+            retryAfter: retryAfterValue,
+            delay,
+            message: "Rate limits are temporary - will keep retrying until successful"
+          }
+        )
+
+        if (onRetryProgress) {
+          onRetryProgress({
+            isRetrying: true,
+            attempt: attempt + 1,
+            maxAttempts: undefined,
+            delaySeconds: waitTimeSeconds,
+            reason: "Rate limit exceeded",
+            startedAt: Date.now(),
+          })
+        }
+
+        if (checkStopFlag && state.shouldStopAgent) {
+          clearRetryStatus()
+          throw new Error("Aborted by emergency stop")
+        }
+        await new Promise(resolve => setTimeout(resolve, delay))
+        attempt++
+        continue
+      }
+
+      // For other retryable errors, respect the retry limit
+      if (attempt >= retryCount) {
+        diagnosticsService.logError(
+          logCategory,
+          "Call failed after all retries",
+          {
+            error: error instanceof Error ? error.message : String(error),
+            errorType: error instanceof HttpError ? "HttpError" : error instanceof Error ? "Error" : typeof error,
+            status: error instanceof HttpError ? error.status : undefined,
+            attempts: attempt + 1,
+            maxRetries: retryCount + 1,
+          },
+        )
+        clearRetryStatus()
+        throw lastError
+      }
+
+      const delay = calculateBackoffDelay(attempt, baseDelay, maxDelay)
+
+      diagnosticsService.logWarning(
+        logCategory,
+        `Call failed, retrying in ${Math.round(delay / 1000)}s (attempt ${attempt + 1}/${retryCount + 1})`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+          errorType: error instanceof HttpError ? "HttpError" : error instanceof Error ? "Error" : typeof error,
+          status: error instanceof HttpError ? error.status : undefined,
+          delay,
+          attempt: attempt + 1,
+          maxRetries: retryCount + 1,
+        }
+      )
+
+      const reason = error instanceof HttpError
+        ? `HTTP ${error.status} error`
+        : "Network error"
+
+      if (onRetryProgress) {
+        onRetryProgress({
+          isRetrying: true,
+          attempt: attempt + 1,
+          maxAttempts: retryCount + 1,
+          delaySeconds: Math.round(delay / 1000),
+          reason,
+          startedAt: Date.now(),
+        })
+      }
+
+      if (checkStopFlag && state.shouldStopAgent) {
+        clearRetryStatus()
+        throw new Error("Aborted by emergency stop")
+      }
+      await new Promise(resolve => setTimeout(resolve, delay))
+      attempt++
+    }
+  }
+}
+
+/**
+ * Alias for withRetry for backwards compatibility
+ * @deprecated Use withRetry instead
+ */
+export const apiCallWithRetry = withRetry

--- a/apps/desktop/src/main/llm/structured-output.ts
+++ b/apps/desktop/src/main/llm/structured-output.ts
@@ -1,0 +1,220 @@
+/**
+ * Structured Output Module
+ * Handles JSON schema parsing and context extraction
+ */
+
+import { z } from "zod"
+import { createProviderFromConfig } from "./providers"
+import { extractJsonObject } from "./providers/base"
+import { logLLM } from "../debug"
+import type { LLMMessage } from "./types"
+
+/**
+ * Schema for LLM tool call responses
+ */
+export const LLMToolCallSchema = z.object({
+  toolCalls: z
+    .array(
+      z.object({
+        name: z.string(),
+        arguments: z.record(z.any()),
+      }),
+    )
+    .optional(),
+  content: z.string().optional(),
+  needsMoreWork: z.boolean().optional(),
+})
+
+export type LLMToolCallResponse = z.infer<typeof LLMToolCallSchema>
+
+/**
+ * Schema for context extraction responses
+ */
+export const ContextExtractionSchema = z.object({
+  resources: z.array(
+    z.object({
+      type: z.string(),
+      id: z.string(),
+    }),
+  ),
+})
+
+export type ContextExtractionResponse = z.infer<typeof ContextExtractionSchema>
+
+/**
+ * JSON schema for context extraction (OpenAI format)
+ */
+export const CONTEXT_EXTRACTION_SCHEMA = {
+  name: "ContextExtraction",
+  description: "Extract resource identifiers from conversation",
+  schema: {
+    type: "object",
+    properties: {
+      resources: {
+        type: "array",
+        description: "Array of active resource identifiers",
+        items: {
+          type: "object",
+          properties: {
+            type: {
+              type: "string",
+              description: "Resource type (session, connection, handle, etc)",
+            },
+            id: {
+              type: "string",
+              description: "The resource identifier value",
+            },
+          },
+          required: ["type", "id"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["resources"],
+    additionalProperties: false,
+  },
+  strict: true,
+}
+
+/**
+ * Clean LLM response content for JSON parsing
+ */
+function cleanResponseContent(content: string): string {
+  let cleanContent = content.trim()
+
+  // Remove common LLM formatting artifacts
+  cleanContent = cleanContent
+    .replace(/<\|[^|]*\|>/g, "") // Remove special tokens
+    .replace(/```json\s*/g, "") // Remove code block markers
+    .replace(/```\s*/g, "")
+    .replace(/^\s*[\w\s]*:\s*/, "") // Remove leading text
+    .trim()
+
+  return cleanContent
+}
+
+/**
+ * Parse LLM response content into LLMToolCallResponse
+ */
+export function parseToolCallResponse(content: string): LLMToolCallResponse {
+  const cleanContent = cleanResponseContent(content)
+
+  // Try to extract JSON object if embedded in text
+  const jsonObject = extractJsonObject(cleanContent)
+  if (jsonObject) {
+    try {
+      return LLMToolCallSchema.parse(jsonObject)
+    } catch {
+      // Continue to fallback
+    }
+  }
+
+  // Try direct JSON parse
+  try {
+    const parsed = JSON.parse(cleanContent)
+    return LLMToolCallSchema.parse(parsed)
+  } catch {
+    // If parsing fails, return text content
+    const textContent = content.replace(/<\|[^|]*\|>/g, "").trim()
+    if (textContent) {
+      return { content: textContent, needsMoreWork: true }
+    }
+    return { content: "", needsMoreWork: true }
+  }
+}
+
+/**
+ * Parse LLM response content into ContextExtractionResponse
+ */
+export function parseContextExtractionResponse(content: string): ContextExtractionResponse {
+  const cleanContent = cleanResponseContent(content)
+
+  // Try to extract JSON object
+  const jsonObject = extractJsonObject(cleanContent)
+  if (jsonObject) {
+    try {
+      return ContextExtractionSchema.parse(jsonObject)
+    } catch {
+      // Continue to fallback
+    }
+  }
+
+  // Try direct JSON parse
+  try {
+    const parsed = JSON.parse(cleanContent)
+    return ContextExtractionSchema.parse(parsed)
+  } catch {
+    return { resources: [] }
+  }
+}
+
+/**
+ * Make a structured LLM call for tool responses
+ * Uses the provider abstraction for flexible backend support
+ */
+export async function makeStructuredToolCall(
+  messages: Array<{ role: string; content: string }>,
+  _providerId?: string,
+): Promise<LLMToolCallResponse> {
+  const provider = createProviderFromConfig("mcp")
+
+  // Convert messages to LLMMessage format
+  const llmMessages: LLMMessage[] = messages.map((m) => ({
+    role: m.role as "system" | "user" | "assistant",
+    content: m.content,
+  }))
+
+  const response = await provider.makeCall(llmMessages, {
+    useStructuredOutput: true,
+  })
+
+  return response
+}
+
+/**
+ * Make a structured LLM call for context extraction
+ */
+export async function makeStructuredContextExtraction(
+  prompt: string,
+  _providerId?: string,
+): Promise<ContextExtractionResponse> {
+  const provider = createProviderFromConfig("mcp")
+
+  const messages: LLMMessage[] = [
+    {
+      role: "system",
+      content:
+        "You are a context extraction assistant. Analyze conversation history and extract useful resource identifiers and context information. Always respond with valid JSON.",
+    },
+    {
+      role: "user",
+      content: prompt,
+    },
+  ]
+
+  try {
+    const response = await provider.makeCall(messages, {
+      useStructuredOutput: true,
+    })
+
+    if (response.content) {
+      return parseContextExtractionResponse(response.content)
+    }
+
+    return { resources: [] }
+  } catch (error) {
+    logLLM("Context extraction failed:", error)
+    return { resources: [] }
+  }
+}
+
+/**
+ * Make a regular text completion call (for transcript processing)
+ */
+export async function makeTextCompletion(
+  prompt: string,
+  _providerId?: string,
+): Promise<string> {
+  const provider = createProviderFromConfig("transcript")
+  return provider.makeTextCompletion(prompt)
+}

--- a/apps/desktop/src/main/llm/types.ts
+++ b/apps/desktop/src/main/llm/types.ts
@@ -1,0 +1,151 @@
+/**
+ * LLM-specific types for the provider abstraction layer
+ */
+
+import type { LLMToolCallResponse, MCPToolCall } from "../mcp-service"
+
+/**
+ * Callback for reporting retry progress to the UI
+ */
+export type RetryProgressCallback = (info: {
+  isRetrying: boolean
+  attempt: number
+  maxAttempts?: number // undefined for rate limits (infinite retries)
+  delaySeconds: number
+  reason: string
+  startedAt: number
+}) => void
+
+/**
+ * Callback for streaming content updates
+ */
+export type StreamingCallback = (chunk: string, accumulated: string) => void
+
+/**
+ * Result of completion verification
+ */
+export interface CompletionVerification {
+  isComplete: boolean
+  confidence?: number
+  missingItems?: string[]
+  reason?: string
+}
+
+/**
+ * Options for making an LLM call
+ */
+export interface LLMCallOptions {
+  /** Use structured output (JSON schema) if available */
+  useStructuredOutput?: boolean
+  /** Session ID for abort controller registration */
+  sessionId?: string
+  /** Callback for retry progress reporting */
+  onRetryProgress?: RetryProgressCallback
+  /** Callback for streaming content updates */
+  onStreamingUpdate?: StreamingCallback
+}
+
+/**
+ * Model capability information learned at runtime
+ */
+export interface ModelCapabilities {
+  supportsJsonSchema: boolean
+  supportsJsonObject: boolean
+  lastTested: number
+}
+
+/**
+ * LLM message format
+ */
+export interface LLMMessage {
+  role: "system" | "user" | "assistant"
+  content: string
+}
+
+/**
+ * Configuration options for LLM providers
+ */
+export interface LLMProviderConfig {
+  apiKey: string
+  baseUrl?: string
+  model: string
+  temperature?: number
+  seed?: number
+}
+
+/**
+ * Response format types
+ */
+export type ResponseFormatType = "json_schema" | "json_object" | "text"
+
+/**
+ * JSON schema for structured output
+ */
+export interface JsonSchemaFormat {
+  type: "json_schema"
+  json_schema: {
+    name: string
+    description?: string
+    schema: Record<string, unknown>
+    strict?: boolean
+  }
+}
+
+/**
+ * JSON object response format
+ */
+export interface JsonObjectFormat {
+  type: "json_object"
+}
+
+/**
+ * Text response format (default)
+ */
+export interface TextFormat {
+  type: "text"
+}
+
+export type ResponseFormat = JsonSchemaFormat | JsonObjectFormat | TextFormat
+
+/**
+ * Raw API response from LLM providers (OpenAI-compatible format)
+ */
+export interface RawLLMResponse {
+  id?: string
+  object?: string
+  created?: number
+  model?: string
+  choices: Array<{
+    index?: number
+    message: {
+      role: string
+      content: string | null
+      tool_calls?: Array<{
+        id: string
+        type: string
+        function: {
+          name: string
+          arguments: string
+        }
+      }>
+      reasoning?: string | { text: string }
+    }
+    finish_reason?: string
+  }>
+  usage?: {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+  }
+  error?: {
+    message: string
+    type?: string
+    code?: string
+    failed_generation?: string
+  }
+}
+
+/**
+ * Re-export types from mcp-service for convenience
+ */
+export type { LLMToolCallResponse, MCPToolCall }


### PR DESCRIPTION
## Summary
- Creates a clean LLM provider abstraction layer in `apps/desktop/src/main/llm/`
- Introduces provider interface that all LLM backends implement (OpenAI, Groq, Gemini)
- Extracts retry logic into a generic utility reusable by other services
- Separates agent mode utilities into focused modules

## Changes

### New Module Structure
```
apps/desktop/src/main/llm/
├── index.ts                 # Unified public API
├── types.ts                 # LLM-specific types
├── retry.ts                 # Generic retry with backoff
├── structured-output.ts     # JSON schema handling
├── providers/
│   ├── base.ts              # Abstract LLMProvider interface
│   ├── openai.ts            # OpenAI/OpenRouter implementation
│   ├── groq.ts              # Groq implementation
│   ├── gemini.ts            # Gemini implementation
│   └── index.ts             # Provider factory
└── agent/
    ├── context-extraction.ts # History analysis
    ├── tool-execution.ts     # Tool calling logic
    └── index.ts             # Agent module exports
```

### Key Features
1. **Provider Interface**: Single interface all providers implement
   - `makeCall()`, `makeStreamingCall()`, `makeTextCompletion()`
   - `verifyCompletion()` for task completion verification
   - `supportsStructuredOutput()`, `supportsJsonMode()` for capability detection

2. **Reusable Retry Logic**: Generic `withRetry()` utility
   - Exponential backoff with jitter
   - Rate limit handling (429) with infinite retries
   - Configurable retry options

3. **Agent Utilities**: Focused modules for agent mode
   - Context extraction from conversation history
   - Tool execution with kill switch support
   - Sequential vs parallel execution modes

4. **Backwards Compatible**: Legacy API functions still exported
   - `makeLLMCallWithFetch`, `makeLLMCallWithStreaming`
   - `makeTextCompletionWithFetch`, `verifyCompletionWithFetch`

## Test plan
- [x] TypeScript compilation passes
- [x] All existing tests pass (38 tests)
- [ ] Manual testing of LLM calls with each provider

## Related
Fixes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)