### PR TITLE
fix: resize panel for text input mode after waveform recording (#840)

### DIFF
--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -21,6 +21,7 @@ import { Send } from "lucide-react"
 
 const VISUALIZER_BUFFER_LENGTH = 70
 const WAVEFORM_MIN_HEIGHT = 80
+const TEXT_INPUT_MIN_HEIGHT = 160
 
 const getInitialVisualizerData = () =>
   Array<number>(VISUALIZER_BUFFER_LENGTH).fill(-1000)
@@ -776,11 +777,14 @@ export function Component() {
 
 	  }, [anyVisibleSessions, showTextInput, recording, textInputMutation.isPending, mcpTextInputMutation.isPending])
 
+  // Use appropriate minimum height based on current mode
+  const minHeight = showTextInput ? TEXT_INPUT_MIN_HEIGHT : WAVEFORM_MIN_HEIGHT
+
   return (
     <PanelResizeWrapper
       enableResize={true}
       minWidth={200}
-      minHeight={WAVEFORM_MIN_HEIGHT}
+      minHeight={minHeight}
       className={cn(
         "floating-panel modern-text-strong flex h-screen flex-col text-foreground",
         isDark ? "dark" : ""


### PR DESCRIPTION
## Summary

Fixes #840 - Text input flow broken after waveform size reduction

## Problem

After the waveform recording shrinks the panel to `WAVEFORM_MIN_HEIGHT` (80px), triggering text input mode would leave the panel at 80px height, which is too small for the text input UI to be usable.

## Solution

1. Added a new constant `TEXT_INPUT_MIN_HEIGHT = 160` for the minimum text input panel height
2. Updated `resizePanelForTextInput()` to actually resize the panel to at least `TEXT_INPUT_MIN_HEIGHT` when the current height is too small
3. Called `resizePanelForTextInput()` in `showPanelWindowAndShowTextInput()` before showing the panel
4. Updated the renderer's `PanelResizeWrapper` to use dynamic `minHeight` based on `showTextInput` state

## Changes

- `apps/desktop/src/main/window.ts`: Added `TEXT_INPUT_MIN_HEIGHT` constant and updated `resizePanelForTextInput()` to resize the panel
- `apps/desktop/src/renderer/src/pages/panel.tsx`: Added dynamic `minHeight` based on text input mode

## Testing

1. Start the app with `pnpm dev -- -d`
2. Record a voice message (panel shrinks to 80px for waveform)
3. Trigger text input mode (Ctrl+T or via menu)
4. Verify the panel resizes to at least 160px height

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author