### PR TITLE
feat: add model registry with fuzzy matching for context windows

### DIFF
--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -162,8 +162,11 @@ const MODEL_REGISTRY: Record<string, ModelSpec> = {
   // -------------------------------------------------------------------------
   // DeepSeek models
   // -------------------------------------------------------------------------
+  // Note: "deepseek-v3" becomes "deepseek-3" after normalization (v(\d+) -> $1)
   "deepseek-r1": { contextWindow: 128_000, maxOutputTokens: 8_192 },
+  "deepseek-r-1": { contextWindow: 128_000, maxOutputTokens: 8_192 },
   "deepseek-v3": { contextWindow: 128_000, maxOutputTokens: 8_192 },
+  "deepseek-3": { contextWindow: 128_000, maxOutputTokens: 8_192 },
   "deepseek-coder": { contextWindow: 128_000, maxOutputTokens: 8_192 },
   "deepseek-chat": { contextWindow: 128_000, maxOutputTokens: 8_192 },
   "deepseek": { contextWindow: 128_000, maxOutputTokens: 8_192 },


### PR DESCRIPTION
## Summary

Adds a comprehensive model registry with fuzzy matching to correctly determine context windows for LLM models, especially those accessed through OpenAI-compatible proxies.

## Problem

When using Claude models through an OpenAI-compatible proxy (e.g., `localhost:8317/v1`), the model name `claude-haiku-4-5-20251001` didn't match any GPT patterns in the static defaults, causing it to fall back to 64K context instead of the correct 200K.

## Solution

### Model Registry (~100 models)
- **Anthropic Claude** (all 200K context): opus, sonnet, haiku - versions 3.x through 4.x
- **OpenAI** (128K): GPT-4, GPT-4o, o1, o3 series
- **Google Gemini** (1M+): 1.5, 2.0, 2.5, 3.0 series
- **xAI Grok** (up to 2M): grok-2 through grok-4
- **Others**: DeepSeek, Mistral, Qwen, Llama, Codestral

### Fuzzy Matching
- `normalizeModelName()`: Strips provider prefixes (`openai/`, `anthropic/`), date suffixes (`-20251001`), normalizes version separators
- `calculateMatchScore()`: Scores matches by pattern length, position, and word boundaries
- `lookupModelSpec()`: Finds best matching model spec from registry
- `getModelContextWindow()`: Uses fuzzy matching with provider-specific fallbacks

### Example Matches
| Input Model | Matched Pattern | Context Window |
|-------------|-----------------|----------------|
| `claude-haiku-4-5-20251001` | `claude-haiku-4-5` | 200,000 |
| `openai/claude-sonnet-4` | `claude-sonnet-4` | 200,000 |
| `gpt-4o-mini-2024-07-18` | `gpt-4o-mini` | 128,000 |
| `gemini-2.5-flash-preview` | `gemini-2.5-flash` | 1,048,576 |

## Testing
- ✅ TypeScript typecheck passed
- ✅ All 46 tests passed

## Related Research
Inspired by patterns from:
- [OpenCode](https://github.com/opencode-ai/opencode) - Go registry with hardcoded context windows
- [pi-mono](https://github.com/badlogic/pi-mono) - Generated TypeScript model registry

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author