### PR TITLE
feat: make OpenAI Compatible, Groq, and Gemini sections collapsible in model settings

### DIFF
--- a/apps/desktop/src/main/config.ts
+++ b/apps/desktop/src/main/config.ts
@@ -140,6 +140,11 @@ const getConfig = () => {
     // Gemini TTS defaults
     geminiTtsModel: "gemini-2.5-flash-preview-tts",
     geminiTtsVoice: "Kore",
+    // Provider Section Collapse defaults - collapsed by default
+    providerSectionCollapsedOpenai: true,
+    providerSectionCollapsedGroq: true,
+    providerSectionCollapsedGemini: true,
+
     // API Retry defaults
     apiRetryCount: 3,
     apiRetryBaseDelay: 1000, // 1 second

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -198,8 +198,19 @@ export function Component() {
 
         {/* OpenAI Compatible Provider Section */}
         <div className={`rounded-lg border ${activeProviders.openai.length > 0 ? 'border-primary/30 bg-primary/5' : ''}`}>
-          <div className="px-3 py-2 flex items-center justify-between w-full">
+          <button
+            type="button"
+            className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
+            onClick={() => saveConfig({ providerSectionCollapsedOpenai: !configQuery.data.providerSectionCollapsedOpenai })}
+            aria-expanded={!configQuery.data.providerSectionCollapsedOpenai}
+            aria-controls="openai-provider-content"
+          >
             <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedOpenai ? (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              )}
               OpenAI Compatible
               {activeProviders.openai.length > 0 && (
                 <CheckCircle2 className="h-4 w-4 text-primary" />
@@ -212,83 +223,85 @@ export function Component() {
                 ))}
               </div>
             )}
