### PR TITLE
fix: add 3-second active sync for mobile conversation messages

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -93,7 +93,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.3.0"
+        versionName "1.4.0"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/apps/mobile/src/lib/activeConversationSync.ts
+++ b/apps/mobile/src/lib/activeConversationSync.ts
@@ -1,0 +1,253 @@
+/**
+ * ActiveConversationSync - Fast polling sync for the currently viewed conversation.
+ *
+ * Problem: The existing sync mechanism (App.tsx) polls every 15s for the full
+ * conversation list, which is too slow and heavyweight for real-time message
+ * updates. Messages get lost, cut off, or arrive late.
+ *
+ * Solution: This service polls every 3 seconds ONLY for the currently viewed
+ * conversation using a lightweight status endpoint (updatedAt + messageCount).
+ * Only when the server state has changed does it fetch the full conversation.
+ *
+ * Flow:
+ *   1. Every 3s, call GET /conversations/:id/status → { updatedAt, messageCount }
+ *   2. Compare with locally known updatedAt / messageCount
+ *   3. If different → fetch full conversation via GET /conversations/:id
+ *   4. Deliver the updated messages to the caller via callback
+ */
+
+import { SettingsApiClient, ConversationStatus, ServerConversationMessage } from './settingsApi';
+
+const POLL_INTERVAL_MS = 3000;
+
+export interface ActiveSyncState {
+  /** Whether the sync loop is currently running */
+  isActive: boolean;
+  /** Timestamp of the last successful sync check */
+  lastCheckAt: number | null;
+  /** Timestamp of the last time messages were actually updated */
+  lastUpdateAt: number | null;
+  /** Number of consecutive errors */
+  errorCount: number;
+  /** Last error message, if any */
+  lastError: string | null;
+}
+
+export interface ConversationUpdate {
+  conversationId: string;
+  messages: ServerConversationMessage[];
+  title: string;
+  updatedAt: number;
+  messageCount: number;
+}
+
+export type OnConversationUpdate = (update: ConversationUpdate) => void;
+export type OnSyncStateChange = (state: ActiveSyncState) => void;
+
+export class ActiveConversationSync {
+  private client: SettingsApiClient;
+  private conversationId: string | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private isPolling = false;
+
+  // Known server state to detect changes
+  private knownUpdatedAt: number = 0;
+  private knownMessageCount: number = 0;
+
+  // Callbacks
+  private onUpdate: OnConversationUpdate | null = null;
+  private onStateChange: OnSyncStateChange | null = null;
+
+  // State
+  private state: ActiveSyncState = {
+    isActive: false,
+    lastCheckAt: null,
+    lastUpdateAt: null,
+    errorCount: 0,
+    lastError: null,
+  };
+
+  constructor(client: SettingsApiClient) {
+    this.client = client;
+  }
+
+  /**
+   * Update the API client (e.g., when credentials change).
+   */
+  updateClient(client: SettingsApiClient): void {
+    this.client = client;
+  }
+
+  /**
+   * Start polling for a specific conversation.
+   * Stops any existing polling first.
+   *
+   * @param conversationId - The server-side conversation ID to poll
+   * @param initialUpdatedAt - The locally known updatedAt (to avoid unnecessary first fetch)
+   * @param initialMessageCount - The locally known message count
+   * @param onUpdate - Called when new messages are available
+   * @param onStateChange - Called when sync state changes (for UI indicators)
+   */
+  start(
+    conversationId: string,
+    initialUpdatedAt: number,
+    initialMessageCount: number,
+    onUpdate: OnConversationUpdate,
+    onStateChange?: OnSyncStateChange,
+  ): void {
+    // Stop any existing polling
+    this.stop();
+
+    this.conversationId = conversationId;
+    this.knownUpdatedAt = initialUpdatedAt;
+    this.knownMessageCount = initialMessageCount;
+    this.onUpdate = onUpdate;
+    this.onStateChange = onStateChange || null;
+
+    this.updateState({
+      isActive: true,
+      lastCheckAt: null,
+      lastUpdateAt: null,
+      errorCount: 0,
+      lastError: null,
+    });
+
+    // Do an immediate check, then start the interval
+    void this.pollOnce();
+
+    this.pollTimer = setInterval(() => {
+      void this.pollOnce();
+    }, POLL_INTERVAL_MS);
+  }
+
+  /**
+   * Stop polling.
+   */
+  stop(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.conversationId = null;
+    this.onUpdate = null;
+    this.onStateChange = null;
+    this.isPolling = false;
+
+    if (this.state.isActive) {
+      this.updateState({
+        ...this.state,
+        isActive: false,
+      });
+    }
+  }
+
+  /**
+   * Force an immediate sync (e.g., user taps a refresh button).
+   * Resets error count.
+   */
+  async forceSync(): Promise<void> {
+    if (!this.conversationId) return;
+    this.updateState({ ...this.state, errorCount: 0, lastError: null });
+    await this.fetchAndDeliver();
+  }
+
+  /**
+   * Update the known state (e.g., after a local message send).
+   * This prevents the next poll from re-fetching data we already have.
+   */
+  updateKnownState(updatedAt: number, messageCount: number): void {
+    this.knownUpdatedAt = updatedAt;
+    this.knownMessageCount = messageCount;
+  }
+
+  /**
+   * Get current sync state.
+   */
+  getState(): ActiveSyncState {
+    return { ...this.state };
+  }
+
+  /**
+   * Check if currently active.
+   */
+  isActive(): boolean {
+    return this.state.isActive;
+  }
+
+  // -- Private --
+
+  private async pollOnce(): Promise<void> {
+    if (this.isPolling || !this.conversationId) return;
+    this.isPolling = true;
+
+    try {
+      const status = await this.client.getConversationStatus(this.conversationId);
+
+      this.updateState({
+        ...this.state,
+        lastCheckAt: Date.now(),
+        errorCount: 0,
+        lastError: null,
+      });
+
+      // Check if server state differs from what we know
+      const hasChanged =
+        status.updatedAt > this.knownUpdatedAt ||
+        status.messageCount !== this.knownMessageCount;
+
+      if (hasChanged) {
+        await this.fetchAndDeliver();
+      }
+    } catch (err: any) {
+      const errorCount = this.state.errorCount + 1;
+      this.updateState({
+        ...this.state,
+        lastCheckAt: Date.now(),
+        errorCount,
+        lastError: err.message || 'Unknown error',
+      });
+
+      // After 5 consecutive errors, stop polling to avoid hammering a dead server
+      if (errorCount >= 5) {
+        console.warn('[ActiveConversationSync] Too many errors, stopping polling');
+        this.stop();
+      }
+    } finally {
+      this.isPolling = false;
+    }
+  }
+
+  private async fetchAndDeliver(): Promise<void> {
+    if (!this.conversationId || !this.onUpdate) return;
+
+    try {
+      const fullConv = await this.client.getConversation(this.conversationId);
+
+      // Update known state
+      this.knownUpdatedAt = fullConv.updatedAt;
+      this.knownMessageCount = fullConv.messages.length;
+
+      this.updateState({
+        ...this.state,
+        lastUpdateAt: Date.now(),
+      });
+
+      // Deliver to caller
+      this.onUpdate({
+        conversationId: fullConv.id,
+        messages: fullConv.messages,
+        title: fullConv.title,
+        updatedAt: fullConv.updatedAt,
+        messageCount: fullConv.messages.length,
+      });
+    } catch (err: any) {
+      console.error('[ActiveConversationSync] Failed to fetch full conversation:', err.message);
+      // Don't update knownState on fetch failure - we'll retry next poll
+    }
+  }
+
+  private updateState(newState: ActiveSyncState): void {
+    this.state = newState;
+    this.onStateChange?.(newState);
+  }
+}

