### PR TITLE
feat(mobile): extract and apply fixes from acp-remote fork

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -20,8 +20,6 @@ import { useEffect, useMemo, useCallback, useRef } from 'react';
 
 
 const speakMCPIcon = require('./assets/speakmcp-icon.png');
-const darkSpinner = require('./assets/loading-spinner.gif');
-const lightSpinner = require('./assets/light-spinner.gif');
 
 const Stack = createNativeStackNavigator();
 
@@ -200,7 +198,7 @@ function Navigation() {
     return (
       <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
         <Image
-          source={isDark ? darkSpinner : lightSpinner}
+          source={speakMCPIcon}
           style={styles.spinner}
           resizeMode="contain"
         />

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -23,6 +23,7 @@
     "expo-notifications": "^0.32.16",
     "expo-speech": "~14.0.7",
     "expo-speech-recognition": "^2.1.2",
+    "html5-qrcode": "^2.3.8",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/apps/mobile/src/lib/pushNotifications.ts
+++ b/apps/mobile/src/lib/pushNotifications.ts
@@ -41,9 +41,10 @@ export interface NotificationData {
 // ============================================
 
 /**
- * Check if push notifications are supported (requires physical device)
+ * Check if push notifications are supported (requires physical device, not web)
  */
 export function isSupported(): boolean {
+  if (Platform.OS === 'web') return false;
   return Device.isDevice;
 }
 

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -8,6 +8,9 @@ export type AppConfig = {
   handsFree?: boolean; // hands-free voice mode toggle (optional for backward compatibility)
   ttsEnabled?: boolean; // text-to-speech toggle (optional for backward compatibility)
   messageQueueEnabled?: boolean; // message queue toggle (allows queuing messages while agent is busy)
+  ttsVoiceId?: string; // selected TTS voice identifier
+  ttsRate?: number; // TTS speech rate (0.5 - 2.0)
+  ttsPitch?: number; // TTS pitch (0.5 - 2.0)
 };
 
 const DEFAULTS: AppConfig = {
@@ -17,6 +20,9 @@ const DEFAULTS: AppConfig = {
   handsFree: false,
   ttsEnabled: true,
   messageQueueEnabled: true,
+  ttsVoiceId: undefined,
+  ttsRate: 1.0,
+  ttsPitch: 1.0,
 };
 
 const STORAGE_KEY = 'app_config_v1';

--- a/apps/mobile/src/types/session.ts
+++ b/apps/mobile/src/types/session.ts
@@ -12,6 +12,22 @@ export interface ChatMessage {
 // Re-export shared types for convenience
 export type { ToolCall, ToolResult } from '@speakmcp/shared';
 
+// External session source type (matches desktop's ExternalSessionSource)
+export type ExternalSessionSource = 'augment' | 'claude-code' | 'acp-remote';
+
+// Unified session list item with source information
+export interface UnifiedSessionListItem extends SessionListItem {
+  source: ExternalSessionSource;
+  workspacePath?: string;
+  filePath?: string;
+}
+
+// External session provider info
+export interface ExternalSessionProvider {
+  source: ExternalSessionSource;
+  displayName: string;
+}
+
 export interface Session {
   id: string;
   title: string;

--- a/apps/mobile/src/ui/ACPSessionBadge.tsx
+++ b/apps/mobile/src/ui/ACPSessionBadge.tsx
@@ -1,0 +1,157 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Modal, FlatList, ActivityIndicator } from 'react-native';
+import { useTheme } from './ThemeProvider';
+import { useConfigContext } from '../store/config';
+import { ExtendedSettingsApiClient, ACPSessionInfo, ACPModelOrMode } from '../lib/settingsApi';
+
+interface ACPSessionBadgeProps {
+  compact?: boolean;
+}
+
+/**
+ * Shows the current ACP session model/mode and allows changing them.
+ * Fetches session info from the remote server and displays available options.
+ */
+export function ACPSessionBadge({ compact = false }: ACPSessionBadgeProps) {
+  const { theme } = useTheme();
+  const { config } = useConfigContext();
+  const [sessionInfo, setSessionInfo] = useState<ACPSessionInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [modalType, setModalType] = useState<'model' | 'mode'>('model');
+  const [changing, setChanging] = useState(false);
+
+  const client = new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
+
+  const fetchSessionInfo = async () => {
+    try {
+      setLoading(true);
+      const info = await client.getACPSession();
+      setSessionInfo(info);
+    } catch (error) {
+      console.error('[ACPSessionBadge] Failed to fetch session info:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSessionInfo();
+    // Refresh periodically
+    const interval = setInterval(fetchSessionInfo, 30000);
+    return () => clearInterval(interval);
+  }, [config.baseUrl, config.apiKey]);
+
+  const hasMultipleModels = (sessionInfo?.availableModels?.length ?? 0) > 1;
+  const hasMultipleModes = (sessionInfo?.availableModes?.length ?? 0) > 1;
+  const canInteract = hasMultipleModels || hasMultipleModes;
+
+  const handlePress = () => {
+    if (!canInteract) return;
+    setModalType(hasMultipleModels ? 'model' : 'mode');
+    setModalVisible(true);
+  };
+
+  const handleSelect = async (item: ACPModelOrMode) => {
+    if (!sessionInfo?.agentName || !sessionInfo?.sessionId) return;
+    setChanging(true);
+    try {
+      if (modalType === 'model') {
+        await client.setACPSessionModel(sessionInfo.agentName, sessionInfo.sessionId, item.id);
+      } else {
+        await client.setACPSessionMode(sessionInfo.agentName, sessionInfo.sessionId, item.id);
+      }
+      // Refresh session info
+      await fetchSessionInfo();
+    } catch (error) {
+      console.error(`[ACPSessionBadge] Failed to set ${modalType}:`, error);
+    } finally {
+      setChanging(false);
+      setModalVisible(false);
+    }
+  };
+
+  if (!sessionInfo?.currentModel && !sessionInfo?.agentTitle) {
+    return null;
+  }
+
+  const displayText = compact
+    ? (sessionInfo.currentModel?.split('-').pop() ?? sessionInfo.agentTitle ?? '')
+    : `${sessionInfo.currentModel ?? ''}${sessionInfo.currentMode ? ` • ${sessionInfo.currentMode}` : ''}`;
+
+  const modalItems = modalType === 'model'
+    ? sessionInfo?.availableModels ?? []
+    : sessionInfo?.availableModes ?? [];
+  const currentValue = modalType === 'model' ? sessionInfo?.currentModel : sessionInfo?.currentMode;
+
+  return (
+    <>
+      <TouchableOpacity
+        onPress={handlePress}
+        disabled={!canInteract || loading}
+        style={[styles.badge, { backgroundColor: theme.colors.muted }]}
+      >
+        {loading ? (
+          <ActivityIndicator size="small" color={theme.colors.primary} />
+        ) : (
+          <Text style={[styles.badgeText, { color: theme.colors.mutedForeground }]} numberOfLines={1}>
+            {displayText}
+          </Text>
+        )}
+        {canInteract && <Text style={[styles.chevron, { color: theme.colors.mutedForeground }]}>▼</Text>}
+      </TouchableOpacity>
+
+      <Modal visible={modalVisible} transparent animationType="fade" onRequestClose={() => setModalVisible(false)}>
+        <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={() => setModalVisible(false)}>
+          <View style={[styles.modalContent, { backgroundColor: theme.colors.card }]}>
+            <Text style={[styles.modalTitle, { color: theme.colors.foreground }]}>
+              Select {modalType === 'model' ? 'Model' : 'Mode'}
+            </Text>
+            {changing ? (
+              <ActivityIndicator size="large" color={theme.colors.primary} style={{ marginVertical: 20 }} />
+            ) : (
+              <FlatList
+                data={modalItems}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => (
+                  <TouchableOpacity
+                    style={[styles.modalItem, item.id === currentValue && { backgroundColor: theme.colors.primary + '22' }]}
+                    onPress={() => handleSelect(item)}
+                  >
+                    <Text style={[styles.modalItemText, { color: theme.colors.foreground }]}>{item.name || item.id}</Text>
+                    {item.description && (
+                      <Text style={[styles.modalItemDesc, { color: theme.colors.mutedForeground }]}>{item.description}</Text>
+                    )}
+                  </TouchableOpacity>
+                )}
+              />
+            )}
+            {hasMultipleModels && hasMultipleModes && (
+              <TouchableOpacity
+                style={[styles.switchButton, { borderColor: theme.colors.border }]}
+                onPress={() => setModalType(modalType === 'model' ? 'mode' : 'model')}
+              >
+                <Text style={{ color: theme.colors.primary }}>Switch to {modalType === 'model' ? 'Modes' : 'Models'}</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 8, paddingVertical: 4, borderRadius: 8, gap: 4 },
+  badgeText: { fontSize: 11, fontWeight: '500' },
+  chevron: { fontSize: 8 },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'center', alignItems: 'center' },
+  modalContent: { width: '80%', maxHeight: '60%', borderRadius: 12, padding: 16 },
+  modalTitle: { fontSize: 16, fontWeight: '600', marginBottom: 12, textAlign: 'center' },
+  modalItem: { paddingVertical: 12, paddingHorizontal: 8, borderRadius: 8 },
+  modalItemText: { fontSize: 14, fontWeight: '500' },
+  modalItemDesc: { fontSize: 12, marginTop: 2 },
+  switchButton: { marginTop: 12, paddingVertical: 10, borderTopWidth: 1, alignItems: 'center' },
+});
+
+export default ACPSessionBadge;

--- a/apps/mobile/src/ui/TTSSettings.tsx
+++ b/apps/mobile/src/ui/TTSSettings.tsx
@@ -1,0 +1,363 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Modal, FlatList, Platform } from 'react-native';
+import * as Speech from 'expo-speech';
+import { useTheme } from './ThemeProvider';
+import { spacing, radius } from './theme';
+
+interface TTSSettingsProps {
+  voiceId?: string;
+  rate: number;
+  pitch: number;
+  onVoiceChange: (voiceId: string | undefined) => void;
+  onRateChange: (rate: number) => void;
+  onPitchChange: (pitch: number) => void;
+}
+
+interface VoiceInfo {
+  identifier: string;
+  name: string;
+  language: string;
+  quality?: string;
+}
+
+/**
+ * TTS voice settings component with voice selection, rate, and pitch controls.
+ * Uses expo-speech for voice listing and preview.
+ */
+export function TTSSettings({ voiceId, rate, pitch, onVoiceChange, onRateChange, onPitchChange }: TTSSettingsProps) {
+  const { theme } = useTheme();
+  const [voices, setVoices] = useState<VoiceInfo[]>([]);
+  const [showVoicePicker, setShowVoicePicker] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadVoices = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const availableVoices = await Speech.getAvailableVoicesAsync();
+      // Filter to English voices and sort by quality
+      const englishVoices = availableVoices
+        .filter(v => v.language.startsWith('en'))
+        .map(v => ({
+          identifier: v.identifier,
+          name: v.name,
+          language: v.language,
+          quality: (v as any).quality,
+        }))
+        .sort((a, b) => {
+          // Sort enhanced/premium voices first
+          const aQuality = a.quality === 'Enhanced' || a.quality === 'Premium' ? 0 : 1;
+          const bQuality = b.quality === 'Enhanced' || b.quality === 'Premium' ? 0 : 1;
+          if (aQuality !== bQuality) return aQuality - bQuality;
+          return a.name.localeCompare(b.name);
+        });
+      setVoices(englishVoices);
+    } catch (error) {
+      console.error('[TTSSettings] Failed to load voices:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadVoices();
+  }, [loadVoices]);
+
+  const testVoice = () => {
+    Speech.stop();
+    const options: Speech.SpeechOptions = {
+      language: 'en-US',
+      rate,
+      pitch,
+    };
+    if (voiceId) {
+      options.voice = voiceId;
+    }
+    Speech.speak('Hello! This is a test of the text to speech settings.', options);
+  };
+
+  const currentVoiceName = voiceId
+    ? voices.find(v => v.identifier === voiceId)?.name || voiceId
+    : 'System Default';
+
+  // Simple rate/pitch controls using buttons
+  const adjustRate = (delta: number) => {
+    const newRate = Math.round(Math.max(0.5, Math.min(2.0, rate + delta)) * 10) / 10;
+    onRateChange(newRate);
+  };
+
+  const adjustPitch = (delta: number) => {
+    const newPitch = Math.round(Math.max(0.5, Math.min(2.0, pitch + delta)) * 10) / 10;
+    onPitchChange(newPitch);
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* Voice Selection */}
+      <TouchableOpacity
+        style={[styles.voiceSelector, { borderColor: theme.colors.border, backgroundColor: theme.colors.background }]}
+        onPress={() => {
+          loadVoices();
+          setShowVoicePicker(true);
+        }}
+      >
+        <View style={styles.voiceSelectorContent}>
+          <Text style={[styles.voiceSelectorLabel, { color: theme.colors.mutedForeground }]}>Voice</Text>
+          <View style={styles.voiceSelectorRight}>
+            <Text style={[styles.voiceSelectorText, { color: theme.colors.foreground }]} numberOfLines={1}>
+              {currentVoiceName}
+            </Text>
+            <Text style={[styles.voiceSelectorChevron, { color: theme.colors.mutedForeground }]}>▼</Text>
+          </View>
+        </View>
+      </TouchableOpacity>
+
+      {/* Rate Control */}
+      <View style={styles.sliderRow}>
+        <Text style={[styles.sliderLabel, { color: theme.colors.foreground }]}>Speed</Text>
+        <View style={styles.sliderControls}>
+          <TouchableOpacity
+            style={[styles.adjustButton, { borderColor: theme.colors.border }]}
+            onPress={() => adjustRate(-0.1)}
+          >
+            <Text style={[styles.adjustButtonText, { color: theme.colors.foreground }]}>−</Text>
+          </TouchableOpacity>
+          <Text style={[styles.sliderValue, { color: theme.colors.foreground }]}>{rate.toFixed(1)}x</Text>
+          <TouchableOpacity
+            style={[styles.adjustButton, { borderColor: theme.colors.border }]}
+            onPress={() => adjustRate(0.1)}
+          >
+            <Text style={[styles.adjustButtonText, { color: theme.colors.foreground }]}>+</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Pitch Control */}
+      <View style={styles.sliderRow}>
+        <Text style={[styles.sliderLabel, { color: theme.colors.foreground }]}>Pitch</Text>
+        <View style={styles.sliderControls}>
+          <TouchableOpacity
+            style={[styles.adjustButton, { borderColor: theme.colors.border }]}
+            onPress={() => adjustPitch(-0.1)}
+          >
+            <Text style={[styles.adjustButtonText, { color: theme.colors.foreground }]}>−</Text>
+          </TouchableOpacity>
+          <Text style={[styles.sliderValue, { color: theme.colors.foreground }]}>{pitch.toFixed(1)}</Text>
+          <TouchableOpacity
+            style={[styles.adjustButton, { borderColor: theme.colors.border }]}
+            onPress={() => adjustPitch(0.1)}
+          >
+            <Text style={[styles.adjustButtonText, { color: theme.colors.foreground }]}>+</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Test Button */}
+      <TouchableOpacity
+        style={[styles.testButton, { borderColor: theme.colors.border }]}
+        onPress={testVoice}
+      >
+        <Text style={[styles.testButtonText, { color: theme.colors.primary }]}>Test Voice</Text>
+      </TouchableOpacity>
+
+      {/* Voice Picker Modal */}
+      <Modal
+        visible={showVoicePicker}
+        animationType="slide"
+        transparent={true}
+        onRequestClose={() => setShowVoicePicker(false)}
+      >
+        <View style={[styles.modalOverlay]}>
+          <View style={[styles.modalContent, { backgroundColor: theme.colors.background }]}>
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: theme.colors.foreground }]}>Select Voice</Text>
+              <TouchableOpacity onPress={() => setShowVoicePicker(false)}>
+                <Text style={[styles.modalClose, { color: theme.colors.mutedForeground }]}>✕</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* System Default option */}
+            <TouchableOpacity
+              style={[
+                styles.voiceItem,
+                !voiceId && { backgroundColor: theme.colors.primary + '22' },
+                { borderBottomColor: theme.colors.border },
+              ]}
+              onPress={() => {
+                onVoiceChange(undefined);
+                setShowVoicePicker(false);
+              }}
+            >
+              <Text style={[styles.voiceItemName, { color: theme.colors.foreground }]}>System Default</Text>
+              {!voiceId && <Text style={[styles.voiceItemCheck, { color: theme.colors.primary }]}>✓</Text>}
+            </TouchableOpacity>
+
+            <FlatList
+              data={voices}
+              keyExtractor={(item) => item.identifier}
+              renderItem={({ item }) => {
+                const isSelected = voiceId === item.identifier;
+                return (
+                  <TouchableOpacity
+                    style={[
+                      styles.voiceItem,
+                      isSelected && { backgroundColor: theme.colors.primary + '22' },
+                      { borderBottomColor: theme.colors.border },
+                    ]}
+                    onPress={() => {
+                      onVoiceChange(item.identifier);
+                      setShowVoicePicker(false);
+                    }}
+                  >
+                    <View style={{ flex: 1 }}>
+                      <Text style={[styles.voiceItemName, { color: theme.colors.foreground }]}>{item.name}</Text>
+                      <Text style={[styles.voiceItemLang, { color: theme.colors.mutedForeground }]}>
+                        {item.language}{item.quality ? ` • ${item.quality}` : ''}
+                      </Text>
+                    </View>
+                    {isSelected && <Text style={[styles.voiceItemCheck, { color: theme.colors.primary }]}>✓</Text>}
+                  </TouchableOpacity>
+                );
+              }}
+              ListEmptyComponent={
+                <View style={styles.emptyList}>
+                  <Text style={[styles.emptyText, { color: theme.colors.mutedForeground }]}>
+                    {isLoading ? 'Loading voices...' : 'No English voices available'}
+                  </Text>
+                </View>
+              }
+            />
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.sm,
+  },
+  voiceSelector: {
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.sm,
+  },
+  voiceSelectorContent: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  voiceSelectorLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  voiceSelectorRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  voiceSelectorText: {
+    fontSize: 14,
+  },
+  voiceSelectorChevron: {
+    fontSize: 10,
+  },
+  sliderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sliderLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  sliderControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  adjustButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  adjustButtonText: {
+    fontSize: 18,
+    fontWeight: '500',
+  },
+  sliderValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    minWidth: 40,
+    textAlign: 'center',
+  },
+  testButton: {
+    borderWidth: 1,
+    borderRadius: radius.md,
+    padding: spacing.sm,
+    alignItems: 'center',
+  },
+  testButtonText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    maxHeight: '80%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  modalClose: {
+    fontSize: 20,
+    padding: spacing.sm,
+  },
+  voiceItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: spacing.md,
+    borderBottomWidth: 1,
+  },
+  voiceItemName: {
+    fontSize: 14,
+  },
+  voiceItemLang: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  voiceItemCheck: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginLeft: spacing.sm,
+  },
+  emptyList: {
+    padding: spacing.xl,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 14,
+  },
+});
+
+export default TTSSettings;

