### PR TITLE
fix(#821): immediately fetch tools after server start/stop

### DIFF
--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.hydration.test.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.hydration.test.tsx
@@ -84,12 +84,16 @@ function createHookRuntime() {
     }
   }
 
+  // useCallback just returns the callback as-is in this test runtime
+  const useCallback = <T extends (...args: any[]) => any>(callback: T, _deps?: any[]): T => callback
+
   const reactMock = {
     __esModule: true,
     default: {} as any,
     useState,
     useRef,
     useEffect,
+    useCallback,
   }
   reactMock.default = reactMock
 

--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react"
+import React, { useState, useEffect, useRef, useCallback } from "react"
 import { Button } from "@renderer/components/ui/button"
 import { Input } from "@renderer/components/ui/input"
 import { Label } from "@renderer/components/ui/label"
@@ -1200,20 +1200,21 @@ export function MCPConfigManager({
     return () => clearInterval(interval)
   }, [servers, expandedLogs])
 
+  // Fetch tools function - defined as useCallback so it can be reused
+  const fetchTools = useCallback(async () => {
+    try {
+      const toolList = await tipcClient.getMcpDetailedToolList({})
+      setTools(toolList as DetailedTool[])
+    } catch (error) {}
+  }, [])
+
   // Fetch tools periodically
   useEffect(() => {
-    const fetchTools = async () => {
-      try {
-        const toolList = await tipcClient.getMcpDetailedToolList({})
-        setTools(toolList as DetailedTool[])
-      } catch (error) {}
-    }
-
     fetchTools()
     const interval = setInterval(fetchTools, 5000) // Update every 5 seconds
 
     return () => clearInterval(interval)
-  }, [])
+  }, [fetchTools])
 
   // Track known tool server names to detect new servers
   const [knownToolServers, setKnownToolServers] = useState<Set<string>>(new Set())
@@ -1681,6 +1682,8 @@ export function MCPConfigManager({
       const result = await tipcClient.stopMcpServer({ serverName })
       if ((result as any).success) {
         toast.success(`Server ${serverName} stopped successfully`)
+        // Immediately fetch tools to update the UI
+        await fetchTools()
       } else {
         toast.error(`Failed to stop server: ${(result as any).error}`)
       }
@@ -1705,6 +1708,8 @@ export function MCPConfigManager({
       const result = await tipcClient.restartMcpServer({ serverName })
       if ((result as any).success) {
         toast.success(`Server ${serverName} started successfully`)
+        // Immediately fetch tools so they appear without waiting for the 5-second interval
+        await fetchTools()
       } else {
         toast.error(`Failed to start server: ${(result as any).error}`)
       }


### PR DESCRIPTION
## Summary

Fixes #821 - Bug: Enabling server in new profile doesn't make tools appear

## Problem

When a user creates a new profile (where all servers are disabled by default), and then enables/starts a server, the server starts successfully but its tools don't appear in the tools list immediately. Users had to wait for the 5-second polling interval before tools would show up.

## Solution

This fix ensures tools are fetched immediately after a server is started or stopped:

1. **Refactored `fetchTools` to use `useCallback`** - This makes the function reusable from both the periodic `useEffect` and from event handlers

2. **Added immediate `fetchTools()` call after `handleStartServer` succeeds** - When a user starts a server, tools now appear immediately

3. **Added immediate `fetchTools()` call after `handleStopServer` succeeds** - For consistency, tools are also refreshed immediately when a server is stopped

4. **Updated test mock** - Added `useCallback` to the React mock in the hydration test file

## Testing

- [x] Build passes
- [x] All tests pass
- [x] Manually tested with the "web" profile (which has `allServersDisabledByDefault: true`)
- [x] Verified tools appear immediately after enabling a server

## Files Changed

- `apps/desktop/src/renderer/src/components/mcp-config-manager.tsx` - Main fix
- `apps/desktop/src/renderer/src/components/mcp-config-manager.hydration.test.tsx` - Test mock update

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author