### PR TITLE
Remove ESC to close hint and tool call progress from floating menu

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1955,12 +1955,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             </Badge>
           )}
         </div>
-        {/* Esc hint - subtle text in the middle, only in overlay variant where Esc actually closes */}
-        {variant === "overlay" && (
-          <span className="text-[10px] text-muted-foreground/60 hidden sm:inline">
-            Press Esc to close panel
-          </span>
-        )}
         <div className="flex items-center gap-3">
           {/* Profile name */}
           {profileName && (
@@ -2152,23 +2146,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         isSessionActive={!isComplete}
         className="flex-shrink-0"
       />
-
-      {/* Overlay variant: Esc hint and progress bar in styled footer */}
-      {variant === "overlay" && (
-        <div className="flex items-center justify-between px-3 py-1 bg-muted/10 border-t border-border/20 flex-shrink-0">
-          <span className="text-[10px] text-muted-foreground/50">Press Esc to close</span>
-          {!isComplete && (
-            <div className="flex-1 ml-3 h-0.5 bg-muted/50 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-primary transition-all duration-500 ease-out"
-                style={{
-                  width: `${Math.min(100, (currentIteration / maxIterations) * 100)}%`,
-                }}
-              />
-            </div>
-          )}
-        </div>
-      )}
 
       {/* Default variant: Original slim full-width progress bar */}
       {variant !== "overlay" && !isComplete && (


### PR DESCRIPTION
## Summary
Removes UI clutter from the floating menu/panel as requested in #901:

1. **Removed ESC to close hint** - The hint "Press Esc to close panel" in the tile header
2. **Removed tool call progress indicator** - The footer with ESC hint and progress bar showing remaining tool call limit in the overlay variant

## Changes
- Removed the `Press Esc to close panel` text from the tile header section
- Removed the entire footer div in the overlay variant that contained the ESC hint and progress bar

## Result
The floating menu now appears cleaner and more minimal. The ESC functionality still works - users can still press ESC to close the panel, but without the visual hint.

Closes #901

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author