### PR TITLE
fix: re-enable auto-updater using GitHub releases directly

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,40 +1,122 @@
+import electronUpdater, { UpdateInfo } from "electron-updater"
 import { MenuItem, dialog } from "electron"
+import { makePanelWindowClosable, WINDOWS } from "./window"
+import { getRendererHandlers } from "@egoist/tipc/main"
+import { RendererHandlers } from "./renderer-handlers"
 
-/**
- * Auto-updater is disabled - updates are manual via GitHub releases.
- * This prevents 403 errors from the invalid update server (electron-releases.umida.co).
- */
+electronUpdater.autoUpdater.fullChangelog = true
+electronUpdater.autoUpdater.autoDownload = false
+electronUpdater.autoUpdater.autoInstallOnAppQuit = true
+
+// No setFeedURL call — electron-updater reads the bundled app-update.yml
+// which has provider: github, owner: aj47, repo: SpeakMCP.
+// The old code pointed to electron-releases.umida.co which returned 403 errors.
+
+let updateInfo: UpdateInfo | null = null
+let downloadedUpdates: string[] | null = null
+let menuItem: MenuItem | null = null
+
+function enableMenuItem() {
+  if (menuItem) {
+    menuItem.enabled = true
+    menuItem = null
+  }
+}
 
 export function init() {
-  // Auto-updater is disabled - no initialization needed
-}
+  electronUpdater.autoUpdater.addListener("update-downloaded", (e) => {
+    const window = WINDOWS.get("main")
+    if (window) {
+      getRendererHandlers<RendererHandlers>(
+        window.webContents,
+      ).updateAvailable.send(e)
+    }
+  })
 
-export function getUpdateInfo() {
-  return null
-}
+  electronUpdater.autoUpdater.addListener("update-not-available", () => {
+    updateInfo = null
+    enableMenuItem()
+  })
 
-export async function checkForUpdatesMenuItem(_menuItem: MenuItem) {
-  // Auto-updater is disabled - show message directing to GitHub releases
-  await dialog.showMessageBox({
-    title: "Check for Updates",
-    message: `To check for updates, please visit:\nhttps://github.com/aj47/SpeakMCP/releases`,
+  electronUpdater.autoUpdater.addListener("error", (err) => {
+    console.error("[updater] Auto-update error:", err?.message || err)
+    enableMenuItem()
+  })
+
+  let hasSetDownloading = false
+  electronUpdater.autoUpdater.addListener("download-progress", (_info) => {
+    if (!hasSetDownloading) {
+      hasSetDownloading = true
+    }
   })
 }
 
+export function getUpdateInfo() {
+  return updateInfo
+}
+
+export async function checkForUpdatesMenuItem(_menuItem: MenuItem) {
+  menuItem = _menuItem
+  menuItem.enabled = false
+
+  const checkResult = await checkForUpdatesAndDownload().catch(() => null)
+
+  if (checkResult && checkResult.updateInfo) {
+    // Update found — menu item stays disabled, UI will show update button
+  } else {
+    await dialog.showMessageBox({
+      title: "No updates available",
+      message: `You are already using the latest version of ${process.env.PRODUCT_NAME}.`,
+    })
+  }
+}
+
 export async function checkForUpdatesAndDownload() {
-  // Auto-updater is disabled - always return null
-  return { updateInfo: null, downloadedUpdates: null }
+  if (updateInfo && downloadedUpdates) return { downloadedUpdates, updateInfo }
+  if (updateInfo) return { updateInfo, downloadedUpdates }
+
+  const updates = await electronUpdater.autoUpdater.checkForUpdates()
+
+  if (
+    updates &&
+    electronUpdater.autoUpdater.currentVersion.compare(
+      updates.updateInfo.version,
+    ) === -1
+  ) {
+    updateInfo = updates.updateInfo
+    downloadedUpdates = await downloadUpdate()
+    return { updateInfo, downloadedUpdates }
+  }
+
+  updateInfo = null
+  downloadedUpdates = null
+  return { updateInfo, downloadedUpdates }
 }
 
 export function quitAndInstall() {
-  // No-op - auto-updater is disabled
+  makePanelWindowClosable()
+  setTimeout(() => {
+    electronUpdater.autoUpdater.quitAndInstall()
+  })
 }
 
+let cancellationToken: electronUpdater.CancellationToken | null = null
+
 export async function downloadUpdate() {
-  // No-op - auto-updater is disabled
-  return null
+  if (cancellationToken) {
+    return null
+  }
+
+  cancellationToken = new electronUpdater.CancellationToken()
+  const result =
+    await electronUpdater.autoUpdater.downloadUpdate(cancellationToken)
+  cancellationToken = null
+  return result
 }
 
 export function cancelDownloadUpdate() {
-  // No-op - auto-updater is disabled
+  if (cancellationToken) {
+    cancellationToken.cancel()
+    cancellationToken = null
+  }
 }


### PR DESCRIPTION
## Summary

Re-enables the auto-updater that was disabled in commit `ae2992f86` (Dec 28, 2025) because the custom update server (`electron-releases.umida.co`) started returning 403 errors.

## Changes

### `apps/desktop/src/main/updater.ts`
- Restored full `electron-updater` functionality (was replaced with no-op stubs)
- **Removed** the broken `setFeedURL` call pointing to `electron-releases.umida.co`
- electron-updater now uses the bundled `app-update.yml` which already has the correct GitHub provider config (`owner: aj47, repo: SpeakMCP`)
- Added `error` event listener so update failures get logged instead of silently failing

### GitHub Release (already done)
- Uploaded `latest-mac.yml` to the [v1.3.0 release](https://github.com/aj47/SpeakMCP/releases/tag/v1.3.0) with sha512 hashes for both arm64 and x64 DMGs

## How it works
1. `electron-updater` reads the bundled `app-update.yml` (generated at build time by electron-builder) to know where to check for updates
2. It fetches `latest-mac.yml` from the latest GitHub release to compare versions
3. If a newer version exists, it downloads the DMG and notifies the renderer
4. The `<Updater/>` component shows a green "Restart to update" button
5. Future releases via `electron-builder --publish always` will auto-generate `latest-mac.yml`

## Note
No IPC plumbing changes needed — `tipc.ts` handlers (`checkForUpdatesAndDownload`, `quitAndInstall`, `getUpdateInfo`) and the renderer `<Updater/>` component were already wired up and just needed the backend functions to be real again.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author