### PR TITLE
feat: add chat groups/channels for organizing conversations

### DIFF
--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2735,6 +2735,41 @@ export const router = {
     await shell.openPath(conversationsFolder)
   }),
 
+  // Chat Group / Channel Management
+  getChatGroups: t.procedure.action(async () => {
+    return conversationService.getGroups()
+  }),
+
+  createChatGroup: t.procedure
+    .input<{ name: string; color?: string }>()
+    .action(async ({ input }) => {
+      return conversationService.createGroup(input.name, input.color)
+    }),
+
+  updateChatGroup: t.procedure
+    .input<{ groupId: string; name?: string; color?: string }>()
+    .action(async ({ input }) => {
+      return conversationService.updateGroup(input.groupId, {
+        name: input.name,
+        color: input.color,
+      })
+    }),
+
+  deleteChatGroup: t.procedure
+    .input<{ groupId: string }>()
+    .action(async ({ input }) => {
+      await conversationService.deleteGroup(input.groupId)
+    }),
+
+  setConversationGroup: t.procedure
+    .input<{ conversationId: string; groupId: string | undefined }>()
+    .action(async ({ input }) => {
+      await conversationService.setConversationGroup(
+        input.conversationId,
+        input.groupId,
+      )
+    }),
+
   // Panel resize endpoints
   getPanelSize: t.procedure.action(async () => {
     const win = WINDOWS.get("panel")

--- a/apps/desktop/src/renderer/src/lib/queries.ts
+++ b/apps/desktop/src/renderer/src/lib/queries.ts
@@ -209,6 +209,73 @@ export const useSaveMcpConfigFile = () =>
   })
 
 // ============================================================================
