### PR TITLE
feat(mobile): add expandable tool call details in chat UI

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -359,7 +359,7 @@ export default function ChatScreen({ route, navigation }: any) {
   const [debugInfo, setDebugInfo] = useState<string>('');
   const [expandedMessages, setExpandedMessages] = useState<Record<number, boolean>>({});
   // Track which individual tool calls are fully expanded to show all input/output details
-  // Key format: "messageId-toolCallIndex" (messageId falls back to empty string if undefined)
+  // Key format: "messageId-toolCallIndex" (messageId falls back to message array index if undefined)
   const [expandedToolCalls, setExpandedToolCalls] = useState<Record<string, boolean>>({});
   // Track the last failed message for retry functionality
   const [lastFailedMessage, setLastFailedMessage] = useState<string | null>(null);
@@ -2021,13 +2021,16 @@ export default function ChatScreen({ route, navigation }: any) {
                             {m.toolCalls?.map((toolCall, idx) => {
                               const result = m.toolResults?.[idx];
                               const isResultPending = !result && idx >= (m.toolResults?.length ?? 0);
-                              const toolCallKey = `${m.id ?? ''}-${idx}`;
+                              // Use message id or fallback to array index to ensure stable, unique keys
+                              // that won't collide when m.id is undefined (which is common)
+                              const stableMessageKey = m.id ?? String(i);
+                              const toolCallKey = `${stableMessageKey}-${idx}`;
                               const isToolCallFullyExpanded = expandedToolCalls[toolCallKey] ?? false;
                               return (
                                 <View key={idx} style={styles.toolCallSection}>
                                   {/* Tool name heading - tappable to toggle full expansion */}
                                   <Pressable
-                                    onPress={() => toggleToolCallExpansion(m.id ?? '', idx)}
+                                    onPress={() => toggleToolCallExpansion(stableMessageKey, idx)}
                                     style={({ pressed }) => [
                                       styles.toolCallHeader,
                                       pressed && styles.toolCallHeaderPressed,


### PR DESCRIPTION
## Summary

This PR adds the ability to expand tool call details further in the mobile UI, showing full input parameters and results/output of tool calls.

## Problem

Currently, tool call details in the mobile UI are truncated with a `maxHeight: 80` constraint on both the input parameters and output results. This makes it hard to debug or inspect agent behavior when tool calls have lengthy inputs or outputs.

## Solution

Implemented a two-level expansion system:
1. **First level**: Existing message expansion (shows tool calls section)
2. **Second level**: Individual tool call expansion (shows full content without height restrictions)

### Changes

- Add `expandedToolCalls` state to track which individual tool calls are fully expanded (key format: `messageIndex-toolCallIndex`)
- Add `toggleToolCallExpansion` callback to toggle expansion per tool call
- Make tool call headers tappable with visual feedback (`toolCallHeader` and `toolCallHeaderPressed` styles)
- Add 'Input:' and 'Output:' section labels for better clarity (`toolSectionLabel` style)
- Add `toolParamsScrollExpanded` and `toolResultScrollExpanded` styles with larger `maxHeight` (400px) to show full content when expanded
- Add hint text showing expansion state (▶ Full Details / ▼ Collapse)

### User Experience

1. User expands a message with tool calls (first tap)
2. Tool calls are shown with limited height (80px) for quick scanning
3. User taps on a specific tool call header to see full details
4. Input parameters and output results expand to show up to 400px of content
5. User can collapse individual tool calls or the entire message

## Testing

- [x] TypeScript compilation passes
- [x] All existing tests pass (55 tests across 6 test files)

## Labels

`slot-1`

Fixes #983

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author