### PR TITLE
Fix #982: Move Connect button to top of mobile settings UI

### DIFF
--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -596,6 +596,27 @@ export default function SettingsScreen({ navigation }: any) {
       >
         <Text style={styles.h1}>Settings</Text>
 
+        {connectionError && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>⚠️ {connectionError}</Text>
+          </View>
+        )}
+
+        <TouchableOpacity
+          style={[styles.primaryButton, isCheckingConnection && styles.primaryButtonDisabled]}
+          onPress={onSave}
+          disabled={isCheckingConnection}
+        >
+          {isCheckingConnection ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator color={theme.colors.primaryForeground} size="small" />
+              <Text style={styles.primaryButtonText}>  Checking connection...</Text>
+            </View>
+          ) : (
+            <Text style={styles.primaryButtonText}>Connect</Text>
+          )}
+        </TouchableOpacity>
+
         <Text style={styles.sectionTitle}>Appearance</Text>
         <View style={styles.themeSelector}>
           {THEME_OPTIONS.map((option) => (
@@ -947,26 +968,6 @@ export default function SettingsScreen({ navigation }: any) {
           </>
         )}
 
-        {connectionError && (
-          <View style={styles.errorContainer}>
-            <Text style={styles.errorText}>⚠️ {connectionError}</Text>
-          </View>
-        )}
-
-        <TouchableOpacity
-          style={[styles.primaryButton, isCheckingConnection && styles.primaryButtonDisabled]}
-          onPress={onSave}
-          disabled={isCheckingConnection}
-        >
-          {isCheckingConnection ? (
-            <View style={styles.loadingContainer}>
-              <ActivityIndicator color={theme.colors.primaryForeground} size="small" />
-              <Text style={styles.primaryButtonText}>  Checking connection...</Text>
-            </View>
-          ) : (
-            <Text style={styles.primaryButtonText}>Save & Start Chatting</Text>
-          )}
-        </TouchableOpacity>
       </ScrollView>
 
       <Modal visible={showScanner} animationType="slide" onRequestClose={() => setShowScanner(false)}>


### PR DESCRIPTION
## Description

This PR fixes issue #982 by moving the Connect button from the bottom to the top of the mobile settings screen for better accessibility and discoverability.

## Changes

- ✅ Moved Connect button to the top of settings screen (immediately after the header)
- ✅ Moved connection error display to the top alongside the button
- ✅ Changed button text from "Save & Start Chatting" to "Connect" for clarity
- ✅ Removed duplicate button and error container from the bottom

## Impact

Users no longer need to scroll down to find the Connect button - it's now prominently placed at the top of the settings screen as the first interactive element, making it much easier to discover and use.

## Testing

The changes maintain all existing functionality:
- Connection validation still works
- Error messages display correctly at the top
- Button states (loading, disabled) work as before
- Navigation to Sessions screen after successful connection remains unchanged

Closes #982

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author