-          </div>
-          <div className="divide-y border-t">
-            {activeProviders.openai.length === 0 && (
-              <div className="px-3 py-2 bg-muted/30 border-b">
-                <p className="text-xs text-muted-foreground">
-                  This provider is not currently selected for any feature. Select it above to use it.
+          </button>
+          {!configQuery.data.providerSectionCollapsedOpenai && (
+            <div id="openai-provider-content" className="divide-y border-t">
+              {activeProviders.openai.length === 0 && (
+                <div className="px-3 py-2 bg-muted/30 border-b">
+                  <p className="text-xs text-muted-foreground">
+                    This provider is not currently selected for any feature. Select it above to use it.
+                  </p>
+                </div>
+              )}
+
+              <div className="px-3 py-2">
+                <ModelPresetManager />
+                <p className="text-xs text-muted-foreground mt-3">
+                  Create presets with individual API keys for different providers (OpenRouter, Together AI, etc.)
                 </p>
               </div>
-            )}
 
-            <div className="px-3 py-2">
-              <ModelPresetManager />
-              <p className="text-xs text-muted-foreground mt-3">
-                Create presets with individual API keys for different providers (OpenRouter, Together AI, etc.)
-              </p>
-            </div>
+              {/* OpenAI TTS - only shown for native OpenAI preset */}
+              <div className="border-t mt-3 pt-3">
+                <div className="px-3 pb-2">
+                  <span className="text-sm font-medium">Text-to-Speech</span>
+                  <p className="text-xs text-muted-foreground">Only available with native OpenAI API</p>
+                </div>
+                <Control label={<ControlLabel label="TTS Model" tooltip="Choose the OpenAI TTS model to use" />} className="px-3">
+                  <Select
+                    value={configQuery.data.openaiTtsModel || "tts-1"}
+                    onValueChange={(value) => saveConfig({ openaiTtsModel: value as "tts-1" | "tts-1-hd" })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OPENAI_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>
+                          {model.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Control>
 
-            {/* OpenAI TTS - only shown for native OpenAI preset */}
-            <div className="border-t mt-3 pt-3">
-              <div className="px-3 pb-2">
-                <span className="text-sm font-medium">Text-to-Speech</span>
-                <p className="text-xs text-muted-foreground">Only available with native OpenAI API</p>
+                <Control label={<ControlLabel label="TTS Voice" tooltip="Choose the voice for OpenAI TTS" />} className="px-3">
+                  <Select
+                    value={configQuery.data.openaiTtsVoice || "alloy"}
+                    onValueChange={(value) => saveConfig({ openaiTtsVoice: value as "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {OPENAI_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>
+                          {voice.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Control>
+
+                <Control label={<ControlLabel label="TTS Speed" tooltip="Speech speed (0.25 to 4.0)" />} className="px-3">
+                  <Input
+                    type="number"
+                    min="0.25"
+                    max="4.0"
+                    step="0.25"
+                    placeholder="1.0"
+                    defaultValue={configQuery.data.openaiTtsSpeed?.toString()}
+                    onChange={(e) => {
+                      const speed = parseFloat(e.currentTarget.value)
+                      if (!isNaN(speed) && speed >= 0.25 && speed <= 4.0) {
+                        saveConfig({ openaiTtsSpeed: speed })
+                      }
+                    }}
+                  />
+                </Control>
               </div>
-            <Control label={<ControlLabel label="TTS Model" tooltip="Choose the OpenAI TTS model to use" />} className="px-3">
-              <Select
-                value={configQuery.data.openaiTtsModel || "tts-1"}
-                onValueChange={(value) => saveConfig({ openaiTtsModel: value as "tts-1" | "tts-1-hd" })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {OPENAI_TTS_MODELS.map((model) => (
-                    <SelectItem key={model.value} value={model.value}>
-                      {model.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Control>
-
-            <Control label={<ControlLabel label="TTS Voice" tooltip="Choose the voice for OpenAI TTS" />} className="px-3">
-              <Select
-                value={configQuery.data.openaiTtsVoice || "alloy"}
-                onValueChange={(value) => saveConfig({ openaiTtsVoice: value as "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" })}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {OPENAI_TTS_VOICES.map((voice) => (
-                    <SelectItem key={voice.value} value={voice.value}>
-                      {voice.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Control>
-
-            <Control label={<ControlLabel label="TTS Speed" tooltip="Speech speed (0.25 to 4.0)" />} className="px-3">
-              <Input
-                type="number"
-                min="0.25"
-                max="4.0"
-                step="0.25"
-                placeholder="1.0"
-                defaultValue={configQuery.data.openaiTtsSpeed?.toString()}
-                onChange={(e) => {
-                  const speed = parseFloat(e.currentTarget.value)
-                  if (!isNaN(speed) && speed >= 0.25 && speed <= 4.0) {
-                    saveConfig({ openaiTtsSpeed: speed })
-                  }
-                }}
-              />
-            </Control>
             </div>
-          </div>
+          )}
         </div>
 
         {/* Groq Provider Section - rendered in order based on active status */}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -440,6 +440,7 @@ export type Config = {
   autoSaveConversations?: boolean
 
   // Provider Section Collapse Configuration
+  providerSectionCollapsedOpenai?: boolean
   providerSectionCollapsedGroq?: boolean
   providerSectionCollapsedGemini?: boolean
 


### PR DESCRIPTION
## Summary

Makes all three provider sections (OpenAI Compatible, Groq, and Gemini) in the model settings page collapsible and defaults them to collapsed state.

## Changes

- Added `providerSectionCollapsedOpenai` config property to the Config type
- Set all three provider collapsed properties (`providerSectionCollapsedOpenai`, `providerSectionCollapsedGroq`, `providerSectionCollapsedGemini`) to default to `true` (collapsed)
- Refactored the OpenAI Compatible section to have the same collapsible button/chevron pattern already used by Groq and Gemini sections
- Chevron icons toggle between right (collapsed) and down (expanded)

## Testing

- Verified all three sections are collapsed by default on page load
- Verified clicking each section header expands/collapses it correctly
- Verified chevron icons change direction appropriately
- TypeScript compilation passes

Closes #862

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author