### PR TITLE
fix(mobile): live transcript preview + edit before send (#1026)

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -728,8 +728,10 @@ export default function ChatScreen({ route, navigation }: any) {
 		if (a === b) return a;
 		if (b.startsWith(a)) return b;
 		if (a.startsWith(b)) return a;
-		if (a.includes(b)) return a;
-		if (b.includes(a)) return b;
+		const bWordBoundary = new RegExp(`(?:^|\\s)${b.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\s|$)`);
+		if (bWordBoundary.test(a)) return a;
+		const aWordBoundary = new RegExp(`(?:^|\\s)${a.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\\s|$)`);
+		if (aWordBoundary.test(b)) return b;
 		const aWords = a.split(' ');
 		const bWords = b.split(' ');
 		const maxOverlap = Math.min(aWords.length, bWords.length);


### PR DESCRIPTION
Fixes #1026

### What changed
- Show a continuous live STT preview during recording by merging interim + final transcript text
- Make the preview overlay reliably visible (layering) and not truncated
- Add an **edit-before-send** toggle (✏️) for push-to-talk: releasing the mic appends the transcript into the input and focuses it instead of auto-sending

### Verification
- `pnpm --filter @speakmcp/mobile exec tsc --noEmit`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author