### PR TITLE
fix(mobile): resolve web issues with settings API and LayoutAnimation

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,6 +4,7 @@
   "main": "index.ts",
   "scripts": {
     "start": "expo start",
+    "start:web": "expo start --web",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web"

--- a/apps/mobile/src/lib/settingsApi.ts
+++ b/apps/mobile/src/lib/settingsApi.ts
@@ -460,11 +460,11 @@ export class ExtendedSettingsApiClient extends SettingsApiClient {
   // ============================================
 
   async getSkills(): Promise<SkillsResponse> {
-    return this.request<SkillsResponse>('/v1/skills');
+    return this.request<SkillsResponse>('/skills');
   }
 
   async toggleSkillForProfile(skillId: string): Promise<{ success: boolean; skillId: string; enabledForProfile: boolean }> {
-    return this.request(`/v1/skills/${encodeURIComponent(skillId)}/toggle-profile`, {
+    return this.request(`/skills/${encodeURIComponent(skillId)}/toggle-profile`, {
       method: 'POST',
     });
   }
@@ -475,11 +475,11 @@ export class ExtendedSettingsApiClient extends SettingsApiClient {
 
   async getMemories(profileId?: string): Promise<MemoriesResponse> {
     const query = profileId ? `?profileId=${encodeURIComponent(profileId)}` : '';
-    return this.request<MemoriesResponse>(`/v1/memories${query}`);
+    return this.request<MemoriesResponse>(`/memories${query}`);
   }
 
   async deleteMemory(id: string): Promise<{ success: boolean; id: string }> {
-    return this.request(`/v1/memories/${encodeURIComponent(id)}`, {
+    return this.request(`/memories/${encodeURIComponent(id)}`, {
       method: 'DELETE',
     });
   }
@@ -489,11 +489,11 @@ export class ExtendedSettingsApiClient extends SettingsApiClient {
   // ============================================
 
   async getAgentProfiles(): Promise<AgentProfilesResponse> {
-    return this.request<AgentProfilesResponse>('/v1/agent-profiles');
+    return this.request<AgentProfilesResponse>('/agent-profiles');
   }
 
   async toggleAgentProfile(id: string): Promise<{ success: boolean; id: string; enabled: boolean }> {
-    return this.request(`/v1/agent-profiles/${encodeURIComponent(id)}/toggle`, {
+    return this.request(`/agent-profiles/${encodeURIComponent(id)}/toggle`, {
       method: 'POST',
     });
   }
@@ -503,17 +503,17 @@ export class ExtendedSettingsApiClient extends SettingsApiClient {
   // ============================================
 
   async getLoops(): Promise<LoopsResponse> {
-    return this.request<LoopsResponse>('/v1/loops');
+    return this.request<LoopsResponse>('/loops');
   }
 
   async toggleLoop(id: string): Promise<{ success: boolean; id: string; enabled: boolean }> {
-    return this.request(`/v1/loops/${encodeURIComponent(id)}/toggle`, {
+    return this.request(`/loops/${encodeURIComponent(id)}/toggle`, {
       method: 'POST',
     });
   }
 
   async runLoop(id: string): Promise<{ success: boolean; id: string }> {
-    return this.request(`/v1/loops/${encodeURIComponent(id)}/run`, {
+    return this.request(`/loops/${encodeURIComponent(id)}/run`, {
       method: 'POST',
     });
   }

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -409,8 +409,11 @@ export default function SettingsScreen({ navigation }: any) {
   }, []);
 
   // Toggle section collapse state
+  // Note: LayoutAnimation is not properly supported on web, so we skip it there
   const toggleSection = useCallback((section: string) => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    if (Platform.OS !== 'web') {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    }
     setExpandedSections(prev => ({ ...prev, [section]: !prev[section] }));
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes two issues preventing the mobile web app from properly displaying Skills, Memories, Agent Personas, and Agent Loops sections in Settings.

## Issues Fixed

### 1. Double `/v1` prefix causing 404 errors

The `config.baseUrl` already contains `/v1` (e.g., `http://127.0.0.1:3210/v1`), but the endpoint paths in `ExtendedSettingsApiClient` also started with `/v1`, creating invalid URLs like:
- `http://127.0.0.1:3210/v1/v1/skills` → 404
- `http://127.0.0.1:3210/v1/v1/memories` → 404

**Fix**: Removed the `/v1` prefix from endpoint paths so they correctly resolve to `/v1/skills`, `/v1/memories`, etc.

### 2. LayoutAnimation not supported on React Native Web

`LayoutAnimation.configureNext()` doesn't work properly on React Native Web and caused collapsible sections to fail to expand when tapped.

**Fix**: Added platform check to skip `LayoutAnimation` on web.

### 3. Added convenience script

Added `start:web` script to `package.json` for easier web development.

## Testing

1. Run `pnpm start:web` in `apps/mobile`
2. Connect to a desktop server
3. Expand Skills, Memories, Agent Personas, and Agent Loops sections
4. Verify data loads correctly instead of showing "No X configured" messages

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author