### PR TITLE
feat(ui): make tool calls compact and expandable

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -523,12 +523,24 @@ const ToolExecutionBubble: React.FC<{
                       </span>
                       <span className="opacity-50 text-[9px]">{(result.content?.length || 0).toLocaleString()} chars</span>
                     </div>
-                    <pre className={cn(
-                      "rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin",
-                      result.success ? "bg-green-50/50 dark:bg-green-950/30" : "bg-red-50/50 dark:bg-red-950/30"
-                    )}>
-                      {result.error || result.content || "No content"}
-                    </pre>
+                    {result.error && (
+                      <pre className="rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin bg-red-50/50 dark:bg-red-950/30 text-red-700 dark:text-red-300">
+                        {result.error}
+                      </pre>
+                    )}
+                    {result.content && (
+                      <pre className={cn(
+                        "rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin",
+                        result.success ? "bg-green-50/50 dark:bg-green-950/30" : "bg-muted/40"
+                      )}>
+                        {result.content}
+                      </pre>
+                    )}
+                    {!result.error && !result.content && (
+                      <pre className="rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin bg-muted/40">
+                        No content
+                      </pre>
+                    )}
                   </>
                 )}
                 {callIsPending && (
@@ -693,12 +705,24 @@ const AssistantWithToolsBubble: React.FC<{
                             {result.success ? "OK" : "ERR"}
                           </span>
                         </div>
-                        <pre className={cn(
-                          "rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin text-[10px]",
-                          result.success ? "bg-green-50/50 dark:bg-green-950/30" : "bg-red-50/50 dark:bg-red-950/30"
-                        )}>
-                          {result.error || result.content || "No content"}
-                        </pre>
+                        {result.error && (
+                          <pre className="rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin text-[10px] bg-red-50/50 dark:bg-red-950/30 text-red-700 dark:text-red-300">
+                            {result.error}
+                          </pre>
+                        )}
+                        {result.content && (
+                          <pre className={cn(
+                            "rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin text-[10px]",
+                            result.success ? "bg-green-50/50 dark:bg-green-950/30" : "bg-muted/40"
+                          )}>
+                            {result.content}
+                          </pre>
+                        )}
+                        {!result.error && !result.content && (
+                          <pre className="rounded p-1.5 overflow-auto whitespace-pre-wrap break-all max-h-32 scrollbar-thin text-[10px] bg-muted/40">
+                            No content
+                          </pre>
+                        )}
                       </>
                     )}
                   </div>


### PR DESCRIPTION
## Summary

This PR addresses issue #868 by making the tool call UI more compact and less cluttered.

## Changes

- **Replace emoji role indicators** (👤, 🤖, 🔧) with icon components using mingcute icons
- **Make tool calls display as compact single lines** with expand/collapse functionality on click
- **Remove emojis from tool result success/error indicators** - now using Check and XCircle icons from lucide-react
- **Reduce whitespace and make the UI more information-dense** with smaller padding and margins

## Before/After

### Before
- Each tool call took multiple lines with separate sections for inputs/outputs
- Emojis used for role indicators (👤 for user, 🤖 for assistant, 🔧 for tool)
- Emojis used for success/error (✅/❌)
- More whitespace between elements

### After
- Single line per tool call showing: tool icon, tool name, status icon, expand chevron
- Click to expand and see full details (inputs/outputs)
- Icon components instead of emojis for consistent styling
- More compact layout with reduced whitespace

## Testing

- Verified TypeScript compilation passes
- Tested UI changes via CDP debugging with the desktop app
- Tool calls display correctly with expand/collapse functionality

Closes #868

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author