--- a/apps/mobile/src/lib/settingsApi.ts
+++ b/apps/mobile/src/lib/settingsApi.ts
@@ -162,6 +162,13 @@ export interface UpdateConversationRequest {
   updatedAt?: number;
 }
 
+// Lightweight status for active conversation polling
+export interface ConversationStatus {
+  id: string;
+  updatedAt: number;
+  messageCount: number;
+}
+
 export interface SettingsUpdate {
   // MCP Tools Model Configuration
   mcpToolsProviderId?: 'openai' | 'groq' | 'gemini';
@@ -342,6 +349,11 @@ export class SettingsApiClient {
       method: 'PUT',
       body: JSON.stringify(data),
     });
+  }
+
+  // Lightweight status check - returns only updatedAt + messageCount (no message payload)
+  async getConversationStatus(id: string): Promise<ConversationStatus> {
+    return this.request<ConversationStatus>(`/conversations/${encodeURIComponent(id)}/status`);
   }
 }
 

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -2920,37 +2920,42 @@ export default function ChatScreen({ route, navigation }: any) {
 }
 
 function createStyles(theme: Theme, screenHeight: number) {
-  const micButtonHeight = Math.round(screenHeight * 0.2);
   return StyleSheet.create({
     // Compact desktop-style messages: left-border accent, full width, no bubbles
     msg: {
-      paddingLeft: spacing.xs,
-      paddingVertical: 2,
-      marginBottom: 0,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.md,
+      marginBottom: spacing.sm,
       width: '100%',
+      borderRadius: radius.md,
     },
     user: {
-      // User messages: subtle left border accent
-      borderLeftWidth: 2,
-      borderLeftColor: hexToRgba(theme.colors.info, 0.4),
-      paddingLeft: spacing.xs,
+      // User messages: nice primary tint with border
+      backgroundColor: hexToRgba(theme.colors.primary, 0.03),
+      borderLeftWidth: 3,
+      borderLeftColor: theme.colors.primary,
     },
     assistant: {
-      // Assistant messages: subtle left-border accent like desktop
-      borderLeftWidth: 2,
-      borderLeftColor: hexToRgba(theme.colors.mutedForeground, 0.3),
-      paddingLeft: spacing.xs,
+      // Assistant messages: modern card style
+      backgroundColor: theme.colors.card,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      shadowColor: '#000',
+      shadowOpacity: theme.isDark ? 0.3 : 0.05,
+      shadowRadius: 8,
+      shadowOffset: { width: 0, height: 2 },
+      elevation: theme.isDark ? 3 : 1,
     },
     messageHeader: {
       flexDirection: 'row',
       alignItems: 'center',
-      flexWrap: 'wrap',
-      gap: 2,
-      marginBottom: 1,
-      paddingVertical: 1,
-      marginHorizontal: -1,
-      paddingHorizontal: 1,
-      borderRadius: radius.sm,
+      justifyContent: 'space-between',
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.sm,
+      backgroundColor: hexToRgba(theme.colors.mutedForeground, 0.05),
+      borderRadius: radius.md,
+      marginBottom: spacing.xs,
+      minHeight: 44,
     },
     messageHeaderClickable: {
       // Visual hint that header is clickable
@@ -2960,13 +2965,13 @@ function createStyles(theme: Theme, screenHeight: number) {
     },
     expandButton: {
       marginLeft: 'auto',
-      paddingHorizontal: 2,
-      paddingVertical: 1,
+      paddingHorizontal: spacing.sm,
+      paddingVertical: spacing.xs,
     },
     expandButtonText: {
-      fontSize: 8,
+      fontSize: 14,
       color: theme.colors.primary,
-      fontWeight: '500',
+      fontWeight: '600',
     },
 
     inputArea: {
@@ -3012,34 +3017,35 @@ function createStyles(theme: Theme, screenHeight: number) {
     },
     mic: {
       width: '100%' as any,
-      height: micButtonHeight,
-      borderRadius: radius.xl,
-      borderWidth: 1.5,
+      height: 56,
+      borderRadius: radius.full,
+      borderWidth: 1,
       borderColor: theme.colors.border,
       backgroundColor: theme.colors.card,
       alignItems: 'center',
       justifyContent: 'center',
+      flexDirection: 'row',
+      gap: spacing.sm,
     },
     micOn: {
       backgroundColor: theme.colors.primary,
       borderColor: theme.colors.primary,
     },
     micText: {
-      fontSize: 32,
+      fontSize: 24,
     },
     micLabel: {
-      fontSize: 13,
+      fontSize: 14,
       color: theme.colors.mutedForeground,
-      marginTop: 4,
       fontWeight: '600',
     },
     micLabelOn: {
       color: theme.colors.primaryForeground,
     },
     ttsToggle: {
-      width: 32,
-      height: 32,
-      borderRadius: 16,
+      width: 44,
+      height: 44,
+      borderRadius: 22,
       borderWidth: 1,
       borderColor: theme.colors.border,
       backgroundColor: theme.colors.muted,
@@ -3051,18 +3057,20 @@ function createStyles(theme: Theme, screenHeight: number) {
       borderColor: theme.colors.primary,
     },
     ttsToggleText: {
-      fontSize: 14,
+      fontSize: 18,
     },
     sendButton: {
       backgroundColor: theme.colors.primary,
-      paddingHorizontal: spacing.sm,
-      paddingVertical: spacing.xs,
-      borderRadius: radius.md,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      borderRadius: radius.full,
+      minHeight: 44,
+      justifyContent: 'center',
     },
     sendButtonText: {
       color: theme.colors.primaryForeground,
       fontWeight: '600',
-      fontSize: 13,
+      fontSize: 14,
     },
     debugInfo: {
       backgroundColor: theme.colors.muted,
@@ -3217,10 +3225,11 @@ function createStyles(theme: Theme, screenHeight: number) {
     toolCallCompactRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      paddingVertical: 2,
-      paddingHorizontal: 3,
-      borderRadius: radius.sm,
-      gap: 3,
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.sm,
+      borderRadius: radius.md,
+      gap: spacing.xs,
+      minHeight: 36,
     },
     toolCallCompactPending: {
       backgroundColor: hexToRgba(theme.colors.info, 0.05),
@@ -3235,7 +3244,7 @@ function createStyles(theme: Theme, screenHeight: number) {
       opacity: 0.7,
     },
     toolCallCompactIcon: {
-      fontSize: 8,
+      fontSize: 12,
     },
     toolCallCompactIconPending: {
       // uses default
@@ -3248,7 +3257,7 @@ function createStyles(theme: Theme, screenHeight: number) {
     },
     toolCallCompactName: {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-      fontSize: 10,
+      fontSize: 12,
       fontWeight: '500',
       flexShrink: 1,
     },
@@ -3262,7 +3271,7 @@ function createStyles(theme: Theme, screenHeight: number) {
       color: theme.colors.mutedForeground,
     },
     toolCallCompactStatus: {
-      fontSize: 9,
+      fontSize: 11,
       marginLeft: 1,
     },
     toolCallCompactStatusPending: {
@@ -3275,13 +3284,13 @@ function createStyles(theme: Theme, screenHeight: number) {
       color: theme.colors.mutedForeground,
     },
     toolCallCompactChevron: {
-      fontSize: 8,
+      fontSize: 12,
       color: theme.colors.mutedForeground,
       opacity: 0.4,
       marginLeft: 'auto',
     },
     toolCallCompactPreview: {
-      fontSize: 9,
+      fontSize: 11,
       color: theme.colors.mutedForeground,
       opacity: 0.6,
       flex: 1,
@@ -3314,26 +3323,30 @@ function createStyles(theme: Theme, screenHeight: number) {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
       fontWeight: '600',
       color: theme.colors.primary,
-      fontSize: 10,
+      fontSize: 12,
       flex: 1,
     },
     toolCallHeader: {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'space-between',
-      paddingVertical: spacing.xs,
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.sm,
+      backgroundColor: hexToRgba(theme.colors.mutedForeground, 0.05),
+      borderRadius: radius.sm,
       marginBottom: spacing.xs,
+      minHeight: 44,
     },
     toolCallHeaderPressed: {
       opacity: 0.7,
     },
     toolCallExpandHint: {
-      fontSize: 9,
+      fontSize: 11,
       color: theme.colors.mutedForeground,
       fontWeight: '500',
     },
     toolSectionLabel: {
-      fontSize: 8,
+      fontSize: 10,
       fontWeight: '600',
       color: theme.colors.mutedForeground,
       marginBottom: 2,
@@ -3352,10 +3365,10 @@ function createStyles(theme: Theme, screenHeight: number) {
     },
     toolParamsCode: {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-      fontSize: 8,
+      fontSize: 10,
       color: theme.colors.foreground,
       backgroundColor: theme.colors.muted,
-      padding: 3,
+      padding: spacing.xs,
       borderRadius: radius.sm,
     },
     toolResponseSection: {
@@ -3372,14 +3385,14 @@ function createStyles(theme: Theme, screenHeight: number) {
       // No background - let parent handle it
     },
     toolResponseSectionTitle: {
-      fontSize: 9,
+      fontSize: 11,
       fontWeight: '600',
       color: theme.colors.mutedForeground,
       marginBottom: 2,
       opacity: 0.7,
     },
     toolResponsePendingText: {
-      fontSize: 9,
+      fontSize: 11,
       fontStyle: 'italic',
       color: theme.colors.mutedForeground,
       textAlign: 'center',
@@ -3395,16 +3408,16 @@ function createStyles(theme: Theme, screenHeight: number) {
       marginBottom: 1,
     },
     toolResultCharCount: {
-      fontSize: 8,
+      fontSize: 10,
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
       color: theme.colors.mutedForeground,
       opacity: 0.6,
     },
     toolResultBadge: {
-      fontSize: 9,
+      fontSize: 11,
       fontWeight: '600',
-      paddingHorizontal: 4,
-      paddingVertical: 1,
+      paddingHorizontal: spacing.xs,
+      paddingVertical: 2,
       borderRadius: radius.sm,
     },
     toolResultBadgeSuccess: {
@@ -3427,44 +3440,48 @@ function createStyles(theme: Theme, screenHeight: number) {
     },
     toolResultCode: {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-      fontSize: 8,
+      fontSize: 10,
       color: theme.colors.foreground,
       backgroundColor: theme.colors.muted,
-      padding: 3,
+      padding: spacing.xs,
       borderRadius: radius.sm,
     },
     toolResultErrorSection: {
       marginTop: 1,
     },
     toolResultErrorLabel: {
-      fontSize: 8,
+      fontSize: 10,
       fontWeight: '500',
       color: theme.colors.destructive,
       marginBottom: 1,
     },
     toolResultErrorText: {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
-      fontSize: 8,
+      fontSize: 10,
       color: theme.colors.destructive,
       backgroundColor: hexToRgba(theme.colors.destructive, 0.06),
-      padding: 3,
+      padding: spacing.xs,
       borderRadius: radius.sm,
     },
     // Per-message TTS button styles (#1078)
     speakButton: {
       alignSelf: 'flex-start',
-      paddingHorizontal: spacing.xs,
-      paddingVertical: 2,
-      marginTop: 4,
-      borderRadius: radius.sm,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      marginTop: spacing.sm,
+      borderRadius: radius.full,
+      minHeight: 36,
       backgroundColor: hexToRgba(theme.colors.mutedForeground, 0.1),
     } as const,
     speakButtonActive: {
       backgroundColor: hexToRgba(theme.colors.primary, 0.15),
     } as const,
     speakButtonText: {
-      fontSize: 12,
+      fontSize: 14,
       color: theme.colors.mutedForeground,
+      fontWeight: '500',
     } as const,
     speakButtonTextActive: {
       color: theme.colors.primary,

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -735,14 +735,16 @@ export default function ChatScreen({ route, navigation }: any) {
         toolResults: msg.toolResults as any,
       }));
 
-      // Only update if messages actually differ (check all messages, not just the last)
+      // Only update if messages actually differ (check all fields including toolCalls/toolResults)
       setMessages(currentMessages => {
         if (currentMessages.length === convertedMessages.length) {
-          // Same count - check if all messages match (detects edits to any message)
-          const allMatch = currentMessages.every((msg, i) =>
-            msg.role === convertedMessages[i].role &&
-            msg.content === convertedMessages[i].content
-          );
+          const allMatch = currentMessages.every((msg, i) => {
+            const server = convertedMessages[i];
+            return msg.role === server.role &&
+              msg.content === server.content &&
+              JSON.stringify(msg.toolCalls) === JSON.stringify(server.toolCalls) &&
+              JSON.stringify(msg.toolResults) === JSON.stringify(server.toolResults);
+          });
           if (allMatch) {
             return currentMessages; // No change
           }
@@ -754,7 +756,7 @@ export default function ChatScreen({ route, navigation }: any) {
 
       // Persist synced messages to the session store so they survive app restart.
       // skipNextPersistRef prevents the setMessages effect from double-persisting.
-      if (currentSession && update.messages.length > 0) {
+      if (currentSession) {
         void sessionStore.setMessagesForSession(currentSession.id, convertedMessages);
       }
     };
@@ -796,10 +798,13 @@ export default function ChatScreen({ route, navigation }: any) {
 
           setMessages(currentMessages => {
             if (currentMessages.length === convertedMessages.length) {
-              const allMatch = currentMessages.every((msg, i) =>
-                msg.role === convertedMessages[i].role &&
-                msg.content === convertedMessages[i].content
-              );
+              const allMatch = currentMessages.every((msg, i) => {
+                const server = convertedMessages[i];
+                return msg.role === server.role &&
+                  msg.content === server.content &&
+                  JSON.stringify(msg.toolCalls) === JSON.stringify(server.toolCalls) &&
+                  JSON.stringify(msg.toolResults) === JSON.stringify(server.toolResults);
+              });
               if (allMatch) {
                 return currentMessages;
               }
@@ -809,7 +814,7 @@ export default function ChatScreen({ route, navigation }: any) {
           });
 
           // Persist synced messages to the session store so they survive app restart
-          if (currentSession && update.messages.length > 0) {
+          if (currentSession) {
             void sessionStore.setMessagesForSession(currentSession.id, convertedMessages);
           }
         };


### PR DESCRIPTION
The existing sync mechanism polled every 15 seconds for the full
conversation list, causing messages to get lost, cut off, or arrive
late on mobile. This adds a fast-polling active sync specifically
for the currently viewed conversation:

- Add lightweight GET /v1/conversations/:id/status endpoint that
  returns only updatedAt + messageCount (no message payload)
- Create ActiveConversationSync service that polls every 3 seconds,
  checks status cheaply, and only fetches full conversation data
  when changes are detected
- Integrate into ChatScreen with automatic pause during SSE
  streaming and resume after responses complete
- Add subtle sync status indicator with force-sync tap support
- Auto-stop after 5 consecutive errors to avoid hammering dead server
- Add automated E2E tests for the new active conversation sync feature

**Recent UI & Feature Improvements:**
- **UI Optimizations:** Improved layout, larger touch targets, and better visibility across the ChatScreen.
- **Enhanced Hands-Free Mode:** 
  - Increased the silence buffer before auto-sending to 5 seconds.
  - Added a visual countdown timer overlay that appears when speech stops.
  - Added "Pause", "Resume", and "Send Now" controls to fully manage the recording state without auto-sending.
  - Repositioned the Hands-Free toggle button next to the TTS button for better discoverability.
- **Compact Tool Executions:** Fixed a major issue with excessive empty space and vertical bloat in long agent conversations. Redundant standalone tool result messages are now dynamically merged into the preceding assistant messages, matching the compact unified design pattern of the desktop app.