### PR TITLE
feat(queue): add play button to resume paused queue after kill switch

### DIFF
--- a/apps/desktop/src/main/message-queue-service.ts
+++ b/apps/desktop/src/main/message-queue-service.ts
@@ -381,6 +381,7 @@ class MessageQueueService {
     const panel = WINDOWS.get("panel")
 
     const queue = this.getQueue(conversationId)
+    const isPaused = this.isQueuePaused(conversationId)
 
     ;[main, panel].forEach((win) => {
       if (win) {
@@ -391,6 +392,7 @@ class MessageQueueService {
               handlers.onMessageQueueUpdate.send({
                 conversationId,
                 queue,
+                isPaused,
               })
             } catch (error) {
               logApp("Failed to send queue update:", error)

--- a/apps/desktop/src/main/renderer-handlers.ts
+++ b/apps/desktop/src/main/renderer-handlers.ts
@@ -27,7 +27,7 @@ export type RendererHandlers = {
   focusAgentSession: (sessionId: string) => void
 
   // Message Queue handlers
-  onMessageQueueUpdate: (data: { conversationId: string; queue: QueuedMessage[] }) => void
+  onMessageQueueUpdate: (data: { conversationId: string; queue: QueuedMessage[]; isPaused: boolean }) => void
 
   updateAvailable: (e: UpdateDownloadedEvent) => void
   navigate: (url: string) => void

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2633,7 +2633,12 @@ export const router = {
     }),
 
   getAllMessageQueues: t.procedure.action(async () => {
-      return messageQueueService.getAllQueues()
+      const queues = messageQueueService.getAllQueues()
+      // Include isPaused state for each queue
+      return queues.map(q => ({
+        ...q,
+        isPaused: messageQueueService.isQueuePaused(q.conversationId),
+      }))
   }),
 
   removeFromMessageQueue: t.procedure

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -6,7 +6,7 @@ import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
 import { tipcClient } from "@renderer/lib/tipc-client"
-import { useAgentStore, useConversationStore, useMessageQueue } from "@renderer/stores"
+import { useAgentStore, useConversationStore, useMessageQueue, useIsQueuePaused } from "@renderer/stores"
 import { AudioPlayer } from "@renderer/components/audio-player"
 import { useConfigQuery } from "@renderer/lib/queries"
 import { useTheme } from "@renderer/contexts/theme-context"
@@ -1158,6 +1158,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
 
   // Get queued messages for this conversation (used in overlay variant)
   const queuedMessages = useMessageQueue(progress?.conversationId)
+  const isQueuePaused = useIsQueuePaused(progress?.conversationId)
   const hasQueuedMessages = queuedMessages.length > 0
 
   // Helper to toggle expansion state for a specific item
@@ -1984,6 +1985,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               conversationId={progress.conversationId}
               messages={queuedMessages}
               compact={isCollapsed}
+              isPaused={isQueuePaused}
             />
           </div>
         )}
@@ -2231,6 +2233,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             conversationId={progress.conversationId}
             messages={queuedMessages}
             compact={false}
+            isPaused={isQueuePaused}
           />
         </div>
       )}

--- a/apps/desktop/src/renderer/src/components/session-tile.tsx
+++ b/apps/desktop/src/renderer/src/components/session-tile.tsx
@@ -23,7 +23,7 @@ import { Button } from "@renderer/components/ui/button"
 import { Badge } from "@renderer/components/ui/badge"
 import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { MessageQueuePanel } from "@renderer/components/message-queue-panel"
-import { useMessageQueue } from "@renderer/stores"
+import { useMessageQueue, useIsQueuePaused } from "@renderer/stores"
 
 const MIN_HEIGHT = 120
 const MAX_HEIGHT = 600
@@ -90,6 +90,7 @@ export function SessionTile({
 
   // Get queued messages for this conversation
   const queuedMessages = useMessageQueue(session.conversationId)
+  const isQueuePaused = useIsQueuePaused(session.conversationId)
 
   // Copy message to clipboard
   const handleCopyMessage = async (e: React.MouseEvent, content: string, messageId: string) => {
@@ -335,6 +336,7 @@ export function SessionTile({
                 conversationId={session.conversationId}
                 messages={queuedMessages}
                 compact={isCollapsed}
+                isPaused={isQueuePaused}
               />
             </div>
           )}

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -89,9 +89,9 @@ export function useStoreSync() {
   // Listen for message queue updates
   useEffect(() => {
     const unlisten = rendererHandlers.onMessageQueueUpdate.listen(
-      (data: { conversationId: string; queue: QueuedMessage[] }) => {
-        logUI('[useStoreSync] Message queue update:', data.conversationId, data.queue.length)
-        updateMessageQueue(data.conversationId, data.queue)
+      (data: { conversationId: string; queue: QueuedMessage[]; isPaused: boolean }) => {
+        logUI('[useStoreSync] Message queue update:', data.conversationId, data.queue.length, 'isPaused:', data.isPaused)
+        updateMessageQueue(data.conversationId, data.queue, data.isPaused)
       }
     )
     return unlisten
@@ -99,12 +99,12 @@ export function useStoreSync() {
 
   // Initial hydration of message queues on mount
   useEffect(() => {
-    tipcClient.getAllMessageQueues().then((queues) => {
+    tipcClient.getAllMessageQueues().then((queues: Array<{ conversationId: string; messages: QueuedMessage[]; isPaused: boolean }>) => {
       logUI('[useStoreSync] Initial message queue hydration:', queues.length, 'queues')
       for (const queue of queues) {
-        updateMessageQueue(queue.conversationId, queue.messages)
+        updateMessageQueue(queue.conversationId, queue.messages, queue.isPaused)
       }
-    }).catch((error) => {
+    }).catch((error: unknown) => {
       logUI('[useStoreSync] Failed to hydrate message queues:', error)
     })
   }, [])

--- a/apps/desktop/src/renderer/src/stores/index.ts
+++ b/apps/desktop/src/renderer/src/stores/index.ts
@@ -1,5 +1,5 @@
 // Zustand stores for state management
-export { useAgentStore, useAgentProgress, useIsAgentProcessing, useMessageQueue } from './agent-store'
+export { useAgentStore, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused } from './agent-store'
 export type { SessionViewMode, SessionFilter, SessionSortBy } from './agent-store'
 export { useConversationStore } from './conversation-store'
 


### PR DESCRIPTION
## Summary

Adds a play/resume button to the queue UI that allows users to restart queue execution after using the kill switch to stop it.

## Changes

### Backend
- Added `pausedConversations` Set to `MessageQueueService` to track paused queues
- Added `pauseQueue()`, `resumeQueue()`, and `isQueuePaused()` methods
- Updated `emitQueueUpdate()` to include `isPaused` in the payload
- Updated `getAllMessageQueues` endpoint to include `isPaused` for each queue
- Updated `stopAgentSession` to pause the queue when stopping a session
- Updated `emergencyStopAll` to pause all queues when emergency stop is triggered

### Frontend
- Fixed `updateMessageQueue` action in agent-store to properly handle `isPaused` parameter
- Added `useIsQueuePaused` hook to check if a conversation's queue is paused
- Updated `use-store-sync.ts` to pass `isPaused` from IPC data to the store
- Updated `MessageQueuePanel` component with:
  - New `isPaused` prop
  - Play/Resume button that calls `resumeMessageQueue` endpoint
  - Orange-themed styling when queue is paused
  - Paused notice explaining how to resume
- Updated all usages of `MessageQueuePanel` in `agent-progress.tsx` and `session-tile.tsx` to pass `isPaused`

## Testing

- TypeScript compilation passes
- All 46 existing tests pass
- Manual testing recommended:
  1. Start a conversation with multiple queued messages
  2. Use kill switch to stop the agent
  3. Verify queue shows as paused with orange styling
  4. Click Resume button to continue processing

Closes #826

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author