### PR TITLE
fix: hide keybind hints from top bar when sessions are active

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -424,28 +424,6 @@ export function Component() {
                 <PredefinedPromptsMenu
                   onSelectPrompt={handleSelectPrompt}
                 />
-                {/* Keybind hints - hidden on narrow screens */}
-                <div className="hidden lg:flex items-center gap-3 text-xs text-muted-foreground ml-2">
-                  <div className="flex items-center gap-1.5">
-                    <Keyboard className="h-3.5 w-3.5" />
-                    <span>Text:</span>
-                    <kbd className="px-1.5 py-0.5 text-xs font-semibold bg-muted border rounded">
-                      {textInputShortcut}
-                    </kbd>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <span>Voice:</span>
-                    <kbd className="px-1.5 py-0.5 text-xs font-semibold bg-muted border rounded">
-                      {voiceInputShortcut}
-                    </kbd>
-                  </div>
-                  <div className="flex items-center gap-1.5">
-                    <span>Dictation:</span>
-                    <kbd className="px-1.5 py-0.5 text-xs font-semibold bg-muted border rounded">
-                      {dictationShortcut}
-                    </kbd>
-                  </div>
-                </div>
               </div>
               <div className="flex items-center gap-2">
                 {/* View mode toggle */}


### PR DESCRIPTION
## Summary

Hides the keyboard shortcut hints (Text, Voice, Dictation) from the header bar during active sessions. Tips remain visible on the splash screen (EmptyState) when no sessions are active.

## Changes

- Removed the keybind hints section from the sessions header bar (displayed when sessions exist)
- Keybind hints remain visible in the EmptyState component (splash screen when no sessions)

## Behavior

**Before**: Keybind hints appeared in both:
- Splash screen (no sessions) ✓
- Top header bar (active sessions) ✗

**After**: Keybind hints only appear on:
- Splash screen (no sessions) ✓
- Clean top bar during active sessions ✓

## Rationale

- Tips are most useful when first opening the app or between sessions
- During active work, the top bar space is better used for session content
- Users don't need persistent tip reminders once they're working

## Testing

- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] All 55 tests pass (`pnpm --filter @speakmcp/desktop test:run`)

Closes #965

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author