### PR TITLE
fix(mobile): prevent double words in streaming responses

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -898,7 +898,15 @@ export default function ChatScreen({ route, navigation }: any) {
           console.log('[ChatScreen] Request superseded within same session, skipping onToken update');
           return;
         }
-        streamingText += tok;
+        // Handle both delta tokens and full-text updates.
+        // Progress events with streamingContent.text send the full accumulated text,
+        // while SSE delta events send just the new token.
+        // Detect full-text updates to prevent double-words from compounding tokens.
+        if (tok.startsWith(streamingText) && tok.length >= streamingText.length) {
+          streamingText = tok;
+        } else {
+          streamingText += tok;
+        }
 
         setMessages((m) => {
           const copy = [...m];
@@ -1241,7 +1249,15 @@ export default function ChatScreen({ route, navigation }: any) {
       const onToken = (tok: string) => {
         if (sessionStore.currentSessionId !== requestSessionId) return;
         if (activeRequestIdRef.current !== thisRequestId) return;
-        streamingText += tok;
+        // Handle both delta tokens and full-text updates.
+        // Progress events with streamingContent.text send the full accumulated text,
+        // while SSE delta events send just the new token.
+        // Detect full-text updates to prevent double-words from compounding tokens.
+        if (tok.startsWith(streamingText) && tok.length >= streamingText.length) {
+          streamingText = tok;
+        } else {
+          streamingText += tok;
+        }
         setMessages((m) => {
           const copy = [...m];
           for (let i = copy.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Port fix from aj47/acp-remote (057d805) to handle both delta tokens and full-text updates in ChatScreen onToken handlers. Progress events send the full accumulated text via streamingContent.text, while SSE delta events send just the new token. Without this check, full-text updates get appended to the existing text causing doubled output like "testtest". The fix detects full-text updates (token starts with current streamingText) and replaces instead of appending.

Applied to both onToken handlers: the main sendMessage flow and the queued message processing flow.

https://claude.ai/code/session_011APeJ5jZM9tRbr6Vo1yLE7