### PR TITLE
feat(agent): add explicit speak_to_user spoken-content path

### DIFF
--- a/apps/desktop/src/main/builtin-tool-definitions.ts
+++ b/apps/desktop/src/main/builtin-tool-definitions.ts
@@ -209,6 +209,22 @@ export const builtinToolDefinitions: BuiltinToolDefinition[] = [
     },
   },
   {
+    name: `${BUILTIN_SERVER_NAME}:speak_to_user`,
+    description:
+      "Speak directly to the user via text-to-speech. Use this when you want the user to hear content aloud. Regular assistant text is not guaranteed to be spoken; this tool explicitly sets spoken output.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: {
+          type: "string",
+          description:
+            "The exact text to speak aloud to the user. Write naturally as speech, without markdown or code formatting.",
+        },
+      },
+      required: ["text"],
+    },
+  },
+  {
     name: `${BUILTIN_SERVER_NAME}:mark_work_complete`,
     description: "Signal explicit completion for the current task. Call this only when all requested work is actually finished and ready for final delivery.",
     inputSchema: {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -31,8 +31,12 @@ import {
   type SummarizationInput,
 } from "./summarization-service"
 import { memoryService } from "./memory-service"
+import { clearSessionSpokenContent, getSessionSpokenContent } from "./session-spoken-content-store"
 
 const MARK_WORK_COMPLETE_TOOL = "speakmcp-settings:mark_work_complete"
+const SPEAK_TO_USER_TOOL = "speakmcp-settings:speak_to_user"
+const INTERNAL_COMPLETION_NUDGE_TEXT =
+  `If all requested work is complete, use ${SPEAK_TO_USER_TOOL} to tell the user the result, then call ${MARK_WORK_COMPLETE_TOOL} with a concise summary. Otherwise continue working and call more tools.`
 
 /**
  * Clean error message by removing stack traces and noise
@@ -390,6 +394,8 @@ export async function processTranscriptWithAgentMode(
   const currentConversationId = conversationId
   const currentSessionId =
     sessionId || `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+  // Clear any stale spoken content from prior runs that may have reused this session ID.
+  clearSessionSpokenContent(currentSessionId)
   // Number of messages in the conversation history that predate this agent session.
   // Used by the UI to show only this session's messages while still saving full history.
   // When continuing a conversation, we set this to 0 so the UI shows the full history.
@@ -463,9 +469,24 @@ export async function processTranscriptWithAgentMode(
     const session = agentSessionTracker.getSession(currentSessionId)
     const conversationTitle = session?.conversationTitle
     const profileName = session?.profileSnapshot?.profileName
+    const storedSpokenContent = getSessionSpokenContent(currentSessionId)
+    const normalizedStoredSpokenContent =
+      typeof storedSpokenContent === "string" && storedSpokenContent.trim().length > 0
+        ? storedSpokenContent
+        : undefined
+    const isKillSwitchCompletion =
+      update.isComplete &&
+      typeof update.finalContent === "string" &&
+      update.finalContent.includes("emergency kill switch")
+    const spokenContentForUpdate =
+      update.spokenContent ??
+      (update.isComplete && !isKillSwitchCompletion
+        ? normalizedStoredSpokenContent
+        : undefined)
 
     const fullUpdate: AgentProgressUpdate = {
       ...update,
+      spokenContent: spokenContentForUpdate,
       sessionId: currentSessionId,
       conversationId: currentConversationId,
       conversationTitle,
@@ -801,17 +822,23 @@ export async function processTranscriptWithAgentMode(
   const formatConversationForProgress = (
     history: typeof conversationHistory,
   ) => {
-    const isNudge = (content: string) =>
-      content.includes("Please either take action using available tools") ||
-      content.includes("You have relevant tools available for this request") ||
-      content.includes("Your previous response was empty") ||
-      content.includes("Verifier indicates the task is not complete") ||
-      content.includes("Please respond with a valid JSON object") ||
-      content.includes("Use available tools directly via native function-calling") ||
-      content.includes("Provide a complete final answer") ||
-      content.includes("Your last response was not a final deliverable") ||
-      content.includes("Your last response was empty or non-deliverable") ||
-      content.includes("Continue and finish remaining work")
+    const isNudge = (content: string) => {
+      const trimmed = content.trim()
+      if (trimmed === INTERNAL_COMPLETION_NUDGE_TEXT) return true
+
+      return (
+        content.includes("Please either take action using available tools") ||
+        content.includes("You have relevant tools available for this request") ||
+        content.includes("Your previous response was empty") ||
+        content.includes("Verifier indicates the task is not complete") ||
+        content.includes("Please respond with a valid JSON object") ||
+        content.includes("Use available tools directly via native function-calling") ||
+        content.includes("Provide a complete final answer") ||
+        content.includes("Your last response was not a final deliverable") ||
+        content.includes("Your last response was empty or non-deliverable") ||
+        content.includes("Continue and finish remaining work")
+      )
+    }
 
     return history
       .filter((entry) => !(entry.role === "user" && isNudge(entry.content)))
@@ -1794,7 +1821,7 @@ Return ONLY JSON per schema.`,
             }
             addMessage(
               "user",
-              `If all requested work is complete, call ${MARK_WORK_COMPLETE_TOOL} with a concise summary and then provide the final answer. Otherwise continue working and call more tools.`,
+              INTERNAL_COMPLETION_NUDGE_TEXT,
             )
             completionSignalHintCount++
             // Do NOT reset noOpCount here. Substantive text without tool calls or explicit
@@ -2818,6 +2845,7 @@ Return ONLY JSON per schema.`,
     }
 
     // Clean up session state at the end of agent processing
+    clearSessionSpokenContent(currentSessionId)
     agentSessionStateManager.cleanupSession(currentSessionId)
   }
 }

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -2653,7 +2653,7 @@ export class MCPService {
 
         // Check if it's a built-in tool
         if (isBuiltinTool(matchingTool.name)) {
-          const result = await executeBuiltinTool(matchingTool.name, toolCall.arguments || {})
+          const result = await executeBuiltinTool(matchingTool.name, toolCall.arguments || {}, sessionId)
           if (result) {
             return endSpanAndReturn(result)
           }

--- a/apps/desktop/src/main/session-spoken-content-store.ts
+++ b/apps/desktop/src/main/session-spoken-content-store.ts
@@ -1,0 +1,13 @@
+const sessionSpokenContent = new Map<string, string>()
+
+export function setSessionSpokenContent(sessionId: string, text: string): void {
+  sessionSpokenContent.set(sessionId, text)
+}
+
+export function getSessionSpokenContent(sessionId: string): string | undefined {
+  return sessionSpokenContent.get(sessionId)
+}
+
+export function clearSessionSpokenContent(sessionId: string): void {
+  sessionSpokenContent.delete(sessionId)
+}

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -70,8 +70,15 @@ export const AGENT_MODE_ADDITIONS = `
 
 AGENT MODE: You can see tool results and make follow-up tool calls. Continue calling tools until the task is completely resolved. If a tool fails, try alternative approaches before giving up.
 
+RESPONDING TO USER:
+- Use speakmcp-settings:speak_to_user whenever you want the user to hear your response aloud
+- Write speak_to_user text naturally as speech (no markdown, code blocks, or formatting)
+- If speak_to_user is unavailable, provide your final user-facing answer in normal assistant text
+
 COMPLETION SIGNAL:
-- When all requested work is fully complete and speakmcp-settings:mark_work_complete is available, call it with a concise summary
+- When all requested work is fully complete:
+  - If speakmcp-settings:speak_to_user is available, call it with the final user-facing response first
+  - Then call speakmcp-settings:mark_work_complete with a concise completion summary (if available)
 - If mark_work_complete is not available, provide a complete final user-facing answer directly
 - Do not call mark_work_complete while work is still in progress or partially done
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -103,6 +103,7 @@ const CompactMessage: React.FC<{
     toolResults?: Array<{ success: boolean; content: string; error?: string }>
     timestamp: number
   }
+  ttsText?: string
   isLast: boolean
   isComplete: boolean
   hasErrors: boolean
@@ -111,7 +112,7 @@ const CompactMessage: React.FC<{
   onToggleExpand: () => void
   /** Variant controls TTS auto-play - only 'overlay' variant auto-plays TTS to prevent double playback */
   variant?: "default" | "overlay" | "tile"
-}> = ({ message, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default" }) => {
+}> = ({ message, ttsText, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default" }) => {
   const [audioData, setAudioData] = useState<ArrayBuffer | null>(null)
   const [isGeneratingAudio, setIsGeneratingAudio] = useState(false)
   const [ttsError, setTtsError] = useState<string | null>(null)
@@ -165,7 +166,7 @@ const CompactMessage: React.FC<{
 
     try {
       const result = await tipcClient.generateSpeech({
-        text: message.content,
+        text: ttsText || message.content,
       })
       setAudioData(result.audio)
       return result.audio
@@ -370,7 +371,7 @@ const CompactMessage: React.FC<{
             <div className="mt-2">
               <AudioPlayer
                 audioData={audioData || undefined}
-                text={message.content}
+                text={ttsText || message.content}
                 onGenerateAudio={generateAudio}
                 isGenerating={isGeneratingAudio}
                 error={ttsError}
@@ -2354,6 +2355,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                           <CompactMessage
                             key={itemKey}
                             message={item.data}
+                            ttsText={isLastAssistant ? progress.spokenContent : undefined}
                             isLast={isLastAssistant}
                             isComplete={isComplete}
                             hasErrors={hasErrors}
@@ -2704,11 +2706,13 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                   : isFinalAssistantMessage // Only final assistant message expanded by default
 
                 if (item.kind === "message") {
+                  const isLastAssistant = index === lastAssistantDisplayIndex
                   return (
                     <CompactMessage
                       key={itemKey}
                       message={item.data}
-                      isLast={index === lastAssistantDisplayIndex}
+                      ttsText={isLastAssistant ? progress.spokenContent : undefined}
+                      isLast={isLastAssistant}
                       isComplete={isComplete}
                       hasErrors={hasErrors}
                       wasStopped={wasStopped}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -206,6 +206,7 @@ export interface AgentProgressUpdate {
   isComplete: boolean
   isSnoozed?: boolean
   finalContent?: string
+  spokenContent?: string
   conversationHistory?: Array<{
     role: "user" | "assistant" | "tool"
     content: string

--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -47,6 +47,7 @@ export interface AgentProgressUpdate {
   steps: AgentProgressStep[];
   isComplete: boolean;
   finalContent?: string;
+  spokenContent?: string;
   conversationHistory?: ConversationHistoryMessage[];
   streamingContent?: {
     text: string;
@@ -951,4 +952,3 @@ export class OpenAIClient {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- add a new builtin tool `speakmcp-settings:speak_to_user` so the agent can explicitly control spoken TTS output
- add session-scoped spoken-content storage (`session-spoken-content-store.ts`) and pass `sessionId` to built-in tool handlers
- extend `AgentProgressUpdate` with optional `spokenContent` and auto-populate it on final completion updates in `llm.ts`
- update completion nudges + system prompt guidance so the intended flow is `speak_to_user` then `mark_work_complete`
- update renderer TTS generation in `agent-progress.tsx` to prefer `progress.spokenContent` for the final assistant message while keeping displayed `finalContent` unchanged
- keep backward compatibility: if `speak_to_user` is never called, existing TTS behavior is preserved

## Key Files
- `apps/desktop/src/main/builtin-tool-definitions.ts`
- `apps/desktop/src/main/builtin-tools.ts`
- `apps/desktop/src/main/session-spoken-content-store.ts`
- `apps/desktop/src/main/llm.ts`
- `apps/desktop/src/main/mcp-service.ts`
- `apps/desktop/src/main/system-prompts.ts`
- `apps/desktop/src/renderer/src/components/agent-progress.tsx`
- `apps/desktop/src/shared/types.ts`
- `apps/mobile/src/lib/openaiClient.ts`

## Validation
- `pnpm build:shared`
- `pnpm --filter @speakmcp/desktop typecheck:node`
- `pnpm --filter @speakmcp/desktop typecheck:web`
- `pnpm --filter @speakmcp/desktop exec vitest run src/main/llm-fetch.test.ts src/main/tts-preprocessing.test.ts`