### PR TITLE
fix: make MCP tool details modal responsive and scrollable

### DIFF
--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
@@ -2164,32 +2164,32 @@ export function MCPConfigManager({
                                     <Eye className="h-4 w-4" />
                                   </Button>
                                 </DialogTrigger>
-                                <DialogContent className="max-w-2xl">
-                                  <DialogHeader>
-                                    <DialogTitle>{tool.name}</DialogTitle>
-                                    <DialogDescription>
+                                <DialogContent className="max-w-2xl w-[90vw] max-h-[85vh] overflow-y-auto">
+                                  <DialogHeader className="min-w-0">
+                                    <DialogTitle className="break-words">{tool.name}</DialogTitle>
+                                    <DialogDescription className="break-words">
                                       {tool.description}
                                     </DialogDescription>
                                   </DialogHeader>
-                                  <div className="space-y-4">
-                                    <div>
+                                  <div className="space-y-4 min-w-0">
+                                    <div className="min-w-0">
                                       <Label className="text-sm font-medium">
                                         Server
                                       </Label>
-                                      <p className="text-sm text-muted-foreground mt-1">
+                                      <p className="text-sm text-muted-foreground mt-1 break-words">
                                         {tool.serverName}
                                       </p>
                                     </div>
-                                    <div>
+                                    <div className="min-w-0">
                                       <Label className="text-sm font-medium">
                                         Input Schema
                                       </Label>
-                                      <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs">
+                                      <pre className="mt-2 max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs whitespace-pre-wrap break-words">
                                         {JSON.stringify(tool.inputSchema, null, 2)}
                                       </pre>
                                     </div>
                                   </div>
-                                  <div>
+                                  <div className="min-w-0">
                                     <Label className="text-sm font-medium">
                                       Profile Availability
                                     </Label>

--- a/apps/desktop/src/renderer/src/components/mcp-tool-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-tool-manager.tsx
@@ -370,19 +370,19 @@ export function MCPToolManager({ onToolToggle }: MCPToolManagerProps) {
                                   <Eye className="h-4 w-4" />
                                 </Button>
                               </DialogTrigger>
-                              <DialogContent className="max-w-2xl">
-                                <DialogHeader>
-                                  <DialogTitle>{tool.name}</DialogTitle>
-                                  <DialogDescription>
+                              <DialogContent className="max-w-2xl w-[90vw] max-h-[85vh] overflow-y-auto">
+                                <DialogHeader className="min-w-0">
+                                  <DialogTitle className="break-words">{tool.name}</DialogTitle>
+                                  <DialogDescription className="break-words">
                                     {tool.description}
                                   </DialogDescription>
                                 </DialogHeader>
-                                <div className="space-y-4">
-                                  <div>
+                                <div className="space-y-4 min-w-0">
+                                  <div className="min-w-0">
                                     <Label className="text-sm font-medium">
                                       Input Schema
                                     </Label>
-                                    <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs">
+                                    <pre className="mt-2 max-h-80 overflow-auto rounded-md bg-muted p-3 text-xs whitespace-pre-wrap break-words">
                                       {JSON.stringify(
                                         tool.inputSchema,
                                         null,


### PR DESCRIPTION
## Summary

Fixes #795 - MCP tool details modal not responsive or scrollable

## Problem

The MCP tool details modal had several UI issues:
- Text overflowed horizontally off the screen
- Text overflowed vertically off the screen when there was too much content
- No scrolling mechanism to view hidden content
- Not responsive to different screen sizes

## Solution

Updated both `mcp-tool-manager.tsx` and `mcp-config-manager.tsx` with the following fixes:

1. **Vertical overflow**: Added `max-h-[85vh]` and `overflow-y-auto` to DialogContent to limit height and enable scrolling
2. **Horizontal overflow**: Added `w-[90vw]` for responsive width capping on smaller screens
3. **Text wrapping**: Added `break-words` class to title, description, and server name elements
4. **Pre element handling**: Changed from `max-h-64` to `max-h-80` and added `whitespace-pre-wrap break-words` for better JSON schema display
5. **Flex overflow prevention**: Added `min-w-0` to flex containers to prevent content from overflowing parent bounds

## Testing

- [x] TypeScript compilation passes
- [x] All 38 unit tests pass
- [x] Production build succeeds
- [x] Dev server starts successfully

## Files Changed

- `apps/desktop/src/renderer/src/components/mcp-tool-manager.tsx`
- `apps/desktop/src/renderer/src/components/mcp-config-manager.tsx`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author