### PR TITLE
Move Connect button to top of mobile settings UI

### DIFF
--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -596,6 +596,27 @@ export default function SettingsScreen({ navigation }: any) {
       >
         <Text style={styles.h1}>Settings</Text>
 
+        {connectionError && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>⚠️ {connectionError}</Text>
+          </View>
+        )}
+
+        <TouchableOpacity
+          style={[styles.primaryButton, isCheckingConnection && styles.primaryButtonDisabled]}
+          onPress={onSave}
+          disabled={isCheckingConnection}
+        >
+          {isCheckingConnection ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator color={theme.colors.primaryForeground} size="small" />
+              <Text style={styles.primaryButtonText}>  Checking connection...</Text>
+            </View>
+          ) : (
+            <Text style={styles.primaryButtonText}>Save & Start Chatting</Text>
+          )}
+        </TouchableOpacity>
+
         <Text style={styles.sectionTitle}>Appearance</Text>
         <View style={styles.themeSelector}>
           {THEME_OPTIONS.map((option) => (
@@ -946,27 +967,6 @@ export default function SettingsScreen({ navigation }: any) {
             )}
           </>
         )}
-
-        {connectionError && (
-          <View style={styles.errorContainer}>
-            <Text style={styles.errorText}>⚠️ {connectionError}</Text>
-          </View>
-        )}
-
-        <TouchableOpacity
-          style={[styles.primaryButton, isCheckingConnection && styles.primaryButtonDisabled]}
-          onPress={onSave}
-          disabled={isCheckingConnection}
-        >
-          {isCheckingConnection ? (
-            <View style={styles.loadingContainer}>
-              <ActivityIndicator color={theme.colors.primaryForeground} size="small" />
-              <Text style={styles.primaryButtonText}>  Checking connection...</Text>
-            </View>
-          ) : (
-            <Text style={styles.primaryButtonText}>Save & Start Chatting</Text>
-          )}
-        </TouchableOpacity>
       </ScrollView>
 
       <Modal visible={showScanner} animationType="slide" onRequestClose={() => setShowScanner(false)}>


### PR DESCRIPTION
## Description

This PR moves the "Save & Start Chatting" button from the bottom to the top of the mobile settings screen for better accessibility and discoverability.

## Changes
- Moved the Connect button to appear immediately after the Settings heading
- Connection error message also moved to stay near the button
- Users no longer need to scroll to find the most important action

## Testing
- [ ] Verify button appears at the top of settings screen
- [ ] Verify button functionality remains unchanged
- [ ] Verify connection error displays correctly near the button
- [ ] Test on both iOS and Android

Fixes #982

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author