### PR TITLE
feat: add read_media_file builtin tool (replaces filesystem server package)

### DIFF
--- a/apps/desktop/src/main/builtin-tool-definitions.ts
+++ b/apps/desktop/src/main/builtin-tool-definitions.ts
@@ -339,6 +339,20 @@ export const builtinToolDefinitions: BuiltinToolDefinition[] = [
       required: ["skillId"],
     },
   },
+  {
+    name: `${BUILTIN_SERVER_NAME}:read_media_file`,
+    description: "Read an image or audio file and return it as base64-encoded data. Use this to load media files for multimodal LLM processing. Supports common image formats (png, jpg, gif, webp, svg) and audio formats (mp3, wav, ogg, flac).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Absolute path to the media file to read",
+        },
+      },
+      required: ["path"],
+    },
+  },
 ]
 
 /**


### PR DESCRIPTION
## Summary

Adds a lightweight `read_media_file` builtin tool for reading images and audio files as base64-encoded data. This is the **only unique functionality** not already covered by the existing `execute_command` tool.

## Context

This replaces PR #955 which proposed a full 680-line filesystem MCP server package. After analysis, we determined that:

- All filesystem operations (read, write, edit, mkdir, ls, mv, find) are already covered by `speakmcp-settings:execute_command` via shell commands
- The only unique value a dedicated filesystem tool provides is **base64-encoded media file reading** for multimodal LLM input

## Changes

**104 lines added** (vs 948 lines in the closed PR #955)

- Added `read_media_file` tool definition in `builtin-tool-definitions.ts`
- Added handler implementation in `builtin-tools.ts`

## Supported Formats

| Type | Extensions |
|------|------------|
| Images | png, jpg, jpeg, gif, webp, bmp, svg |
| Audio | mp3, wav, ogg, flac |

## Usage

```json
{
  "name": "speakmcp-settings:read_media_file",
  "arguments": {
    "path": "/path/to/image.png"
  }
}
```

Returns base64-encoded data with MIME type for multimodal LLM processing.

## Testing

- [x] TypeScript type checks pass

---

Closes the need for #953 with a minimal solution.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author