+// Chat Group / Channel Hooks
+// ============================================================================
+
+export const useChatGroupsQuery = () =>
+  useQuery({
+    queryKey: ["chat-groups"],
+    queryFn: async () => {
+      return tipcClient.getChatGroups()
+    },
+  })
+
+export const useCreateChatGroupMutation = () =>
+  useMutation({
+    mutationFn: async ({ name, color }: { name: string; color?: string }) => {
+      return tipcClient.createChatGroup({ name, color })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chat-groups"] })
+    },
+  })
+
+export const useUpdateChatGroupMutation = () =>
+  useMutation({
+    mutationFn: async ({
+      groupId,
+      name,
+      color,
+    }: {
+      groupId: string
+      name?: string
+      color?: string
+    }) => {
+      return tipcClient.updateChatGroup({ groupId, name, color })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chat-groups"] })
+    },
+  })
+
+export const useDeleteChatGroupMutation = () =>
+  useMutation({
+    mutationFn: async (groupId: string) => {
+      return tipcClient.deleteChatGroup({ groupId })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chat-groups"] })
+      queryClient.invalidateQueries({ queryKey: ["conversation-history"] })
+    },
+  })
+
+export const useSetConversationGroupMutation = () =>
+  useMutation({
+    mutationFn: async ({
+      conversationId,
+      groupId,
+    }: {
+      conversationId: string
+      groupId: string | undefined
+    }) => {
+      return tipcClient.setConversationGroup({ conversationId, groupId })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["conversation-history"] })
+    },
+  })
+
+// ============================================================================
 // History-themed aliases for better semantic naming
 // ============================================================================
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -376,6 +376,8 @@ export interface Conversation {
   createdAt: number
   updatedAt: number
   messages: ConversationMessage[]
+  /** ID of the group/channel this conversation belongs to */
+  groupId?: string
   metadata?: {
     totalTokens?: number
     model?: string
@@ -392,6 +394,8 @@ export interface ConversationHistoryItem {
   messageCount: number
   lastMessage: string
   preview: string
+  /** ID of the group/channel this conversation belongs to */
+  groupId?: string
 }
 
 export type ProfileMcpServerConfig = {

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -1,5 +1,5 @@
-import { useLayoutEffect, useMemo } from 'react';
-import { View, Text, FlatList, TouchableOpacity, StyleSheet, Alert, Platform, Image } from 'react-native';
+import { useLayoutEffect, useMemo, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, Alert, Platform, Image, ScrollView, TextInput, Modal } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../ui/ThemeProvider';
 import { spacing, radius, Theme } from '../ui/theme';
@@ -9,9 +9,21 @@ import { useTunnelConnection } from '../store/tunnelConnection';
 import { useProfile } from '../store/profile';
 import { ConnectionStatusIndicator } from '../ui/ConnectionStatusIndicator';
 import { SessionListItem } from '../types/session';
+import type { ChatGroup } from '@speakmcp/shared';
 
 const darkSpinner = require('../../assets/loading-spinner.gif');
 const lightSpinner = require('../../assets/light-spinner.gif');
+
+const GROUP_COLORS = [
+  '#3b82f6', // blue
+  '#10b981', // emerald
+  '#f59e0b', // amber
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#f97316', // orange
+];
 
 interface Props {
   navigation: any;
@@ -23,6 +35,14 @@ export default function SessionListScreen({ navigation }: Props) {
   const connectionManager = useConnectionManager();
   const { connectionInfo } = useTunnelConnection();
   const { currentProfile } = useProfile();
+
+  // Group state
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null); // null = "All"
+  const [showCreateGroupModal, setShowCreateGroupModal] = useState(false);
+  const [newGroupName, setNewGroupName] = useState('');
+  const [newGroupColor, setNewGroupColor] = useState(GROUP_COLORS[0]);
+  const [showMoveToGroupModal, setShowMoveToGroupModal] = useState(false);
+  const [movingSessionId, setMovingSessionId] = useState<string | null>(null);
 
   useLayoutEffect(() => {
     navigation?.setOptions?.({
@@ -72,6 +92,14 @@ export default function SessionListScreen({ navigation }: Props) {
   const insets = useSafeAreaInsets();
   const sessionStore = useSessionContext();
   const sessions = sessionStore.getSessionList();
+  const groups = sessionStore.groups;
+
+  // Filter sessions by selected group
+  const filteredSessions = useMemo(() => {
+    if (selectedGroupId === null) return sessions;
+    if (selectedGroupId === '__ungrouped__') return sessions.filter(s => !s.groupId);
+    return sessions.filter(s => s.groupId === selectedGroupId);
+  }, [sessions, selectedGroupId]);
 
   if (!sessionStore.ready) {
     return (
@@ -98,7 +126,6 @@ export default function SessionListScreen({ navigation }: Props) {
 
   const handleDeleteSession = (session: SessionListItem) => {
     const doDelete = () => {
-      // Clean up connection for this session (fixes #608)
       connectionManager.removeConnection(session.id);
       sessionStore.deleteSession(session.id);
     };
@@ -119,9 +146,48 @@ export default function SessionListScreen({ navigation }: Props) {
     }
   };
 
+  const handleLongPress = (session: SessionListItem) => {
+    if (Platform.OS === 'web') {
+      // On web, just delete
+      handleDeleteSession(session);
+      return;
+    }
+
+    const options: Array<{ text: string; style?: 'cancel' | 'destructive' | 'default'; onPress?: () => void }> = [];
+
+    if (groups.length > 0) {
+      options.push({
+        text: 'Move to Group',
+        onPress: () => {
+          setMovingSessionId(session.id);
+          setShowMoveToGroupModal(true);
+        },
+      });
+
+      if (session.groupId) {
+        options.push({
+          text: 'Remove from Group',
+          onPress: () => sessionStore.setSessionGroup(session.id, undefined),
+        });
+      }
+    }
+
+    options.push({
+      text: 'Delete',
+      style: 'destructive',
+      onPress: () => {
+        connectionManager.removeConnection(session.id);
+        sessionStore.deleteSession(session.id);
+      },
+    });
+
+    options.push({ text: 'Cancel', style: 'cancel' });
+
+    Alert.alert(session.title, undefined, options);
+  };
+
   const handleClearAll = () => {
     const doClear = () => {
-      // Clean up all connections (fixes #608)
       connectionManager.manager.cleanupAll();
       sessionStore.clearAllSessions();
     };
@@ -142,11 +208,52 @@ export default function SessionListScreen({ navigation }: Props) {
     }
   };
 
+  const handleCreateGroup = async () => {
+    if (!newGroupName.trim()) return;
+    await sessionStore.createGroup(newGroupName.trim(), newGroupColor);
+    setNewGroupName('');
+    setNewGroupColor(GROUP_COLORS[0]);
+    setShowCreateGroupModal(false);
+  };
+
+  const handleDeleteGroup = (group: ChatGroup) => {
+    if (Platform.OS === 'web') {
+      if (window.confirm(`Delete group "${group.name}"? Sessions will be moved to ungrouped.`)) {
+        sessionStore.deleteGroup(group.id);
+        if (selectedGroupId === group.id) setSelectedGroupId(null);
+      }
+    } else {
+      Alert.alert(
+        'Delete Group',
+        `Delete "${group.name}"? Sessions will be moved to ungrouped.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => {
+              sessionStore.deleteGroup(group.id);
+              if (selectedGroupId === group.id) setSelectedGroupId(null);
+            },
+          },
+        ]
+      );
+    }
+  };
+
+  const handleMoveSessionToGroup = (groupId: string | undefined) => {
+    if (movingSessionId) {
+      sessionStore.setSessionGroup(movingSessionId, groupId);
+    }
+    setShowMoveToGroupModal(false);
+    setMovingSessionId(null);
+  };
+
   const formatDate = (timestamp: number) => {
     const date = new Date(timestamp);
     const now = new Date();
     const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
-    
+
     if (diffDays === 0) {
       return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     } else if (diffDays === 1) {
@@ -159,17 +266,28 @@ export default function SessionListScreen({ navigation }: Props) {
 
   const renderSession = ({ item }: { item: SessionListItem }) => {
     const isActive = item.id === sessionStore.currentSessionId;
-    
+    const group = item.groupId ? groups.find(g => g.id === item.groupId) : null;
+
     return (
       <TouchableOpacity
         style={[styles.sessionItem, isActive && styles.sessionItemActive]}
         onPress={() => handleSelectSession(item.id)}
-        onLongPress={() => handleDeleteSession(item)}
+        onLongPress={() => handleLongPress(item)}
       >
         <View style={styles.sessionHeader}>
-          <Text style={styles.sessionTitle} numberOfLines={1}>
-            {item.title}
-          </Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1, marginRight: 8 }}>
+            {group && (
+              <View style={[styles.groupBadge, { backgroundColor: (group.color || '#6b7280') + '22' }]}>
+                <View style={[styles.groupDot, { backgroundColor: group.color || '#6b7280' }]} />
+                <Text style={[styles.groupBadgeText, { color: group.color || '#6b7280' }]} numberOfLines={1}>
+                  {group.name}
+                </Text>
+              </View>
+            )}
+            <Text style={styles.sessionTitle} numberOfLines={1}>
+              {item.title}
+            </Text>
+          </View>
           <Text style={styles.sessionDate}>{formatDate(item.updatedAt)}</Text>
         </View>
         <Text style={styles.sessionPreview} numberOfLines={2}>
@@ -204,13 +322,161 @@ export default function SessionListScreen({ navigation }: Props) {
         )}
       </View>
 
+      {/* Group filter chips */}
+      {groups.length > 0 && (
+        <View style={styles.groupFilterContainer}>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.groupFilterScroll}>
+            <TouchableOpacity
+              style={[styles.groupChip, selectedGroupId === null && styles.groupChipActive]}
+              onPress={() => setSelectedGroupId(null)}
+            >
+              <Text style={[styles.groupChipText, selectedGroupId === null && styles.groupChipTextActive]}>All</Text>
+            </TouchableOpacity>
+            {groups.map((group) => (
+              <TouchableOpacity
+                key={group.id}
+                style={[
+                  styles.groupChip,
+                  selectedGroupId === group.id && styles.groupChipActive,
+                  selectedGroupId === group.id && { borderColor: group.color || theme.colors.primary },
+                ]}
+                onPress={() => setSelectedGroupId(selectedGroupId === group.id ? null : group.id)}
+                onLongPress={() => handleDeleteGroup(group)}
+              >
+                <View style={[styles.groupDot, { backgroundColor: group.color || '#6b7280' }]} />
+                <Text
+                  style={[
+                    styles.groupChipText,
+                    selectedGroupId === group.id && { color: group.color || theme.colors.primary },
+                  ]}
+                  numberOfLines={1}
+                >
+                  {group.name}
+                </Text>
+              </TouchableOpacity>
+            ))}
+            <TouchableOpacity
+              style={styles.groupChip}
+              onPress={() => setShowCreateGroupModal(true)}
+            >
+              <Text style={styles.groupChipText}>+</Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </View>
+      )}
+
+      {/* Add group button when no groups exist */}
+      {groups.length === 0 && sessions.length > 0 && (
+        <TouchableOpacity
+          style={styles.createGroupBanner}
+          onPress={() => setShowCreateGroupModal(true)}
+        >
+          <Text style={styles.createGroupBannerText}>+ Create a group to organize chats</Text>
+        </TouchableOpacity>
+      )}
+
       <FlatList
-        data={sessions}
+        data={filteredSessions}
         renderItem={renderSession}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={sessions.length === 0 ? styles.emptyList : styles.list}
+        contentContainerStyle={filteredSessions.length === 0 ? styles.emptyList : styles.list}
         ListEmptyComponent={EmptyState}
       />
+
+      {/* Create Group Modal */}
+      <Modal
+        visible={showCreateGroupModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowCreateGroupModal(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={() => setShowCreateGroupModal(false)}
+        >
+          <TouchableOpacity activeOpacity={1} style={styles.modalContent} onPress={() => {}}>
+            <Text style={styles.modalTitle}>Create Group</Text>
+            <TextInput
+              style={styles.modalInput}
+              value={newGroupName}
+              onChangeText={setNewGroupName}
+              placeholder="Group name..."
+              placeholderTextColor={theme.colors.mutedForeground}
+              autoFocus
+              onSubmitEditing={handleCreateGroup}
+            />
+            <View style={styles.colorPicker}>
+              {GROUP_COLORS.map((color) => (
+                <TouchableOpacity
+                  key={color}
+                  style={[
+                    styles.colorDot,
+                    { backgroundColor: color },
+                    newGroupColor === color && styles.colorDotSelected,
+                  ]}
+                  onPress={() => setNewGroupColor(color)}
+                />
+              ))}
+            </View>
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                style={styles.modalButtonCancel}
+                onPress={() => setShowCreateGroupModal(false)}
+              >
+                <Text style={styles.modalButtonCancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalButtonCreate, !newGroupName.trim() && { opacity: 0.5 }]}
+                onPress={handleCreateGroup}
+                disabled={!newGroupName.trim()}
+              >
+                <Text style={styles.modalButtonCreateText}>Create</Text>
+              </TouchableOpacity>
+            </View>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
+
+      {/* Move to Group Modal */}
+      <Modal
+        visible={showMoveToGroupModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowMoveToGroupModal(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={() => setShowMoveToGroupModal(false)}
+        >
+          <TouchableOpacity activeOpacity={1} style={styles.modalContent} onPress={() => {}}>
+            <Text style={styles.modalTitle}>Move to Group</Text>
+            <TouchableOpacity
+              style={styles.moveGroupOption}
+              onPress={() => handleMoveSessionToGroup(undefined)}
+            >
+              <Text style={styles.moveGroupOptionText}>Ungrouped</Text>
+            </TouchableOpacity>
+            {groups.map((group) => (
+              <TouchableOpacity
+                key={group.id}
+                style={styles.moveGroupOption}
+                onPress={() => handleMoveSessionToGroup(group.id)}
+              >
+                <View style={[styles.groupDot, { backgroundColor: group.color || '#6b7280' }]} />
+                <Text style={styles.moveGroupOptionText}>{group.name}</Text>
+              </TouchableOpacity>
+            ))}
+            <TouchableOpacity
+              style={[styles.modalButtonCancel, { marginTop: spacing.md }]}
+              onPress={() => setShowMoveToGroupModal(false)}
+            >
+              <Text style={styles.modalButtonCancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
     </View>
   );
 }
@@ -260,6 +526,56 @@ function createStyles(theme: Theme) {
       color: theme.colors.destructive,
       fontSize: 14,
     },
+    // Group filter bar
+    groupFilterContainer: {
+      borderBottomWidth: theme.hairline,
+      borderBottomColor: theme.colors.border,
+    },
+    groupFilterScroll: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      gap: spacing.xs,
+    },
+    groupChip: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.sm + 2,
+      paddingVertical: spacing.xs + 1,
+      borderRadius: radius.lg,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      marginRight: spacing.xs,
+    },
+    groupChipActive: {
+      borderColor: theme.colors.primary,
+      backgroundColor: theme.colors.primary + '15',
+    },
+    groupChipText: {
+      fontSize: 12,
+      color: theme.colors.mutedForeground,
+      fontWeight: '500',
+    },
+    groupChipTextActive: {
+      color: theme.colors.primary,
+    },
+    groupDot: {
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      marginRight: 4,
+    },
+    createGroupBanner: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      borderBottomWidth: theme.hairline,
+      borderBottomColor: theme.colors.border,
+    },
+    createGroupBannerText: {
+      fontSize: 13,
+      color: theme.colors.primary,
+      textAlign: 'center',
+    },
+    // Session list
     list: {
       padding: spacing.md,
     },
@@ -304,6 +620,18 @@ function createStyles(theme: Theme) {
       ...theme.typography.caption,
       color: theme.colors.mutedForeground,
     },
+    groupBadge: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 6,
+      paddingVertical: 1,
+      borderRadius: 8,
+      marginRight: 6,
+    },
+    groupBadgeText: {
+      fontSize: 10,
+      fontWeight: '600',
+    },
     emptyState: {
       alignItems: 'center',
       padding: spacing.xl,
@@ -317,6 +645,81 @@ function createStyles(theme: Theme) {
       color: theme.colors.mutedForeground,
       textAlign: 'center',
     },
+    // Modals
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalContent: {
+      backgroundColor: theme.colors.card,
+      borderRadius: radius.xl,
+      padding: spacing.lg,
+      width: '85%',
+      maxWidth: 360,
+    },
+    modalTitle: {
+      ...theme.typography.h3,
+      marginBottom: spacing.md,
+    },
+    modalInput: {
+      ...theme.typography.body,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: radius.md,
+      padding: spacing.sm,
+      color: theme.colors.foreground,
+      marginBottom: spacing.md,
+    },
+    colorPicker: {
+      flexDirection: 'row',
+      gap: spacing.sm,
+      marginBottom: spacing.lg,
+    },
+    colorDot: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+    },
+    colorDotSelected: {
+      borderWidth: 3,
+      borderColor: theme.colors.foreground,
+    },
+    modalButtons: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      gap: spacing.sm,
+    },
+    modalButtonCancel: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+    },
+    modalButtonCancelText: {
+      color: theme.colors.mutedForeground,
+      fontWeight: '500',
+    },
+    modalButtonCreate: {
+      backgroundColor: theme.colors.primary,
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.sm,
+      borderRadius: radius.md,
+    },
+    modalButtonCreateText: {
+      color: theme.colors.primaryForeground,
+      fontWeight: '600',
+    },
+    moveGroupOption: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: spacing.sm + 2,
+      paddingHorizontal: spacing.sm,
+      borderBottomWidth: theme.hairline,
+      borderBottomColor: theme.colors.border,
+    },
+    moveGroupOptionText: {
+      ...theme.typography.body,
+      color: theme.colors.foreground,
+    },
   });
 }
-

--- a/apps/mobile/src/types/session.ts
+++ b/apps/mobile/src/types/session.ts
@@ -20,6 +20,8 @@ export interface Session {
   messages: ChatMessage[];
   /** Server-side conversation ID for continuing conversations on the SpeakMCP server */
   serverConversationId?: string;
+  /** ID of the group/channel this session belongs to */
+  groupId?: string;
   /** Optional metadata about the session */
   metadata?: {
     model?: string;
@@ -35,6 +37,8 @@ export interface SessionListItem {
   messageCount: number;
   lastMessage: string;
   preview: string;
+  /** ID of the group/channel this session belongs to */
+  groupId?: string;
 }
 
 /**
@@ -103,6 +107,7 @@ export function sessionToListItem(session: Session): SessionListItem {
     messageCount: session.messages.length,
     lastMessage: preview.substring(0, 100),
     preview: preview.substring(0, 200),
+    groupId: session.groupId,
   };
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -77,3 +77,16 @@ export interface MessageQueue {
   messages: QueuedMessage[];
 }
 
+/**
+ * Chat group / channel - used to organize conversations into logical groups.
+ * Shared between desktop and mobile apps.
+ */
+export interface ChatGroup {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  /** Optional color for visual distinction (hex string, e.g. "#3b82f6") */
+  color?: string;
+}
+


### PR DESCRIPTION
Add the ability to group chats into named, color-coded groups on both desktop and mobile platforms.

Shared:
- Add ChatGroup type to @speakmcp/shared

Desktop:
- Add groupId to Conversation and ConversationHistoryItem types
- Add group CRUD and assignment methods to ConversationService
- Add TIPC handlers for group management
- Add React Query hooks for groups
- Update sidebar with collapsible group sections, create/edit/delete group dialogs, and move-to-group dropdown on past sessions

Mobile:
- Add groupId to Session and SessionListItem types
- Add group management to sessions store (AsyncStorage persistence)
- Update SessionListScreen with group filter chips, create group modal, move-to-group modal via long-press, and group badges on sessions

https://claude.ai/code/session_01Um2KZCRkM8dMHr3QUSqmBZ