### PR TITLE
fix: align search icons and standardize icon-text spacing across UI

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-summary-view.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-summary-view.tsx
@@ -136,7 +136,7 @@ function SummaryCard({
           variant={isSaved ? "ghost" : "outline"}
           size="sm"
           className={cn(
-            "shrink-0",
+            "shrink-0 gap-2",
             isSaved && "text-green-600 dark:text-green-400"
           )}
           onClick={(e) => {
@@ -149,12 +149,12 @@ function SummaryCard({
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : isSaved ? (
             <>
-              <CheckCircle className="h-4 w-4 mr-1" />
+              <CheckCircle className="h-4 w-4" />
               Saved
             </>
           ) : (
             <>
-              <Save className="h-4 w-4 mr-1" />
+              <Save className="h-4 w-4" />
               Save
             </>
           )}

--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.tsx
@@ -376,10 +376,10 @@ function ServerDialog({ server, onSave, onCancel, onImportFromFile, onImportFrom
             <Button
               variant={activeTab === 'file' ? 'default' : 'outline'}
               onClick={() => setActiveTab('file')}
-              className="flex-1"
+              className="flex-1 gap-1"
               size="sm"
             >
-              <Upload className="mr-1 h-3 w-3" />
+              <Upload className="h-3 w-3" />
               From File
             </Button>
           )}
@@ -387,10 +387,10 @@ function ServerDialog({ server, onSave, onCancel, onImportFromFile, onImportFrom
             <Button
               variant={activeTab === 'paste' ? 'default' : 'outline'}
               onClick={() => setActiveTab('paste')}
-              className="flex-1"
+              className="flex-1 gap-1"
               size="sm"
             >
-              <FileText className="mr-1 h-3 w-3" />
+              <FileText className="h-3 w-3" />
               Paste JSON
             </Button>
           )}
@@ -693,11 +693,11 @@ function ServerDialog({ server, onSave, onCancel, onImportFromFile, onImportFrom
                 }
               }}
               disabled={isValidatingJson || !jsonInputText.trim()}
-              className="w-full"
+              className="w-full gap-2"
             >
               {isValidatingJson ? (
                 <>
-                  <Spinner className="mr-2 h-4 w-4" />
+                  <Spinner className="h-4 w-4" />
                   Validating...
                 </>
               ) : (
@@ -1947,24 +1947,24 @@ export function MCPConfigManager({
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
               <div className="flex flex-1 items-center gap-3">
                 <div className="relative flex-1 max-w-sm">
-                  <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     placeholder="Search tools..."
                     value={toolSearchQuery}
                     onChange={(e) => setToolSearchQuery(e.target.value)}
-                    className="pl-8 h-9"
+                    className="pl-9"
                   />
                 </div>
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={() => setShowDisabledTools(!showDisabledTools)}
-                  className="shrink-0"
+                  className="shrink-0 gap-2"
                 >
                   {showDisabledTools ? (
-                    <EyeOff className="mr-2 h-4 w-4" />
+                    <EyeOff className="h-4 w-4" />
                   ) : (
-                    <Eye className="mr-2 h-4 w-4" />
+                    <Eye className="h-4 w-4" />
                   )}
                   {showDisabledTools ? "Hide Disabled" : "Show All"}
                 </Button>
@@ -1974,18 +1974,18 @@ export function MCPConfigManager({
                   variant="outline"
                   size="sm"
                   onClick={() => handleToggleAllTools(true)}
-                  className="shrink-0"
+                  className="shrink-0 gap-1"
                 >
-                  <Power className="mr-1 h-3 w-3" />
+                  <Power className="h-3 w-3" />
                   All ON
                 </Button>
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={() => handleToggleAllTools(false)}
-                  className="shrink-0"
+                  className="shrink-0 gap-1"
                 >
-                  <PowerOff className="mr-1 h-3 w-3" />
+                  <PowerOff className="h-3 w-3" />
                   All OFF
                 </Button>
               </div>
@@ -2078,18 +2078,18 @@ export function MCPConfigManager({
                           variant="ghost"
                           size="sm"
                           onClick={() => handleToggleAllToolsForServer(serverName, true)}
-                          className="h-6 px-2 text-xs"
+                          className="h-6 gap-1 px-2 text-xs"
                         >
-                          <Power className="mr-1 h-3 w-3" />
+                          <Power className="h-3 w-3" />
                           ON
                         </Button>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => handleToggleAllToolsForServer(serverName, false)}
-                          className="h-6 px-2 text-xs"
+                          className="h-6 gap-1 px-2 text-xs"
                         >
-                          <PowerOff className="mr-1 h-3 w-3" />
+                          <PowerOff className="h-3 w-3" />
                           OFF
                         </Button>
                       </div>
@@ -2189,12 +2189,12 @@ export function MCPConfigManager({
                                           <Badge
                                             key={profile.id}
                                             variant={isEnabled ? "default" : "secondary"}
-                                            className={`text-xs ${isCurrent ? "ring-2 ring-primary ring-offset-1" : ""}`}
+                                            className={`gap-1 text-xs ${isCurrent ? "ring-2 ring-primary ring-offset-1" : ""}`}
                                           >
                                             {isEnabled ? (
-                                              <CheckCircle className="mr-1 h-3 w-3" />
+                                              <CheckCircle className="h-3 w-3" />
                                             ) : (
-                                              <XCircle className="mr-1 h-3 w-3" />
+                                              <XCircle className="h-3 w-3" />
                                             )}
                                             {profile.name}
                                             {isCurrent && " (current)"}
@@ -2257,14 +2257,14 @@ export function MCPConfigManager({
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >
-            <Button variant="outline" size="sm" onClick={handleExportConfig}>
-              <Download className="mr-2 h-4 w-4" />
+            <Button variant="outline" size="sm" className="gap-2" onClick={handleExportConfig}>
+              <Download className="h-4 w-4" />
               Export
             </Button>
             <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
               <DialogTrigger asChild>
-                <Button size="sm">
-                  <Plus className="mr-2 h-4 w-4" />
+                <Button size="sm" className="gap-2">
+                  <Plus className="h-4 w-4" />
                   Add Server
                 </Button>
               </DialogTrigger>

--- a/apps/desktop/src/renderer/src/components/mcp-tool-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-tool-manager.tsx
@@ -241,11 +241,12 @@ export function MCPToolManager({ onToolToggle }: MCPToolManagerProps) {
             variant="outline"
             size="sm"
             onClick={() => setShowDisabledTools(!showDisabledTools)}
+            className="gap-2"
           >
             {showDisabledTools ? (
-              <EyeOff className="mr-2 h-4 w-4" />
+              <EyeOff className="h-4 w-4" />
             ) : (
-              <Eye className="mr-2 h-4 w-4" />
+              <Eye className="h-4 w-4" />
             )}
             {showDisabledTools ? "Hide Disabled" : "Show All"}
           </Button>
@@ -256,12 +257,12 @@ export function MCPToolManager({ onToolToggle }: MCPToolManagerProps) {
       <div className="flex flex-col gap-4 sm:flex-row">
         <div className="min-w-0 flex-1">
           <div className="relative">
-            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               placeholder="Search tools..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-8"
+              className="pl-9"
             />
           </div>
         </div>
@@ -325,9 +326,9 @@ export function MCPToolManager({ onToolToggle }: MCPToolManagerProps) {
                           e.stopPropagation()
                           handleToggleAllTools(serverName, true)
                         }}
-                        className="h-7 px-2 text-xs"
+                        className="h-7 gap-1 px-2 text-xs"
                       >
-                        <Power className="mr-1 h-3 w-3" />
+                        <Power className="h-3 w-3" />
                         All ON
                       </Button>
                       <Button
@@ -337,9 +338,9 @@ export function MCPToolManager({ onToolToggle }: MCPToolManagerProps) {
                           e.stopPropagation()
                           handleToggleAllTools(serverName, false)
                         }}
-                        className="h-7 px-2 text-xs"
+                        className="h-7 gap-1 px-2 text-xs"
                       >
-                        <PowerOff className="mr-1 h-3 w-3" />
+                        <PowerOff className="h-3 w-3" />
                         All OFF
                       </Button>
                     </div>

--- a/apps/desktop/src/renderer/src/components/model-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/model-selector.tsx
@@ -221,10 +221,10 @@ export function ModelSelector({
           }}
           header={
             <div
-              className="flex items-center border-b px-3 py-2"
+              className="flex items-center gap-2 border-b px-3 py-2"
               onMouseDown={(e) => e.preventDefault()}
             >
-              <Search className="mr-2 h-4 w-4 shrink-0 text-muted-foreground" />
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
               <Input
                 ref={searchInputRef}
                 placeholder="Search models..."
@@ -276,8 +276,8 @@ export function ModelSelector({
             )}
 
             {hasError && (
-              <div className="flex items-center justify-center py-8 text-destructive">
-                <AlertCircle className="mr-2 h-4 w-4" />
+              <div className="flex items-center justify-center gap-2 py-8 text-destructive">
+                <AlertCircle className="h-4 w-4" />
                 <span className="text-sm">Failed to load models</span>
               </div>
             )}

--- a/apps/desktop/src/renderer/src/components/preset-model-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/preset-model-selector.tsx
@@ -303,10 +303,10 @@ export function PresetModelSelector({
           onCloseAutoFocus={(e) => e.preventDefault()}
           header={
             <div
-              className="flex items-center border-b px-3 py-2"
+              className="flex items-center gap-2 border-b px-3 py-2"
               onMouseDown={(e) => e.preventDefault()}
             >
-              <Search className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+              <Search className="text-muted-foreground h-4 w-4 shrink-0" />
               <Input
                 ref={searchInputRef}
                 placeholder="Search models..."
@@ -336,10 +336,10 @@ export function PresetModelSelector({
               </div>
             )}
           {models.length === 0 && !isLoading && (
-            <div className="text-muted-foreground flex items-center justify-center py-4 text-sm">
+            <div className="text-muted-foreground flex items-center justify-center gap-2 py-4 text-sm">
               {hasError ? (
                 <>
-                  <AlertCircle className="mr-2 h-4 w-4" />
+                  <AlertCircle className="h-4 w-4" />
                   {error}
                 </>
               ) : (

--- a/apps/desktop/src/renderer/src/pages/memories.tsx
+++ b/apps/desktop/src/renderer/src/pages/memories.tsx
@@ -470,13 +470,14 @@ export function Component() {
               <Button
                 variant="destructive"
                 size="sm"
+                className="gap-2"
                 onClick={() => setBulkDeleteConfirm(true)}
                 disabled={deleteMultipleMutation.isPending}
               >
                 {deleteMultipleMutation.isPending ? (
-                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  <Trash2 className="h-4 w-4 mr-2" />
+                  <Trash2 className="h-4 w-4" />
                 )}
                 Delete Selected ({selectedIds.size})
               </Button>
@@ -486,9 +487,9 @@ export function Component() {
                 variant="outline"
                 size="sm"
                 onClick={() => setDeleteAllConfirm(true)}
-                className="text-destructive hover:text-destructive"
+                className="gap-2 text-destructive hover:text-destructive"
               >
-                <Trash2 className="h-4 w-4 mr-2" />
+                <Trash2 className="h-4 w-4" />
                 Delete All
               </Button>
             )}
@@ -558,8 +559,8 @@ export function Component() {
             <Button variant="outline" onClick={() => setEditingMemory(null)}>
               Cancel
             </Button>
-            <Button onClick={handleSaveEdit} disabled={updateMutation.isPending}>
-              {updateMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            <Button className="gap-2" onClick={handleSaveEdit} disabled={updateMutation.isPending}>
+              {updateMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
               Save
             </Button>
           </DialogFooter>
@@ -584,10 +585,11 @@ export function Component() {
             </Button>
             <Button
               variant="destructive"
+              className="gap-2"
               onClick={() => deleteConfirmId && deleteMutation.mutate(deleteConfirmId)}
               disabled={deleteMutation.isPending}
             >
-              {deleteMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              {deleteMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
               Delete
             </Button>
           </DialogFooter>
@@ -612,10 +614,11 @@ export function Component() {
             </Button>
             <Button
               variant="destructive"
+              className="gap-2"
               onClick={() => deleteMultipleMutation.mutate([...selectedIds].filter(id => filteredIds.has(id)))}
               disabled={deleteMultipleMutation.isPending}
             >
-              {deleteMultipleMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              {deleteMultipleMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
               Delete {visibleSelectedCount} Memories
             </Button>
           </DialogFooter>
@@ -640,10 +643,11 @@ export function Component() {
             </Button>
             <Button
               variant="destructive"
+              className="gap-2"
               onClick={() => deleteAllMutation.mutate()}
               disabled={deleteAllMutation.isPending}
             >
-              {deleteAllMutation.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              {deleteAllMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
               Delete All Memories
             </Button>
           </DialogFooter>

--- a/apps/desktop/src/renderer/src/pages/settings-agent-personas.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agent-personas.tsx
@@ -353,12 +353,12 @@ export function SettingsAgentPersonas() {
           </div>
 
           <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={handleCancel}>
-              <X className="h-4 w-4 mr-2" />
+            <Button variant="outline" className="gap-2" onClick={handleCancel}>
+              <X className="h-4 w-4" />
               Cancel
             </Button>
-            <Button onClick={handleSave}>
-              <Save className="h-4 w-4 mr-2" />
+            <Button className="gap-2" onClick={handleSave}>
+              <Save className="h-4 w-4" />
               Save
             </Button>
           </div>
@@ -376,8 +376,8 @@ export function SettingsAgentPersonas() {
             Configure personas that can be delegated to for specialized tasks
           </p>
         </div>
-        <Button onClick={handleCreate}>
-          <Plus className="h-4 w-4 mr-2" />
+        <Button className="gap-2" onClick={handleCreate}>
+          <Plus className="h-4 w-4" />
           Add Persona
         </Button>
       </div>

--- a/apps/desktop/src/renderer/src/pages/settings-external-agents.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-external-agents.tsx
@@ -202,8 +202,8 @@ export function SettingsExternalAgents() {
             )}
           </div>
           <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={handleCancel}><X className="h-4 w-4 mr-2" />Cancel</Button>
-            <Button onClick={handleSave}><Save className="h-4 w-4 mr-2" />Save</Button>
+            <Button variant="outline" className="gap-2" onClick={handleCancel}><X className="h-4 w-4" />Cancel</Button>
+            <Button className="gap-2" onClick={handleSave}><Save className="h-4 w-4" />Save</Button>
           </div>
         </CardContent>
       </Card>
@@ -217,7 +217,7 @@ export function SettingsExternalAgents() {
           <h1 className="text-2xl font-bold">External Agents</h1>
           <p className="text-muted-foreground">Configure external AI agents (ACP, Stdio, Remote) for delegation</p>
         </div>
-        <Button onClick={handleCreate}><Plus className="h-4 w-4 mr-2" />Add External Agent</Button>
+        <Button className="gap-2" onClick={handleCreate}><Plus className="h-4 w-4" />Add External Agent</Button>
       </div>
       {editing ? renderEditForm() : renderProfileList(externalAgents)}
     </div>

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -265,8 +265,8 @@ export function SettingsLoops() {
                 </CardDescription>
               </div>
               <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={() => handleRunNow(loop)}>
-                  <Play className="h-4 w-4 mr-1" />Run Now
+                <Button variant="outline" size="sm" className="gap-2" onClick={() => handleRunNow(loop)}>
+                  <Play className="h-4 w-4" />Run Now
                 </Button>
                 <Button variant="ghost" size="icon" onClick={() => handleEdit(loop)}>
                   <Edit2 className="h-4 w-4" />
@@ -407,11 +407,11 @@ export function SettingsLoops() {
             </div>
           </div>
           <div className="flex justify-end gap-2 pt-4">
-            <Button variant="outline" onClick={handleCancel}>
-              <X className="h-4 w-4 mr-2" />Cancel
+            <Button variant="outline" className="gap-2" onClick={handleCancel}>
+              <X className="h-4 w-4" />Cancel
             </Button>
-            <Button onClick={handleSave}>
-              <Save className="h-4 w-4 mr-2" />Save
+            <Button className="gap-2" onClick={handleSave}>
+              <Save className="h-4 w-4" />Save
             </Button>
           </div>
         </CardContent>
@@ -428,8 +428,8 @@ export function SettingsLoops() {
             Configure agents to run automatically at regular intervals
           </p>
         </div>
-        <Button onClick={handleCreate}>
-          <Plus className="h-4 w-4 mr-2" />Add Loop
+        <Button className="gap-2" onClick={handleCreate}>
+          <Plus className="h-4 w-4" />Add Loop
         </Button>
       </div>
       {editing ? renderEditForm() : renderLoopList()}

--- a/apps/desktop/src/renderer/src/pages/settings-skills.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-skills.tsx
@@ -348,18 +348,20 @@ export function Component() {
             <Button
               variant="outline"
               size="sm"
+              className="gap-1.5"
               onClick={() => openSkillsFolderMutation.mutate()}
             >
-              <FolderOpen className="h-3 w-3 mr-1" />
+              <FolderOpen className="h-3 w-3" />
               Open Folder
             </Button>
             <Button
               variant="outline"
               size="sm"
+              className="gap-1.5"
               onClick={() => scanSkillsFolderMutation.mutate()}
               disabled={scanSkillsFolderMutation.isPending}
             >
-              <RefreshCw className={`h-3 w-3 mr-1 ${scanSkillsFolderMutation.isPending ? 'animate-spin' : ''}`} />
+              <RefreshCw className={`h-3 w-3 ${scanSkillsFolderMutation.isPending ? 'animate-spin' : ''}`} />
               Scan Folder
             </Button>
             <DropdownMenu>
@@ -367,37 +369,39 @@ export function Component() {
                 <Button
                   variant="outline"
                   size="sm"
+                  className="gap-1.5"
                   disabled={importSkillMutation.isPending || importSkillFolderMutation.isPending || importSkillsFromParentFolderMutation.isPending || importSkillFromGitHubMutation.isPending}
                 >
-                  <Upload className="h-3 w-3 mr-1" />
+                  <Upload className="h-3 w-3" />
                   Import
-                  <ChevronDown className="h-3 w-3 ml-1" />
+                  <ChevronDown className="h-3 w-3" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => setIsGitHubDialogOpen(true)}>
-                  <Github className="h-4 w-4 mr-2" />
+                  <Github />
                   Import from GitHub
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => importSkillMutation.mutate()}>
-                  <Upload className="h-4 w-4 mr-2" />
+                  <Upload />
                   Import SKILL.md File
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => importSkillFolderMutation.mutate()}>
-                  <FolderOpen className="h-4 w-4 mr-2" />
+                  <FolderOpen />
                   Import Skill Folder
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => importSkillsFromParentFolderMutation.mutate()}>
-                  <FolderUp className="h-4 w-4 mr-2" />
+                  <FolderUp />
                   Bulk Import from Folder
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
             <Button
               size="sm"
+              className="gap-1.5"
               onClick={() => setIsCreateDialogOpen(true)}
             >
-              <Plus className="h-3 w-3 mr-1" />
+              <Plus className="h-3 w-3" />
               New Skill
             </Button>
           </div>
@@ -612,15 +616,15 @@ export function Component() {
               }}>
                 Cancel
               </Button>
-              <Button onClick={handleImportFromGitHub} disabled={importSkillFromGitHubMutation.isPending}>
+              <Button className="gap-1.5" onClick={handleImportFromGitHub} disabled={importSkillFromGitHubMutation.isPending}>
                 {importSkillFromGitHubMutation.isPending ? (
                   <>
-                    <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    <Loader2 className="h-3 w-3 animate-spin" />
                     Importing...
                   </>
                 ) : (
                   <>
-                    <Github className="h-3 w-3 mr-1" />
+                    <Github className="h-3 w-3" />
                     Import
                   </>
                 )}


### PR DESCRIPTION
- Fix search icon vertical centering in mcp-tool-manager and mcp-config-manager by replacing brittle `top-2.5` with `top-1/2 -translate-y-1/2` and adjusting left/padding to match the pattern used in memories and past-sessions-dialog
- Standardize button icon spacing to use flexbox `gap-2` (for h-4 w-4 icons) and `gap-1`/`gap-1.5` (for h-3 w-3 icons) instead of inconsistent `mr-1`/`mr-2` margins on individual icons
- Clean up DropdownMenuItem icons in settings-skills to rely on the built-in `gap-2` and `[&>svg]:size-4` from the component
- Apply consistent spacing across 10 files: mcp-tool-manager, mcp-config-manager, settings-loops, settings-skills, settings-external-agents, settings-agent-personas, model-selector, preset-model-selector, agent-summary-view, and memories

https://claude.ai/code/session_01V5MH9Zpk9NmBHSpdAzCKAE