### PR TITLE
fix: remove max height constraint on session tiles

### DIFF
--- a/apps/desktop/src/renderer/src/components/session-tile.tsx
+++ b/apps/desktop/src/renderer/src/components/session-tile.tsx
@@ -26,7 +26,7 @@ import { MessageQueuePanel } from "@renderer/components/message-queue-panel"
 import { useMessageQueue, useIsQueuePaused } from "@renderer/stores"
 
 const MIN_HEIGHT = 120
-const MAX_HEIGHT = 600
+const MAX_HEIGHT = 4000 // Allow tiles to fill large displays - effectively no practical limit
 const DEFAULT_HEIGHT = 280
 
 interface SessionTileProps {

--- a/apps/desktop/src/renderer/src/hooks/use-resizable.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-resizable.ts
@@ -9,7 +9,7 @@ export const TILE_DIMENSIONS = {
   height: {
     default: 300,
     min: 150,
-    max: 800,
+    max: 4000, // Allow tiles to fill large displays - effectively no practical limit
   },
 } as const
 


### PR DESCRIPTION
## Summary

Fixes #926 - Removes the artificial max height constraint on session tiles to allow them to fill available vertical space on large displays.

## Problem

Session tiles in the sessions view had a max height constraint (800px in use-resizable.ts and 600px in session-tile.tsx) that limited their display even when the window is large. This created unnecessary scrolling and didn't take advantage of available screen space.

## Solution

Increased the max height limit to 4000px, which effectively removes the practical limit and allows session tiles to expand to fill available vertical space when users resize them.

## Changes

- `apps/desktop/src/renderer/src/hooks/use-resizable.ts` - Updated `TILE_DIMENSIONS.height.max` from 800 to 4000
- `apps/desktop/src/renderer/src/components/session-tile.tsx` - Updated `MAX_HEIGHT` from 600 to 4000

## Testing

- [x] TypeScript compilation passes
- [x] All 46 tests pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author