### PR TITLE
feat(langfuse): add sessions support to group traces by conversation

### DIFF
--- a/apps/desktop/OBSERVABILITY.md
+++ b/apps/desktop/OBSERVABILITY.md
@@ -34,11 +34,18 @@ SpeakMCP integrates with [Langfuse](https://langfuse.com/) to provide comprehens
 
 Once configured, all agent interactions will appear in your Langfuse dashboard:
 
+- **Sessions**: Conversations are grouped by session ID, allowing you to:
+  - Replay entire conversation threads
+  - See all agent interactions within a conversation
+  - Track costs and token usage per conversation
+  - Debug multi-turn conversations end-to-end
+
 - **Traces**: Each agent session creates a trace containing:
   - User input (voice transcription or text)
   - All LLM generations with token counts
   - All MCP tool calls with inputs/outputs
   - Final output/response
+  - Profile tags (e.g., `profile:General Assistant`)
 
 - **Generations**: Individual LLM API calls showing:
   - Model used (e.g., `gpt-4o`, `gemini-2.0-flash`)
@@ -53,6 +60,16 @@ Once configured, all agent interactions will appear in your Langfuse dashboard:
   - Output results
   - Execution time
   - Success/error status
+
+### Langfuse Features Used
+
+| Feature | SpeakMCP Mapping |
+|---------|------------------|
+| **Sessions** | Conversation ID - groups all agent interactions in a conversation |
+| **Traces** | Agent Session ID - individual agent run with all LLM/tool calls |
+| **Tags** | Profile name (e.g., `profile:General Assistant`) for filtering |
+| **Generations** | Individual LLM API calls with token usage |
+| **Spans** | MCP tool executions with inputs/outputs |
 
 ### Self-Hosted Langfuse
 

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -411,16 +411,22 @@ export async function processTranscriptWithAgentMode(
   agentSessionStateManager.createSession(currentSessionId, effectiveProfileSnapshot)
 
   // Create Langfuse trace for this agent session if enabled
+  // - traceId: unique ID for this trace (our agent session ID)
+  // - sessionId: groups traces together in Langfuse (our conversation ID)
   if (isLangfuseEnabled()) {
     createAgentTrace(currentSessionId, {
       name: "Agent Session",
+      sessionId: currentConversationId,  // Groups all agent sessions in this conversation
       metadata: {
-        conversationId: currentConversationId,
         maxIterations,
         hasHistory: !!previousConversationHistory?.length,
         profileId: effectiveProfileSnapshot?.profileId,
+        profileName: effectiveProfileSnapshot?.profileName,
       },
       input: transcript,
+      tags: effectiveProfileSnapshot?.profileName
+        ? [`profile:${effectiveProfileSnapshot.profileName}`]
+        : undefined,
     })
   }
 


### PR DESCRIPTION
## Summary

Builds on the Langfuse integration from PR #929 by adding **Sessions** support - a key Langfuse feature that groups multiple traces together for conversation-level observability.

## What are Langfuse Sessions?

[Langfuse Sessions](https://langfuse.com/docs/observability/features/sessions) group multiple traces together, enabling:
- **Conversation Replay**: View entire conversation threads in one place
- **Cost Tracking**: Track token usage and costs per conversation
- **Multi-turn Debugging**: Debug issues across multiple agent interactions
- **Session Metrics**: Aggregate metrics at the conversation level

## Changes

### `langfuse-service.ts`
- Added `sessionId` parameter to `createAgentTrace()` for grouping traces
- Added `tags` parameter for categorization/filtering
- Added `release` parameter for version tracking
- Improved documentation with Langfuse concept explanations
- Added debug logging for trace creation

### `llm.ts`
- Pass `conversationId` as Langfuse `sessionId` to group all agent sessions within a conversation
- Add profile name as a tag (e.g., `profile:General Assistant`) for filtering in Langfuse
- Include `profileName` in trace metadata

### `OBSERVABILITY.md`
- Documented Sessions feature and benefits
- Added feature mapping table showing how SpeakMCP concepts map to Langfuse
- Updated trace documentation to mention profile tags

## Feature Mapping

| Langfuse Feature | SpeakMCP Mapping |
|-----------------|------------------|
| **Sessions** | Conversation ID - groups all agent interactions in a conversation |
| **Traces** | Agent Session ID - individual agent run with all LLM/tool calls |
| **Tags** | Profile name (e.g., `profile:General Assistant`) for filtering |
| **Generations** | Individual LLM API calls with token usage |
| **Spans** | MCP tool executions with inputs/outputs |

## Testing

- ✅ TypeScript compilation passes (`tsc --noEmit` for node config)
- ✅ All tests pass (13/13 in llm-fetch.test.ts)
- ✅ Pre-existing type error in index.ts is unrelated (setTimeout.unref issue)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author