### PR TITLE
feat: hide internal completion nudge via ephemeral message system

### DIFF
--- a/apps/desktop/src/main/builtin-tool-definitions.ts
+++ b/apps/desktop/src/main/builtin-tool-definitions.ts
@@ -9,7 +9,11 @@
  * import from services that might also need access to these definitions.
  */
 
+import { BUILTIN_SERVER_NAME } from '../shared/builtin-tool-names'
 import { acpRouterToolDefinitions } from './acp/acp-router-tool-definitions'
+
+// Re-export for backward compatibility (single source of truth in @shared/builtin-tool-names)
+export { BUILTIN_SERVER_NAME }
 
 // Define a local type to avoid importing from mcp-service
 export interface BuiltinToolDefinition {
@@ -21,9 +25,6 @@ export interface BuiltinToolDefinition {
     required: string[]
   }
 }
-
-// The virtual server name for built-in tools
-export const BUILTIN_SERVER_NAME = "speakmcp-settings"
 
 // Tool definitions
 export const builtinToolDefinitions: BuiltinToolDefinition[] = [

--- a/apps/desktop/src/main/conversation-history-utils.test.ts
+++ b/apps/desktop/src/main/conversation-history-utils.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect } from "vitest"
+import {
+  filterEphemeralMessages,
+  isEphemeralMessage,
+  type ConversationMessage,
+} from "./conversation-history-utils"
+
+describe("conversation-history-utils", () => {
+  describe("filterEphemeralMessages", () => {
+    it("should remove ephemeral messages from history", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Hello",
+          timestamp: 1000,
+        },
+        {
+          role: "assistant",
+          content: "Hi there",
+          timestamp: 2000,
+        },
+        {
+          role: "user",
+          content: "Internal nudge",
+          timestamp: 3000,
+          ephemeral: true,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(2)
+      expect(filtered[0].content).toBe("Hello")
+      expect(filtered[1].content).toBe("Hi there")
+    })
+
+    it("should strip ephemeral field from returned messages", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Test",
+          timestamp: 1000,
+          ephemeral: false,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(1)
+      expect("ephemeral" in filtered[0]).toBe(false)
+    })
+
+    it("should preserve all non-ephemeral messages", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Message 1",
+          timestamp: 1000,
+        },
+        {
+          role: "assistant",
+          content: "Response 1",
+          timestamp: 2000,
+        },
+        {
+          role: "tool",
+          content: "Tool result",
+          timestamp: 3000,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(3)
+      expect(filtered.map((m) => m.content)).toEqual([
+        "Message 1",
+        "Response 1",
+        "Tool result",
+      ])
+    })
+
+    it("should preserve toolCalls and toolResults", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "assistant",
+          content: "Calling tool",
+          timestamp: 1000,
+          toolCalls: [
+            {
+              name: "test_tool",
+              arguments: { arg: "value" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: "Tool output",
+          timestamp: 2000,
+          toolResults: [
+            {
+              success: true,
+              content: "Result",
+            },
+          ],
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(2)
+      expect(filtered[0].toolCalls).toEqual([
+        {
+          name: "test_tool",
+          arguments: { arg: "value" },
+        },
+      ])
+      expect(filtered[1].toolResults).toEqual([
+        {
+          success: true,
+          content: "Result",
+        },
+      ])
+    })
+
+    it("should handle empty history", () => {
+      const history: ConversationMessage[] = []
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(0)
+    })
+
+    it("should handle history with only ephemeral messages", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Ephemeral 1",
+          timestamp: 1000,
+          ephemeral: true,
+        },
+        {
+          role: "user",
+          content: "Ephemeral 2",
+          timestamp: 2000,
+          ephemeral: true,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(0)
+    })
+
+    it("should handle mixed ephemeral and non-ephemeral messages", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Real message 1",
+          timestamp: 1000,
+        },
+        {
+          role: "user",
+          content: "Ephemeral nudge",
+          timestamp: 2000,
+          ephemeral: true,
+        },
+        {
+          role: "assistant",
+          content: "Response",
+          timestamp: 3000,
+        },
+        {
+          role: "user",
+          content: "Another ephemeral",
+          timestamp: 4000,
+          ephemeral: true,
+        },
+        {
+          role: "user",
+          content: "Real message 2",
+          timestamp: 5000,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(3)
+      expect(filtered.map((m) => m.content)).toEqual([
+        "Real message 1",
+        "Response",
+        "Real message 2",
+      ])
+    })
+
+    it("should preserve message order", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "First",
+          timestamp: 1000,
+        },
+        {
+          role: "user",
+          content: "Ephemeral",
+          timestamp: 2000,
+          ephemeral: true,
+        },
+        {
+          role: "user",
+          content: "Second",
+          timestamp: 3000,
+        },
+        {
+          role: "user",
+          content: "Another ephemeral",
+          timestamp: 4000,
+          ephemeral: true,
+        },
+        {
+          role: "user",
+          content: "Third",
+          timestamp: 5000,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered.map((m) => m.content)).toEqual(["First", "Second", "Third"])
+    })
+
+    it("should handle messages with undefined ephemeral field", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Message without ephemeral field",
+          timestamp: 1000,
+        },
+        {
+          role: "user",
+          content: "Message with ephemeral false",
+          timestamp: 2000,
+          ephemeral: false,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(2)
+    })
+
+    it("should handle complex toolResults structures", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "tool",
+          content: "Complex result",
+          timestamp: 1000,
+          toolResults: [
+            {
+              success: true,
+              content: [
+                {
+                  type: "text",
+                  text: "Result text",
+                },
+              ],
+            },
+          ],
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(1)
+      expect(filtered[0].toolResults).toEqual([
+        {
+          success: true,
+          content: [
+            {
+              type: "text",
+              text: "Result text",
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe("isEphemeralMessage", () => {
+    it("should return true for ephemeral messages", () => {
+      const msg: ConversationMessage = {
+        role: "user",
+        content: "Ephemeral",
+        ephemeral: true,
+      }
+
+      expect(isEphemeralMessage(msg)).toBe(true)
+    })
+
+    it("should return false for non-ephemeral messages", () => {
+      const msg: ConversationMessage = {
+        role: "user",
+        content: "Regular",
+      }
+
+      expect(isEphemeralMessage(msg)).toBe(false)
+    })
+
+    it("should return false for messages with ephemeral: false", () => {
+      const msg: ConversationMessage = {
+        role: "user",
+        content: "Regular",
+        ephemeral: false,
+      }
+
+      expect(isEphemeralMessage(msg)).toBe(false)
+    })
+
+    it("should return false for messages with undefined ephemeral", () => {
+      const msg: ConversationMessage = {
+        role: "user",
+        content: "Regular",
+        ephemeral: undefined,
+      }
+
+      expect(isEphemeralMessage(msg)).toBe(false)
+    })
+  })
+
+  describe("integration scenarios", () => {
+    it("should handle internal completion nudge scenario", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Please complete this task",
+          timestamp: 1000,
+        },
+        {
+          role: "assistant",
+          content: "I'll help with that",
+          timestamp: 2000,
+        },
+        {
+          role: "user",
+          content:
+            "If all requested work is complete, use speakmcp-settings:respond_to_user to tell the user the result, then call speakmcp-settings:mark_work_complete with a concise summary. Otherwise continue working and call more tools.",
+          timestamp: 3000,
+          ephemeral: true,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(2)
+      expect(filtered.every((m) => !("ephemeral" in m))).toBe(true)
+    })
+
+    it("should handle multiple ephemeral nudges in sequence", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "user",
+          content: "Task 1",
+          timestamp: 1000,
+        },
+        {
+          role: "user",
+          content: "Nudge 1",
+          timestamp: 2000,
+          ephemeral: true,
+        },
+        {
+          role: "assistant",
+          content: "Working on it",
+          timestamp: 3000,
+        },
+        {
+          role: "user",
+          content: "Nudge 2",
+          timestamp: 4000,
+          ephemeral: true,
+        },
+        {
+          role: "assistant",
+          content: "Done",
+          timestamp: 5000,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(3)
+      expect(filtered.map((m) => m.content)).toEqual([
+        "Task 1",
+        "Working on it",
+        "Done",
+      ])
+    })
+
+    it("should preserve all metadata except ephemeral flag", () => {
+      const history: ConversationMessage[] = [
+        {
+          role: "assistant",
+          content: "Response with metadata",
+          timestamp: 1000,
+          toolCalls: [
+            {
+              name: "tool1",
+              arguments: { key: "value" },
+            },
+          ],
+          toolResults: [
+            {
+              success: true,
+              content: "Success",
+            },
+          ],
+          ephemeral: false,
+        },
+      ]
+
+      const filtered = filterEphemeralMessages(history)
+
+      expect(filtered).toHaveLength(1)
+      const msg = filtered[0]
+      expect(msg.role).toBe("assistant")
+      expect(msg.content).toBe("Response with metadata")
+      expect(msg.timestamp).toBe(1000)
+      expect(msg.toolCalls).toBeDefined()
+      expect(msg.toolResults).toBeDefined()
+      expect("ephemeral" in msg).toBe(false)
+    })
+  })
+})

--- a/apps/desktop/src/main/conversation-history-utils.ts
+++ b/apps/desktop/src/main/conversation-history-utils.ts
@@ -1,0 +1,46 @@
+/**
+ * Utility functions for filtering and processing conversation history.
+ * Dependency-light module for handling ephemeral messages.
+ */
+
+/**
+ * Message type with optional ephemeral flag for internal nudges.
+ * Ephemeral messages are included in LLM context but excluded from:
+ * - Persisted conversation history
+ * - Progress UI display
+ * - Returned conversation history
+ */
+export interface ConversationMessage {
+  role: "user" | "assistant" | "tool"
+  content: string
+  toolCalls?: unknown[]
+  toolResults?: unknown[]
+  timestamp?: number
+  ephemeral?: boolean
+}
+
+type WithEphemeralFlag = { ephemeral?: boolean }
+
+/**
+ * Filter out ephemeral messages from conversation history.
+ * Returns a new array without the ephemeral flag exposed.
+ */
+export function filterEphemeralMessages<T extends WithEphemeralFlag>(
+  history: T[],
+): Array<Omit<T, "ephemeral">> {
+  return history
+    .filter((msg) => !msg.ephemeral)
+    .map((msg) => {
+      const { ephemeral: _ephemeral, ...rest } = msg
+      return rest as Omit<T, "ephemeral">
+    })
+}
+
+/**
+ * Check if a message is ephemeral.
+ */
+export function isEphemeralMessage<T extends WithEphemeralFlag>(
+  msg: T,
+): msg is T & { ephemeral: true } {
+  return msg.ephemeral === true
+}

--- a/apps/desktop/src/shared/builtin-tool-names.ts
+++ b/apps/desktop/src/shared/builtin-tool-names.ts
@@ -1,0 +1,13 @@
+// Dependency-free constants for built-in tool names that may be referenced by both
+// main and renderer code.
+
+// The virtual server name for built-in tools (single source of truth; imported by main + renderer)
+export const BUILTIN_SERVER_NAME = "speakmcp-settings"
+
+export const RESPOND_TO_USER_TOOL = `${BUILTIN_SERVER_NAME}:respond_to_user`
+export const MARK_WORK_COMPLETE_TOOL = `${BUILTIN_SERVER_NAME}:mark_work_complete`
+
+// Internal completion nudge message: include in the LLM context, but hide from the progress UI.
+// Keep this as a single canonical string so we can filter it via exact match (no false positives).
+export const INTERNAL_COMPLETION_NUDGE_TEXT =
+  `If all requested work is complete, use ${RESPOND_TO_USER_TOOL} to tell the user the result, then call ${MARK_WORK_COMPLETE_TOOL} with a concise summary. Otherwise continue working and call more tools.`


### PR DESCRIPTION
Implements PR #1072 changes rebased on current main:

- Add ephemeral flag to conversationHistory entries in llm.ts so internal completion nudges are fed to the LLM but never persisted to disk
- Add addEphemeralMessage() helper for in-memory-only messages
- Filter ephemeral messages in formatConversationForProgress and in the returned conversationHistory (via filterEphemeralMessages utility)
- Move BUILTIN_SERVER_NAME, MARK_WORK_COMPLETE_TOOL, RESPOND_TO_USER_TOOL, and INTERNAL_COMPLETION_NUDGE_TEXT to shared/builtin-tool-names.ts so both main and renderer can reference the canonical nudge text
- Update agent-progress.tsx renderer fallback to exact-match the nudge text (avoiding false-positive filtering of legitimate user messages)
- Add conversation-history-utils.ts with filterEphemeralMessages utility and full vitest coverage

https://claude.ai/code/session_011FnJcDgnHhMZJMQHCRNrdZ