### PR TITLE
fix: display follow-up messages immediately after session stop (#1029)

### DIFF
--- a/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
+++ b/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
@@ -4,7 +4,8 @@ import { Button } from "@renderer/components/ui/button"
 import { Send, Mic, OctagonX } from "lucide-react"
 import { useMutation } from "@tanstack/react-query"
 import { tipcClient } from "@renderer/lib/tipc-client"
-import { useConfigQuery } from "@renderer/lib/queries"
+import { queryClient, useConfigQuery } from "@renderer/lib/queries"
+import { useAgentStore } from "@renderer/stores"
 import { PredefinedPromptsMenu } from "./predefined-prompts-menu"
 
 interface TileFollowUpInputProps {
@@ -54,8 +55,18 @@ export function TileFollowUpInput({
         })
       }
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       setText("")
+      // Optimistically append user message to the session's conversation history
+      // so it appears immediately in the session tile without waiting for agent progress updates
+      if (sessionId) {
+        useAgentStore.getState().appendUserMessageToSession(sessionId, variables)
+      }
+      // Also invalidate React Query caches so other views (e.g., panel) stay in sync
+      if (conversationId) {
+        queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] })
+        queryClient.invalidateQueries({ queryKey: ["conversation-history"] })
+      }
       onMessageSent?.()
     },
   })


### PR DESCRIPTION
## Problem

When a user sends a follow-up message after stopping/killing a session, the message was not visible in the chat UI until the agent responded with its first progress update. This created a confusing gap where the user typed a message but couldn't see it.

**Root cause**: `TileFollowUpInput` and `OverlayFollowUpInput` called `createMcpTextInput` which saved the message to the database but didn't update the Zustand store (`agentProgressById`) that session tiles read from. The session tiles only display messages from `progress?.conversationHistory`, which only gets populated when `agentProgressUpdate` IPC events arrive from the main process.

Note: `panel.tsx` didn't have this bug because it calls `addMessage()` (which invalidates React Query) before calling `createMcpTextInput`.

## Solution

1. **Added `appendUserMessageToSession()` method** to the agent Zustand store — optimistically appends a user message to an existing session's `conversationHistory`
2. **Updated `TileFollowUpInput`** — after successful mutation, calls `appendUserMessageToSession` to immediately show the message in the session tile
3. **Updated `OverlayFollowUpInput`** — same pattern as above
4. **Added React Query invalidation** — invalidates `["conversation", conversationId]` and `["conversation-history"]` so other views (e.g., panel) stay in sync

When the actual `agentProgressUpdate` arrives from the main process, it merges with/overwrites the optimistic data — the user message is already there, so no duplication occurs.

## Files Changed

- `apps/desktop/src/renderer/src/stores/agent-store.ts` — new `appendUserMessageToSession` method
- `apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx` — optimistic update + query invalidation
- `apps/desktop/src/renderer/src/components/overlay-follow-up-input.tsx` — optimistic update + query invalidation

## Testing

- ✅ TypeScript typecheck passes (`pnpm --filter @speakmcp/desktop typecheck`)

Closes #1029

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author