--- a/apps/mobile/src/ui/WebQRScanner.tsx
+++ b/apps/mobile/src/ui/WebQRScanner.tsx
@@ -1,0 +1,213 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
+
+interface WebQRScannerProps {
+  onScan: (data: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * Web-only QR code scanner using html5-qrcode library.
+ * Only renders on web platform, returns null on native.
+ */
+export function WebQRScanner({ onScan, onClose }: WebQRScannerProps) {
+  const scannerRef = useRef<any>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(true);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+
+    let html5QrCode: any = null;
+    let mounted = true;
+    let isRunning = false;
+
+    const initScanner = async () => {
+      try {
+        // Dynamic import for web only
+        const { Html5Qrcode } = await import('html5-qrcode');
+
+        if (!mounted) return;
+
+        html5QrCode = new Html5Qrcode('web-qr-reader');
+        scannerRef.current = html5QrCode;
+
+        await html5QrCode.start(
+          { facingMode: 'environment' },
+          {
+            fps: 10,
+            qrbox: { width: 250, height: 250 },
+          },
+          (decodedText: string) => {
+            // Success callback - stop scanner before calling onScan
+            if (isRunning) {
+              isRunning = false;
+              try {
+                const state = html5QrCode.getState?.();
+                if (state === 2 || state === 3) {
+                  html5QrCode.stop().catch(() => {});
+                }
+              } catch {
+                // Ignore stop errors
+              }
+            }
+            onScan(decodedText);
+          },
+          () => {
+            // Error callback (QR not found in frame) - ignore
+          }
+        );
+
+        isRunning = true;
+        if (mounted) {
+          setIsStarting(false);
+        }
+      } catch (err: any) {
+        console.error('[WebQRScanner] Error:', err);
+        isRunning = false;
+        if (mounted) {
+          setIsStarting(false);
+          if (err?.message?.includes('Permission denied') || err?.name === 'NotAllowedError') {
+            setError('Camera permission denied. Please allow camera access and try again.');
+          } else if (err?.message?.includes('not found') || err?.name === 'NotFoundError') {
+            setError('No camera found. Please connect a camera and try again.');
+          } else {
+            setError(err?.message || 'Failed to start camera');
+          }
+        }
+      }
+    };
+
+    initScanner();
+
+    return () => {
+      mounted = false;
+      if (html5QrCode) {
+        try {
+          // Check if scanner is actually running before trying to stop
+          const state = html5QrCode.getState?.();
+          // State 2 = SCANNING, State 3 = PAUSED (both can be stopped)
+          if (state === 2 || state === 3 || isRunning) {
+            html5QrCode.stop().catch(() => {});
+          }
+        } catch {
+          // Ignore errors when stopping - scanner may already be stopped
+        }
+      }
+    };
+  }, [onScan]);
+
+  if (Platform.OS !== 'web') {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Scan QR Code</Text>
+        <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+          <Text style={styles.closeText}>✕</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.scannerWrapper}>
+        {isStarting && !error && (
+          <View style={styles.loadingOverlay}>
+            <Text style={styles.loadingText}>Starting camera...</Text>
+          </View>
+        )}
+        {error && (
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>{error}</Text>
+            <TouchableOpacity onPress={onClose} style={styles.retryButton}>
+              <Text style={styles.retryText}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+        <div
+          id="web-qr-reader"
+          style={{ width: '100%', maxWidth: 400 }}
+          ref={containerRef as any}
+        />
+      </View>
+
+      <Text style={styles.hint}>
+        Point your camera at a SpeakMCP QR code
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    padding: 20,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  closeButton: {
+    padding: 10,
+  },
+  closeText: {
+    color: '#fff',
+    fontSize: 24,
+  },
+  scannerWrapper: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'relative',
+  },
+  loadingOverlay: {
+    position: 'absolute',
+    zIndex: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  errorContainer: {
+    position: 'absolute',
+    zIndex: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  errorText: {
+    color: '#ff6b6b',
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  retryButton: {
+    backgroundColor: '#333',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  hint: {
+    color: '#888',
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 20,
+  },
+});
+
+export default WebQRScanner;


### PR DESCRIPTION
Ports the following mobile app fixes from aj47/acp-remote:

- Prevent double words in streaming responses by detecting full-text vs delta token updates in onToken callbacks
- Prevent text selection on hold-to-talk button on web using native DOM event listeners and CSS user-select properties (Pressable instead of TouchableOpacity)
- Replace animated GIF spinners with static icon across all screens (App.tsx, ChatScreen, SessionListScreen) for better performance
- Remove orphaned useEffect for modelUpdateTimeout in SettingsScreen
- Add web QR code scanner (WebQRScanner) using html5-qrcode with URL paste fallback for web platform
- Add TTS voice settings (TTSSettings) with voice selection, rate, and pitch controls using expo-speech
- Add ACP session badge (ACPSessionBadge) showing current model/mode with picker UI for changing them
- Add ACP session types and normalization in settingsApi.ts (normalize modelId -> id field names)
- Add external session types and API methods for unified conversation history (augment, claude-code sources)
- Add web platform guard for push notifications (isSupported returns false on web)
- Add ExternalSessionSource and UnifiedSessionListItem types
- Add ttsVoiceId, ttsRate, ttsPitch to AppConfig store
- Add html5-qrcode dependency for web QR scanning

https://claude.ai/code/session_01B9wpDAGRDc83dTyrT8tzsw