### PR TITLE
feat(ui): Improve sidebar UI per issue #923

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -464,7 +464,7 @@ export function ActiveAgentsSidebar() {
       )}
 
       {/* Past Sessions Section */}
-      <div className="mt-3 border-t pt-2">
+      <div className="mt-3 pt-2">
         <div
           className={cn(
             "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-all duration-200",
@@ -492,6 +492,7 @@ export function ActiveAgentsSidebar() {
               : "Past Sessions"}
           >
             <Clock className="h-3.5 w-3.5" />
+            <span>Past</span>
             {conversationHistoryQuery.data && conversationHistoryQuery.data.length > 0 && (
               <span className="text-[10px] text-muted-foreground">
                 {conversationHistoryQuery.data.length}
@@ -527,7 +528,7 @@ export function ActiveAgentsSidebar() {
                 <Input
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder="Search sessions..."
+                  placeholder="Search..."
                   className="h-7 pl-7 text-xs"
                 />
               </div>


### PR DESCRIPTION
## Summary

This PR addresses the UI improvements requested in #923:

### Changes Made

1. **Add 'Past' label next to clock icon** - The Past Sessions section now displays "Past" text alongside the clock icon for better clarity

2. **Simplify search placeholder** - Changed the search input placeholder from "Search sessions..." to "Search..." for a cleaner look

3. **Remove horizontal separator** - Removed the `border-t` divider between active and past sessions for a more cohesive appearance

### Files Changed

- `apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx`

### Testing

- [x] Type checking passes (`pnpm typecheck`)
- [x] All tests pass (`pnpm test`)

Closes #923

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author