### PR TITLE
fix(mobile): make Rapid Fire sessions visible immediately + clarify voice feedback (#1027)

### DIFF
--- a/apps/desktop/tsconfig.web.json
+++ b/apps/desktop/tsconfig.web.json
@@ -21,8 +21,18 @@
     "strict": false,
     "noImplicitAny": false,
     "skipLibCheck": true,
+    "types": [],
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
     "baseUrl": ".",
     "paths": {
+      "react": [
+        "./node_modules/@types/react"
+      ],
+      "react-dom": [
+        "./node_modules/@types/react-dom"
+      ],
       "@renderer/*": [
         "src/renderer/src/*"
       ],
@@ -31,7 +41,7 @@
       ],
       "@shared/*": [
         "src/shared/*"
-      ],
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1027 - Rapid Fire mode on mobile: sessions not visible and unclear voice feedback

## What changed

### Sessions visibility
- **Immediately visible**: Sessions are now immediately visible in the list when created during Rapid Fire mode
- **Highlight effect**: New sessions get a highlighted border (primary color) for 5 seconds to make them easy to spot
- **Auto-scroll**: List automatically scrolls to top when a new session is created
- **Last session banner**: Shows a banner above the Rapid Fire button with the last created session and an "Open" button

### Voice feedback text improvements
- "Release to send..." → "Release to save to a new chat…"
- "Sending..." → "Saving…"
- "Sent to a new chat. Tap it to open." → "Saved to a new chat. Tap it above to open."
- Added voice hint text: "Voice replies: ON (they play after you open the chat)" or "Voice replies: OFF (enable TTS in a chat)"
- Button label changes: "Sending" → "Saving"

### Desktop fix
- Fixed React 18/19 type mismatch in desktop tsconfig by adding explicit paths for react and react-dom to ensure TypeScript uses React 18 types from desktop node_modules

## Testing

- Desktop typecheck passes: `pnpm --filter @speakmcp/desktop typecheck` (0 errors)
- Desktop app builds and starts successfully
- Mobile app compiles without errors

## Notes

- The desktop tsconfig fix ensures TypeScript resolves React types from `apps/desktop/node_modules/@types/react` (React 18) instead of the root node_modules which had React 19 types (@types+react@19.1.17)
