### PR TITLE
feat(mobile): Order chat sessions list by last message sent/received

### DIFF
--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -249,7 +249,9 @@ export function useSessions(): SessionStore {
   }, [sessions, currentSessionId]);
 
   const getSessionList = useCallback((): SessionListItem[] => {
-    return sessions.map(sessionToListItem);
+    // Sort sessions by updatedAt in descending order (most recently active first)
+    const sortedSessions = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+    return sortedSessions.map(sessionToListItem);
   }, [sessions]);
 
   const addMessage = useCallback(async (


### PR DESCRIPTION
## Summary

Sorts the chat sessions list in the mobile UI by the timestamp of the last message sent or received. This ensures the most recent conversations appear at the top, improving usability and quick access to active chats.

## Changes

- **`apps/mobile/src/store/sessions.ts`**: Updated `getSessionList()` to sort sessions by `updatedAt` in descending order (most recently active first)

## Implementation Details

The `Session` type already has an `updatedAt` field that is updated whenever:
- A new session is created
- Messages are added to a session
- Server conversation ID is set

The fix simply sorts the sessions array before mapping to list items, ensuring the most recently updated sessions appear at the top of the list.

## Testing

- ✅ TypeScript compilation passes
- ✅ All 55 tests pass

Fixes #984

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/)