### PR TITLE
fix: correct waveform panel shortcut hint text for hold shortcuts

### DIFF
--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -886,7 +886,11 @@ export function Component() {
                       <span>Submit</span>
                     </button>
                     <span className="text-xs text-muted-foreground">
-                      or press <kbd className="px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs">{getSubmitShortcutText}</kbd>
+                      {getSubmitShortcutText.toLowerCase().startsWith("release") ? (
+                        <>or <kbd className="px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs">{getSubmitShortcutText}</kbd></>
+                      ) : (
+                        <>or press <kbd className="px-1.5 py-0.5 rounded bg-muted text-foreground font-mono text-xs">{getSubmitShortcutText}</kbd></>
+                      )}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
When using hold-type shortcuts (like hold-ctrl), the hint text incorrectly showed "or press release keys" which doesn't make sense. Now it correctly shows "or Release keys" for hold shortcuts and "or press [key]" for press-type shortcuts.