### PR TITLE
feat(ui): hide hotkey hints in session view on narrow screens

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -47,8 +47,8 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, textInputShortc
             onSelectPrompt={onSelectPrompt}
           />
         </div>
-        {/* Keybind hints */}
-        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+        {/* Keybind hints - hidden on narrow screens */}
+        <div className="hidden md:flex items-center gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
             <Keyboard className="h-4 w-4" />
             <span>Text:</span>
@@ -378,8 +378,8 @@ export function Component() {
                 <PredefinedPromptsMenu
                   onSelectPrompt={handleSelectPrompt}
                 />
-                {/* Keybind hints */}
-                <div className="flex items-center gap-3 text-xs text-muted-foreground ml-2">
+                {/* Keybind hints - hidden on narrow screens */}
+                <div className="hidden lg:flex items-center gap-3 text-xs text-muted-foreground ml-2">
                   <div className="flex items-center gap-1.5">
                     <Keyboard className="h-3.5 w-3.5" />
                     <span>Text:</span>


### PR DESCRIPTION
## Description

Hides the keyboard shortcut helper tips (text, voice, dictation hotkeys) in the session view when the window width is too narrow.

## Changes

- Added responsive Tailwind CSS classes to the keybind hints containers
- **EmptyState hints**: Use `hidden md:flex` - visible at 768px+ window width
- **Header hints**: Use `hidden lg:flex` - visible at 1024px+ window width (higher threshold because the header has more elements)

## Behavior

- At narrow window widths, hotkey hints disappear to prevent layout issues and clutter
- Hints automatically reappear when the window is resized back to a wider width
- Uses CSS media queries via Tailwind's responsive utilities for smooth transitions

## Testing

- [x] Build passes
- [x] App runs correctly
- [x] Hints hide at narrow widths
- [x] Hints show at wider widths

Closes #896

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author