### PR TITLE
fix: show waveform visualization for normal voice dictation mode

### DIFF
--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -410,6 +410,10 @@ export function Component() {
       setShowTextInput(false)
       // Clear text input state in main process so panel doesn't stay in textInput mode (positioning/sizing)
       tipcClient.clearTextInputState({})
+      // Set recording state immediately to show waveform UI without waiting for async mic init
+      // This prevents flash of stale UI during the ~280ms mic initialization (fixes #974)
+      setRecording(true)
+      recordingRef.current = true
       setVisualizerData(() => getInitialVisualizerData())
       recorderRef.current?.startRecording()
     })
@@ -448,6 +452,11 @@ export function Component() {
         mcpModeRef.current = false
         // Track if recording was triggered via UI button click
         setFromButtonClick(data?.fromButtonClick ?? false)
+        // Set recording state immediately to show waveform UI without waiting for async mic init
+        // This prevents flash of stale UI during the ~280ms mic initialization (fixes #974)
+        setRecording(true)
+        recordingRef.current = true
+        setVisualizerData(() => getInitialVisualizerData())
         tipcClient.showPanelWindow({})
         recorderRef.current?.startRecording()
       }


### PR DESCRIPTION
## Summary

Fixes #974 - Missing waveform for normal voice dictation in desktop app

## Problem

The waveform visualization was only appearing in MCP/agent mode but was missing in normal voice dictation mode. Users would see a static UI instead of the animated waveform bars when using the standard hold-to-talk dictation feature.

## Root Cause

The waveform UI renders conditionally based on the `recording` state being `true`. In MCP/agent mode, `setRecording(true)` was correctly called **before** `recorderRef.current?.startRecording()`. However, in the two normal dictation handlers (`startRecording` and `startOrFinishRecording`), the code only called `recorderRef.current?.startRecording()` without first setting the recording state.

## Solution

Added `setRecording(true)` and `recordingRef.current = true` to both normal dictation handlers, mirroring the working MCP mode pattern:

1. **`startRecording` handler** (lines 402-422): Added state initialization before `startRecording()`
2. **`startOrFinishRecording` handler** (lines 442-466): Added state initialization including `setVisualizerData()` reset

## Testing

- [x] TypeScript compilation passes (`pnpm --filter @speakmcp/desktop exec tsc --noEmit`)
- [x] All 55 tests pass (`pnpm --filter @speakmcp/desktop test:run`)
- [x] App launches successfully in dev mode
- [ ] Manual testing with microphone recommended

## Changes

- `apps/desktop/src/renderer/src/pages/panel.tsx` - Set recording state immediately when normal dictation starts

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author