### PR TITLE
fix: Session side panel shows correct title instead of 'transcribing'

### DIFF
--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -126,6 +126,8 @@ class AgentSessionTracker {
     const session = this.sessions.get(sessionId)
     if (session) {
       Object.assign(session, updates)
+      // Emit update to UI so sidebar and other components reflect changes (e.g., title updates)
+      emitSessionUpdate()
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #924

The session side panel was showing "Transcribing..." instead of the actual session title in agent mode.

## Root Cause

When `agentSessionTracker.updateSession()` was called to update the session title from "Transcribing..." to the actual transcript, the sidebar UI was never notified because `updateSession()` didn't call `emitSessionUpdate()`.

All other session-modifying methods (`startSession`, `completeSession`, `stopSession`, `errorSession`, `snoozeSession`, `unsnoozeSession`, `reviveSession`) properly called `emitSessionUpdate()`, but `updateSession()` was missing this call.

## Fix

Added `emitSessionUpdate()` call inside the `if (session)` block of the `updateSession()` method so UI components are notified when session properties change.

## Testing

- All 46 tests pass
- Type check passes
- Manual verification: App starts successfully and sessions are properly tracked

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author