### PR TITLE
feat(skills): improve skills context instructions for agents

### DIFF
--- a/apps/desktop/DEBUGGING.md
+++ b/apps/desktop/DEBUGGING.md
@@ -65,6 +65,62 @@ window.electron.ipcRenderer.invoke('getAgentSessions')
 ```
 > All procedures in `apps/desktop/src/main/tipc.ts`
 
+---
+
+## Skills Debugging
+
+Skills are instruction files (`SKILL.md`) that get injected into the system prompt to give agents specialized capabilities.
+
+### Check Active Skills
+```javascript
+// List all skills and their enabled state
+await window.electron.ipcRenderer.invoke('getSkills')
+
+// Get skills enabled for current profile
+await window.electron.ipcRenderer.invoke('getProfileSkillsConfig')
+```
+
+### Skills in LLM Context
+When debug logging is enabled (`-d` or `-dl`), you'll see:
+```
+[DEBUG][LLM] Loading skills for session <id>. enabledSkillIds: [...]
+[DEBUG][LLM] Skills instructions loaded: <N> chars
+```
+
+The skills instructions appear in the system prompt with this structure:
+```
+# Active Agent Skills
+## Skills Installation Directory: ~/.speakmcp/skills/
+## Skill: <name>
+**Skill ID:** `<uuid>`
+<instructions>
+```
+
+### Skills Folder Location
+```javascript
+// Get the skills folder path (for manual inspection)
+// macOS: ~/Library/Application Support/speakmcp/skills/
+await window.electron.ipcRenderer.invoke('openSkillsFolder')
+```
+
+### Creating/Installing Skills
+Skills are loaded from `SKILL.md` files with YAML frontmatter:
+```markdown
+---
+name: my-skill
+description: What this skill does
+---
+
+Instructions in markdown...
+```
+
+### Troubleshooting
+- **Skill not loading**: Check if skill is enabled for the current profile in Settings → Skills
+- **Skills not appearing**: Run `scanSkillsFolder` to re-scan for new skill files
+- **Skill instructions truncated**: Very long skills may be compacted in summarization—keep instructions concise
+
+---
+
 ## Mobile App
 ```bash
 pnpm dev:mobile  # Press 'w' for web → localhost:8081

--- a/apps/desktop/src/main/skills-service.ts
+++ b/apps/desktop/src/main/skills-service.ts
@@ -800,7 +800,8 @@ ${skill.instructions}`
       result += `
 ## Active Skills
 
-The following skills are currently enabled:
+The following skills are enabled and provide specialized instructions for specific tasks.
+**IMPORTANT:** Follow each skill's instructions as they are tailored for this environment—use them proactively without needing explicit prompts.
 
 ${skillsContent}
 `
@@ -847,14 +848,13 @@ ${skill.instructions}`
     return `
 # Active Agent Skills
 
-## Skills Installation Directory
-**IMPORTANT**: All skills MUST be installed to this ABSOLUTE path:
-\`${skillsFolder}\`
+The following skills are enabled and provide specialized instructions for specific tasks.
+**IMPORTANT:** Follow each skill's instructions as they are tailored for this environment.
 
-When creating or installing skills, ALWAYS use this exact absolute path. Do NOT use relative paths.
-
-The following skills provide specialized instructions for specific tasks.
-Use \`speakmcp-settings:execute_command\` with the skill's ID to run commands in the skill's directory.
+## Key Information
+- **Skills Directory:** \`${skillsFolder}\`
+- **Execute in Skill Directory:** Use \`speakmcp-settings:execute_command\` with a skill's ID to run commands in that skill's working directory
+- **Skills are Context:** These instructions are part of your system context—use them proactively without needing explicit prompts
 
 ${skillsContent}
 `


### PR DESCRIPTION
## Summary

Improves how agents understand and use skills by enhancing the context instructions injected into the system prompt.

## Changes

### `apps/desktop/DEBUGGING.md`
- Added comprehensive **Skills Debugging** section
- Documents IPC commands for checking active skills (`getSkills`, `getProfileSkillsConfig`)
- Explains expected debug log format for skills loading
- Includes SKILL.md file format reference and troubleshooting tips

### `apps/desktop/src/main/skills-service.ts`
- Updated skills context header to emphasize **proactive usage**
- Added clear statement: "Skills are Context: These instructions are part of your system context—use them proactively without needing explicit prompts"
- Improved formatting of skills information in the system prompt

## Why

Agents were not using skills effectively without explicit prompts from users. This change makes it clear that skills are pre-loaded context that should be applied automatically when relevant.

## Testing

- All tests pass (`pnpm --filter @speakmcp/desktop test:run`)
- Verified skills loading with debug logs enabled (`pnpm dev -- -d`)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author