### PR TITLE
fix: update summarization model when switching presets

### DIFF
--- a/apps/desktop/src/renderer/src/components/model-preset-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/model-preset-manager.tsx
@@ -36,6 +36,7 @@ export function ModelPresetManager() {
     apiKey: "",
     mcpToolsModel: "",
     transcriptProcessingModel: "",
+    summarizationModel: "",
   })
 
   const config = configQuery.data
@@ -82,8 +83,8 @@ export function ModelPresetManager() {
   // Save model selection to the current preset (called when user changes model)
   // Save model selection to both global config AND the current preset in a single save
   const saveModelWithPreset = useCallback((
-    modelType: 'mcpToolsModel' | 'transcriptProcessingModel',
-    globalConfigKey: 'mcpToolsOpenaiModel' | 'transcriptPostProcessingOpenaiModel',
+    modelType: 'mcpToolsModel' | 'transcriptProcessingModel' | 'summarizationModel',
+    globalConfigKey: 'mcpToolsOpenaiModel' | 'transcriptPostProcessingOpenaiModel' | 'dualModelWeakModelName',
     modelId: string
   ) => {
     if (!currentPresetId || !config) return
@@ -145,6 +146,10 @@ export function ModelPresetManager() {
       if (preset.transcriptProcessingModel) {
         updates.transcriptPostProcessingOpenaiModel = preset.transcriptProcessingModel
       }
+      // Apply summarization model if set on the preset (dual-model mode)
+      if (preset.summarizationModel) {
+        updates.dualModelWeakModelName = preset.summarizationModel
+      }
       saveConfig(updates)
       toast.success(`Switched to preset: ${preset.name}`)
     }
@@ -171,6 +176,7 @@ export function ModelPresetManager() {
       updatedAt: Date.now(),
       mcpToolsModel: newPreset.mcpToolsModel || "",
       transcriptProcessingModel: newPreset.transcriptProcessingModel || "",
+      summarizationModel: newPreset.summarizationModel || "",
     }
 
     const existingPresets = config?.modelPresets || []
@@ -179,7 +185,7 @@ export function ModelPresetManager() {
     })
 
     setIsCreateDialogOpen(false)
-    setNewPreset({ name: "", baseUrl: "", apiKey: "", mcpToolsModel: "", transcriptProcessingModel: "" })
+    setNewPreset({ name: "", baseUrl: "", apiKey: "", mcpToolsModel: "", transcriptProcessingModel: "", summarizationModel: "" })
     toast.success("Preset created successfully")
   }
 
@@ -411,6 +417,18 @@ export function ModelPresetManager() {
                     label="Transcript Processing Model"
                     placeholder="Select model for transcripts"
                   />
+
+                  <PresetModelSelector
+                    presetId="new-preset"
+                    baseUrl={newPreset.baseUrl || ""}
+                    apiKey={newPreset.apiKey || ""}
+                    value={newPreset.summarizationModel || ""}
+                    onValueChange={(value) =>
+                      setNewPreset({ ...newPreset, summarizationModel: value })
+                    }
+                    label="Summarization Model"
+                    placeholder="Select model for dual-model summarization"
+                  />
                 </div>
               </div>
             )}
@@ -510,6 +528,18 @@ export function ModelPresetManager() {
                     }
                     label="Transcript Processing Model"
                     placeholder="Select model for transcripts"
+                  />
+
+                  <PresetModelSelector
+                    presetId={editingPreset.id}
+                    baseUrl={editingPreset.baseUrl}
+                    apiKey={editingPreset.apiKey}
+                    value={editingPreset.summarizationModel || ""}
+                    onValueChange={(value) =>
+                      setEditingPreset({ ...editingPreset, summarizationModel: value })
+                    }
+                    label="Summarization Model"
+                    placeholder="Select model for dual-model summarization"
                   />
                 </div>
               </div>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -879,6 +879,7 @@ export interface ModelPreset {
   updatedAt?: number
   mcpToolsModel?: string
   transcriptProcessingModel?: string
+  summarizationModel?: string  // Model for dual-model summarization (weak model)
 }
 
 // ACP Agent Configuration Types


### PR DESCRIPTION
## Summary

Fixes #968 - Summarization model not updating when switching presets

## Problem

When switching between presets, the summarization model name remained unchanged instead of updating to the model that was saved with that preset. This defeated the purpose of having preset-specific configurations for dual-model mode.

## Solution

### 1. Extended `ModelPreset` interface
- Added `summarizationModel` field to store the preferred summarization model for each preset

### 2. Updated preset switching logic
- Modified `handlePresetChange` to apply the `summarizationModel` from the preset to `dualModelWeakModelName` when switching presets

### 3. Updated model saving logic
- Extended `saveModelWithPreset` function to support the new `summarizationModel` type, allowing changes to be saved to both global config and the current preset

### 4. Updated preset dialogs
- Added summarization model selector to both Create Preset and Edit Preset dialogs
- Users can now configure their preferred summarization model as part of the preset

## Files Changed

### `apps/desktop/src/shared/types.ts`
- Added `summarizationModel?: string` field to `ModelPreset` interface

### `apps/desktop/src/renderer/src/components/model-preset-manager.tsx`
- Updated `handlePresetChange` to apply summarization model from preset
- Extended `saveModelWithPreset` type signature to include `summarizationModel`
- Added summarization model selector to Create Preset dialog
- Added summarization model selector to Edit Preset dialog
- Updated `newPreset` state initialization to include `summarizationModel`

## Testing

- [x] TypeScript compilation passes (`pnpm typecheck`)
- [x] All 55 tests pass (`pnpm --filter @speakmcp/desktop test:run`)

## How to Test

1. Enable dual-model mode in Settings > Providers
2. Create or edit a preset and set a specific summarization model
3. Switch to a different preset (with a different summarization model configured)
4. Verify that the summarization model updates to match the new preset
5. Switch back and verify it updates again

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author